### PR TITLE
Add service layer interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ bin/
 
 ### AI ###
 CLAUDE.local.md
+
+### Notes ###
+.notes/

--- a/src/main/java/shelter/service/AdopterBasedMatchingService.java
+++ b/src/main/java/shelter/service/AdopterBasedMatchingService.java
@@ -1,0 +1,24 @@
+package shelter.service;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+import shelter.service.model.MatchResult;
+
+import java.util.List;
+
+/**
+ * Scores and ranks animals for a given adopter by applying a configurable set of matching strategies.
+ * The ranked list can be passed to an ExplanationService for human-readable summaries.
+ */
+public interface AdopterBasedMatchingService {
+
+    /**
+     * Evaluates each animal in the provided list against the adopter's preferences and returns
+     * a ranked list of match results ordered from highest to lowest score.
+     *
+     * @param adopter the adopter to match against
+     * @param animals the pool of animals to evaluate
+     * @return a list of MatchResult objects sorted by descending score
+     */
+    List<MatchResult> match(Adopter adopter, List<Animal> animals);
+}

--- a/src/main/java/shelter/service/AdopterService.java
+++ b/src/main/java/shelter/service/AdopterService.java
@@ -1,0 +1,82 @@
+package shelter.service;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Manages adopter records within the system, including registration, updates, and removal.
+ * Implementations are responsible for validating adopter information before persisting changes.
+ */
+public interface AdopterService {
+
+    /**
+     * Registers a new adopter into the system.
+     * Throws an exception if the adopter is already registered or required fields are missing.
+     *
+     * @param adopter the adopter to register
+     */
+    void register(Adopter adopter);
+
+    /**
+     * Updates the information of an existing adopter record.
+     * Throws an exception if the adopter is not found in the system.
+     *
+     * @param adopter the adopter with updated information
+     */
+    void update(Adopter adopter);
+
+    /**
+     * Removes an adopter from the system.
+     * Throws an exception if the adopter is not found or has a pending adoption request.
+     *
+     * @param adopter the adopter to remove
+     */
+    void remove(Adopter adopter);
+
+    /**
+     * Returns all adopters currently registered in the system.
+     * Returns an empty list if no adopters are registered.
+     *
+     * @return a list of all registered adopters
+     */
+    List<Adopter> listAll();
+
+    /**
+     * Returns the adopter with the given ID.
+     * Throws an exception if no adopter with that ID is found.
+     *
+     * @param id the unique identifier of the adopter
+     * @return the matching adopter
+     */
+    Adopter findById(String id);
+
+    /**
+     * Returns all adopters who registered after the given date.
+     * Returns an empty list if no adopters registered after that date.
+     *
+     * @param date the cutoff date (exclusive)
+     * @return a list of adopters registered after the date
+     */
+    List<Adopter> registeredAfter(LocalDate date);
+
+    /**
+     * Returns all adopters who have at least one approved adoption after the given date.
+     * Returns an empty list if no such adopters exist.
+     *
+     * @param date the cutoff date (exclusive)
+     * @return a list of adopters with an approved adoption after the date
+     */
+    List<Adopter> adoptedAfter(LocalDate date);
+
+    /**
+     * Returns all adopters who have adopted the given animal.
+     * Returns an empty list if no adopter has adopted the animal.
+     *
+     * @param animal the animal to query
+     * @return a list of adopters who adopted the animal
+     */
+    List<Adopter> adoptedAnimal(Animal animal);
+}

--- a/src/main/java/shelter/service/AdoptionService.java
+++ b/src/main/java/shelter/service/AdoptionService.java
@@ -1,0 +1,86 @@
+package shelter.service;
+
+import shelter.domain.AdoptionRequest;
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+import shelter.domain.Shelter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Manages the full lifecycle of adoption requests, from initial submission
+ * through approval or rejection. Implementations are responsible for validating
+ * requests and updating request state accordingly.
+ */
+public interface AdoptionService {
+
+    /**
+     * Submits a new adoption request into the system for review.
+     * Throws an exception if the request is invalid or the animal is unavailable.
+     *
+     * @param request the adoption request to submit
+     */
+    void submit(AdoptionRequest request);
+
+    /**
+     * Approves a pending adoption request and marks the animal as adopted.
+     * Throws an exception if the request is not in a pending state.
+     *
+     * @param request the adoption request to approve
+     */
+    void approve(AdoptionRequest request);
+
+    /**
+     * Rejects a pending adoption request with no further action on the animal.
+     * Throws an exception if the request is not in a pending state.
+     *
+     * @param request the adoption request to reject
+     */
+    void reject(AdoptionRequest request);
+
+    /**
+     * Returns all adoption requests submitted by the given adopter.
+     * Returns an empty list if the adopter has no requests on record.
+     *
+     * @param adopter the adopter whose requests to retrieve
+     * @return a list of adoption requests belonging to the adopter
+     */
+    List<AdoptionRequest> getRequestsByAdopter(Adopter adopter);
+
+    /**
+     * Returns all adoption requests associated with animals in the given shelter.
+     * Returns an empty list if the shelter has no adoption requests.
+     *
+     * @param shelter the shelter to query
+     * @return a list of adoption requests for animals in the shelter
+     */
+    List<AdoptionRequest> getRequestsByShelter(Shelter shelter);
+
+    /**
+     * Returns all adoption requests for the given animal across all adopters.
+     * Returns an empty list if no requests exist for the animal.
+     *
+     * @param animal the animal to query
+     * @return a list of adoption requests targeting the animal
+     */
+    List<AdoptionRequest> getRequestsByAnimal(Animal animal);
+
+    /**
+     * Returns all adoption requests submitted after the given date.
+     * Returns an empty list if no requests exist after that date.
+     *
+     * @param date the cutoff date (exclusive)
+     * @return a list of adoption requests submitted after the date
+     */
+    List<AdoptionRequest> getRequestsAfter(LocalDate date);
+
+    /**
+     * Returns all approved adoption requests where approval occurred after the given date.
+     * Returns an empty list if no approvals exist after that date.
+     *
+     * @param date the cutoff date (exclusive)
+     * @return a list of approved adoption requests after the date
+     */
+    List<AdoptionRequest> getApprovedAfter(LocalDate date);
+}

--- a/src/main/java/shelter/service/AnimalBasedMatchingService.java
+++ b/src/main/java/shelter/service/AnimalBasedMatchingService.java
@@ -1,0 +1,24 @@
+package shelter.service;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+import shelter.service.model.MatchResult;
+
+import java.util.List;
+
+/**
+ * Scores and ranks adopters for a given animal by applying a configurable set of matching strategies.
+ * Supports animal-centric adoption workflows as the counterpart to AdopterBasedMatchingService.
+ */
+public interface AnimalBasedMatchingService {
+
+    /**
+     * Evaluates each adopter in the provided list against the given animal and returns
+     * a ranked list of match results ordered from highest to lowest score.
+     *
+     * @param animal   the animal to match against
+     * @param adopters the pool of adopters to evaluate
+     * @return a list of MatchResult objects sorted by descending score
+     */
+    List<MatchResult> match(Animal animal, List<Adopter> adopters);
+}

--- a/src/main/java/shelter/service/AnimalService.java
+++ b/src/main/java/shelter/service/AnimalService.java
@@ -1,0 +1,76 @@
+package shelter.service;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+import shelter.domain.Shelter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Manages animal records within the system, including registration, updates, and removal.
+ * Implementations are responsible for maintaining consistency between animal records and shelter rosters.
+ */
+public interface AnimalService {
+
+    /**
+     * Registers a new animal into the specified shelter.
+     * Throws an exception if the shelter is at capacity or the animal is already registered.
+     *
+     * @param animal  the animal to register
+     * @param shelter the shelter to assign the animal to
+     */
+    void register(Animal animal, Shelter shelter);
+
+    /**
+     * Updates the information of an existing animal record; the animal may be any subtype such as Dog, Cat, or Rabbit.
+     * Throws an exception if the animal is not found in the system.
+     *
+     * @param animal the animal with updated information
+     */
+    void update(Animal animal);
+
+    /**
+     * Removes an animal from the system and its associated shelter.
+     * Throws an exception if the animal is not found or has a pending adoption request.
+     *
+     * @param animal the animal to remove
+     */
+    void remove(Animal animal);
+
+    /**
+     * Returns all animals currently registered in the specified shelter.
+     * Returns an empty list if the shelter has no animals.
+     *
+     * @param shelter the shelter to query
+     * @return a list of animals in the shelter
+     */
+    List<Animal> getAnimalsByShelter(Shelter shelter);
+
+    /**
+     * Returns all animals registered into the system after the given date.
+     * Returns an empty list if no animals were registered after that date.
+     *
+     * @param date the cutoff date (exclusive)
+     * @return a list of animals registered after the date
+     */
+    List<Animal> registeredAfter(LocalDate date);
+
+    /**
+     * Returns all animals that were adopted after the given date.
+     * Returns an empty list if no animals were adopted after that date.
+     *
+     * @param date the cutoff date (exclusive)
+     * @return a list of animals adopted after the date
+     */
+    List<Animal> adoptedAfter(LocalDate date);
+
+    /**
+     * Returns all animals adopted by the given adopter.
+     * Returns an empty list if the adopter has not adopted any animals.
+     *
+     * @param adopter the adopter to query
+     * @return a list of animals adopted by the adopter
+     */
+    List<Animal> adoptedBy(Adopter adopter);
+}

--- a/src/main/java/shelter/service/AuditService.java
+++ b/src/main/java/shelter/service/AuditService.java
@@ -1,0 +1,32 @@
+package shelter.service;
+
+import shelter.service.model.AuditEntry;
+
+import java.util.List;
+
+/**
+ * Records audit log entries for operations performed within a service.
+ * The staff member is provided at construction time and applied to all log entries automatically.
+ *
+ * @param <T> the type of the target object being acted upon
+ */
+public interface AuditService<T> {
+
+    /**
+     * Records an audit entry for the given action and target object.
+     * The staff member is determined internally from the instance configured at construction time.
+     * Throws an exception if any argument is null.
+     *
+     * @param action a short description of the action (e.g. "approved", "recorded vaccination")
+     * @param target the object that was acted upon
+     */
+    void log(String action, T target);
+
+    /**
+     * Returns all audit log entries recorded so far.
+     * Returns an empty list if no entries have been logged.
+     *
+     * @return a list of all audit entries
+     */
+    List<AuditEntry<T>> getLog();
+}

--- a/src/main/java/shelter/service/ExplanationService.java
+++ b/src/main/java/shelter/service/ExplanationService.java
@@ -1,0 +1,22 @@
+package shelter.service;
+
+import shelter.service.model.ExplanationResult;
+import shelter.service.model.MatchResult;
+
+import java.util.List;
+
+/**
+ * Generates a structured explanation for a set of match results between animals and adopters.
+ * This interface decouples the explanation logic from the matching logic, allowing AI or mock implementations.
+ */
+public interface ExplanationService {
+
+    /**
+     * Produces a structured explanation of the top match results, including rationale,
+     * confidence assessment, and personalized advice derived from the MatchResult data.
+     *
+     * @param results the ranked list of match results to explain
+     * @return an ExplanationResult containing structured components of the explanation
+     */
+    ExplanationResult explain(List<MatchResult> results);
+}

--- a/src/main/java/shelter/service/RequestNotificationService.java
+++ b/src/main/java/shelter/service/RequestNotificationService.java
@@ -1,0 +1,66 @@
+package shelter.service;
+
+import shelter.domain.AdoptionRequest;
+import shelter.domain.Staff;
+import shelter.domain.TransferRequest;
+import shelter.service.model.NotificationRecord;
+
+import java.util.List;
+
+/**
+ * Dispatches notifications to relevant parties when the status of a request changes.
+ * Implementations may send notifications via email, in-app messaging, or other channels.
+ */
+public interface RequestNotificationService {
+
+    /**
+     * Sends a notification to the adopter when the status of their adoption request changes.
+     * Throws an exception if the request or its associated adopter is null.
+     *
+     * @param request the adoption request whose status has changed
+     */
+    void notifyAdoptionStatusChange(AdoptionRequest request);
+
+    /**
+     * Sends a notification to relevant shelter staff when a transfer request status changes.
+     * Throws an exception if the request or its associated shelters are null.
+     *
+     * @param request the transfer request whose status has changed
+     */
+    void notifyTransferStatusChange(TransferRequest request);
+
+    /**
+     * Returns all notifications that have been dispatched.
+     * Returns an empty list if no notifications have been sent.
+     *
+     * @return a list of all notification records
+     */
+    List<NotificationRecord> listAll();
+
+    /**
+     * Returns all notifications dispatched by the given staff member.
+     * Returns an empty list if the staff member has sent no notifications.
+     *
+     * @param staff the staff member to query
+     * @return a list of notification records sent by the staff member
+     */
+    List<NotificationRecord> getByStaff(Staff staff);
+
+    /**
+     * Returns all notifications associated with the given target identifier.
+     * Returns an empty list if no notifications match the target.
+     *
+     * @param targetId the identifier of the target object
+     * @return a list of notification records for the target
+     */
+    List<NotificationRecord> getByTarget(String targetId);
+
+    /**
+     * Returns all notifications whose action description contains the given keyword.
+     * Returns an empty list if no notifications match the keyword.
+     *
+     * @param keyword the string to search for in action descriptions
+     * @return a list of matching notification records
+     */
+    List<NotificationRecord> searchByAction(String keyword);
+}

--- a/src/main/java/shelter/service/ShelterService.java
+++ b/src/main/java/shelter/service/ShelterService.java
@@ -1,0 +1,44 @@
+package shelter.service;
+
+import shelter.domain.Shelter;
+
+import java.util.List;
+
+/**
+ * Manages shelter records within the system, including registration, updates, and closure.
+ * Implementations are responsible for ensuring shelter capacity constraints are respected.
+ */
+public interface ShelterService {
+
+    /**
+     * Registers a new shelter into the system.
+     * Throws an exception if a shelter with the same name and location already exists.
+     *
+     * @param shelter the shelter to register
+     */
+    void register(Shelter shelter);
+
+    /**
+     * Updates the information of an existing shelter record, such as capacity or location.
+     * Throws an exception if the shelter is not found in the system.
+     *
+     * @param shelter the shelter with updated information
+     */
+    void update(Shelter shelter);
+
+    /**
+     * Removes a shelter from the system.
+     * Throws an exception if the shelter still holds animals or has pending transfer requests.
+     *
+     * @param shelter the shelter to remove
+     */
+    void remove(Shelter shelter);
+
+    /**
+     * Returns all shelters currently registered in the system.
+     * Returns an empty list if no shelters are registered.
+     *
+     * @return a list of all registered shelters
+     */
+    List<Shelter> listAll();
+}

--- a/src/main/java/shelter/service/StaffService.java
+++ b/src/main/java/shelter/service/StaffService.java
@@ -1,0 +1,38 @@
+package shelter.service;
+
+import shelter.domain.Staff;
+
+import java.util.List;
+
+/**
+ * Loads the current operator's staff profile from a file at application startup.
+ * The loaded Staff object represents the person performing operations in this session.
+ */
+public interface StaffService {
+
+    /**
+     * Reads a staff profile from the given file path and returns the corresponding Staff object.
+     * Throws an exception if the file cannot be read or the profile data is invalid.
+     *
+     * @param filePath the path to the staff profile file (CSV or JSON)
+     * @return the Staff object representing the current operator
+     */
+    Staff loadCurrentStaff(String filePath);
+
+    /**
+     * Returns all staff members registered in the system.
+     * Returns an empty list if no staff are registered.
+     *
+     * @return a list of all staff members
+     */
+    List<Staff> listAll();
+
+    /**
+     * Returns all staff members with the given role.
+     * Returns an empty list if no staff with that role exist.
+     *
+     * @param role the role to filter by (e.g. "Veterinarian", "Coordinator")
+     * @return a list of staff members with the specified role
+     */
+    List<Staff> findByRole(String role);
+}

--- a/src/main/java/shelter/service/TransferService.java
+++ b/src/main/java/shelter/service/TransferService.java
@@ -1,0 +1,50 @@
+package shelter.service;
+
+import shelter.domain.Animal;
+import shelter.domain.Shelter;
+import shelter.domain.TransferRequest;
+
+import java.util.List;
+
+/**
+ * Handles inter-shelter animal transfers, including creating and resolving transfer requests.
+ * Implementations must verify animal availability and update shelter records upon approval.
+ */
+public interface TransferService {
+
+    /**
+     * Creates and submits a transfer request to move an animal from one shelter to another.
+     * Throws an exception if the animal is not present in the source shelter or the destination is full.
+     *
+     * @param animal the animal to transfer
+     * @param from   the source shelter currently holding the animal
+     * @param to     the destination shelter to receive the animal
+     * @return the created transfer request
+     */
+    TransferRequest requestTransfer(Animal animal, Shelter from, Shelter to);
+
+    /**
+     * Approves a pending transfer request and moves the animal between shelters.
+     * Throws an exception if the request is not in a pending state.
+     *
+     * @param request the transfer request to approve
+     */
+    void approve(TransferRequest request);
+
+    /**
+     * Rejects a pending transfer request without moving the animal.
+     * Throws an exception if the request is not in a pending state.
+     *
+     * @param request the transfer request to reject
+     */
+    void reject(TransferRequest request);
+
+    /**
+     * Returns all pending transfer requests involving the given shelter, either as source or destination.
+     * Returns an empty list if the shelter has no pending transfer requests.
+     *
+     * @param shelter the shelter to query
+     * @return a list of pending transfer requests involving the shelter
+     */
+    List<TransferRequest> getPendingRequests(Shelter shelter);
+}

--- a/src/main/java/shelter/service/VaccinationService.java
+++ b/src/main/java/shelter/service/VaccinationService.java
@@ -1,0 +1,43 @@
+package shelter.service;
+
+import shelter.domain.Animal;
+import shelter.domain.VaccineType;
+import shelter.service.model.OverdueVaccination;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Tracks vaccination records for animals and identifies overdue vaccinations.
+ * Implementations determine overdue status based on each VaccineType's validity period.
+ */
+public interface VaccinationService {
+
+    /**
+     * Records that an animal received a specific vaccine on the given date.
+     * Throws an exception if any argument is null, or if the vaccine type is not applicable to the animal's species.
+     *
+     * @param animal      the animal that received the vaccine
+     * @param vaccineType the type of vaccine administered
+     * @param date        the date the vaccine was given
+     */
+    void recordVaccination(Animal animal, VaccineType vaccineType, LocalDate date);
+
+    /**
+     * Returns a list of overdue vaccinations for the given animal, including due dates and last administered dates.
+     * Returns an empty list if all vaccinations are up to date.
+     *
+     * @param animal the animal to check
+     * @return a list of overdue vaccination details
+     */
+    List<OverdueVaccination> getOverdueVaccinations(Animal animal);
+
+    /**
+     * Returns the vaccination record for the given unique record ID.
+     * Throws an exception if no record with that ID is found.
+     *
+     * @param id the unique identifier of the vaccination record
+     * @return the matching vaccination record
+     */
+    shelter.domain.VaccinationRecord findById(String id);
+}

--- a/src/main/java/shelter/service/VaccineTypeCatalogService.java
+++ b/src/main/java/shelter/service/VaccineTypeCatalogService.java
@@ -1,0 +1,69 @@
+package shelter.service;
+
+import shelter.domain.VaccineType;
+
+import java.util.List;
+
+/**
+ * Manages the catalog of vaccine types available in the system, supporting full CRUD operations.
+ * The catalog can be initialized from and persisted to a CSV file for easy configuration.
+ */
+public interface VaccineTypeCatalogService {
+
+    /**
+     * Adds a new vaccine type to the catalog.
+     * Throws an exception if a vaccine type with the same name already exists.
+     *
+     * @param vaccineType the vaccine type to add
+     */
+    void add(VaccineType vaccineType);
+
+    /**
+     * Updates an existing vaccine type in the catalog.
+     * Throws an exception if the vaccine type is not found.
+     *
+     * @param vaccineType the vaccine type with updated information
+     */
+    void update(VaccineType vaccineType);
+
+    /**
+     * Removes a vaccine type from the catalog by name.
+     * Throws an exception if the vaccine type is not found.
+     *
+     * @param name the name of the vaccine type to remove
+     */
+    void remove(String name);
+
+    /**
+     * Returns the vaccine type with the given name.
+     * Throws an exception if no matching vaccine type is found.
+     *
+     * @param name the name to look up
+     * @return the matching vaccine type
+     */
+    VaccineType findByName(String name);
+
+    /**
+     * Returns all vaccine types currently in the catalog.
+     * Returns an empty list if the catalog is empty.
+     *
+     * @return a list of all vaccine types
+     */
+    List<VaccineType> listAll();
+
+    /**
+     * Loads vaccine types from a CSV file, replacing the current catalog contents.
+     * Throws an exception if the file path is invalid or the file format is incorrect.
+     *
+     * @param filePath the path to the CSV file
+     */
+    void loadFromCsv(String filePath);
+
+    /**
+     * Saves the current catalog contents to a CSV file.
+     * Throws an exception if the file cannot be written.
+     *
+     * @param filePath the path to the CSV file
+     */
+    void saveToCsv(String filePath);
+}

--- a/src/main/java/shelter/service/model/AuditEntry.java
+++ b/src/main/java/shelter/service/model/AuditEntry.java
@@ -1,0 +1,71 @@
+package shelter.service.model;
+
+import shelter.domain.Staff;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents a single audit log entry recording who performed an action, what was affected, and when.
+ * Instances are immutable once created to preserve the integrity of the audit trail.
+ *
+ * @param <T> the type of the target object that was acted upon
+ */
+public class AuditEntry<T> {
+
+    private final Staff staff;
+    private final String action;
+    private final T target;
+    private final LocalDateTime timestamp;
+
+    /**
+     * Constructs an AuditEntry with the given staff, action, target, and timestamp.
+     * The timestamp should represent the moment the action was performed.
+     *
+     * @param staff     the staff member who performed the action
+     * @param action    a short description of the action
+     * @param target    the object that was acted upon
+     * @param timestamp the date and time the action occurred
+     */
+    public AuditEntry(Staff staff, String action, T target, LocalDateTime timestamp) {
+        this.staff = staff;
+        this.action = action;
+        this.target = target;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Returns the staff member who performed the action.
+     *
+     * @return the staff member
+     */
+    public Staff getStaff() {
+        return staff;
+    }
+
+    /**
+     * Returns the description of the action performed.
+     *
+     * @return the action string
+     */
+    public String getAction() {
+        return action;
+    }
+
+    /**
+     * Returns the target object that was acted upon.
+     *
+     * @return the target object
+     */
+    public T getTarget() {
+        return target;
+    }
+
+    /**
+     * Returns the timestamp of when the action was performed.
+     *
+     * @return the timestamp
+     */
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/shelter/service/model/ExplanationResult.java
+++ b/src/main/java/shelter/service/model/ExplanationResult.java
@@ -1,0 +1,56 @@
+package shelter.service.model;
+
+// TODO: fields are pending team discussion — confirm what AI should generate before finalizing this class
+
+/**
+ * Represents the structured output of an ExplanationService call for a set of match results.
+ * Encapsulates multiple aspects of the AI-generated explanation, allowing callers to use
+ * each component independently.
+ */
+public class ExplanationResult {
+
+    private final String matchRationale;
+    private final String confidenceAssessment;
+    private final String personalizedAdvice;
+
+    /**
+     * Constructs an ExplanationResult with all explanation components.
+     * All fields are immutable once set; use the builder or constructor to supply values.
+     *
+     * @param matchRationale       explanation of why the top matches are good or poor fits
+     * @param confidenceAssessment assessment of whether the match scores are reliable and meaningful
+     * @param personalizedAdvice   tailored recommendations for the adopter based on their profile
+     */
+    public ExplanationResult(String matchRationale, String confidenceAssessment, String personalizedAdvice) {
+        this.matchRationale = matchRationale;
+        this.confidenceAssessment = confidenceAssessment;
+        this.personalizedAdvice = personalizedAdvice;
+    }
+
+    /**
+     * Returns the rationale explaining why the matched animals are a good or poor fit.
+     *
+     * @return the match rationale string
+     */
+    public String getMatchRationale() {
+        return matchRationale;
+    }
+
+    /**
+     * Returns an assessment of how reliable and meaningful the match scores are.
+     *
+     * @return the confidence assessment string
+     */
+    public String getConfidenceAssessment() {
+        return confidenceAssessment;
+    }
+
+    /**
+     * Returns personalized advice for the adopter based on their lifestyle and preferences.
+     *
+     * @return the personalized advice string
+     */
+    public String getPersonalizedAdvice() {
+        return personalizedAdvice;
+    }
+}

--- a/src/main/java/shelter/service/model/MatchResult.java
+++ b/src/main/java/shelter/service/model/MatchResult.java
@@ -1,0 +1,56 @@
+package shelter.service.model;
+
+import shelter.domain.Animal;
+import shelter.domain.Adopter;
+
+/**
+ * Represents the result of a single match between an animal and an adopter.
+ * Holds both parties and the computed score, supporting both forward and reverse matching directions.
+ */
+public class MatchResult {
+
+    private final Animal animal;
+    private final Adopter adopter;
+    private final int score;
+
+    /**
+     * Constructs a MatchResult with the given animal, adopter, and score.
+     * Higher scores indicate a stronger compatibility between the two parties.
+     *
+     * @param animal  the animal involved in this match
+     * @param adopter the adopter involved in this match
+     * @param score   the computed match score
+     */
+    public MatchResult(Animal animal, Adopter adopter, int score) {
+        this.animal = animal;
+        this.adopter = adopter;
+        this.score = score;
+    }
+
+    /**
+     * Returns the animal associated with this match result.
+     *
+     * @return the matched animal
+     */
+    public Animal getAnimal() {
+        return animal;
+    }
+
+    /**
+     * Returns the adopter associated with this match result.
+     *
+     * @return the matched adopter
+     */
+    public Adopter getAdopter() {
+        return adopter;
+    }
+
+    /**
+     * Returns the match score for this result.
+     *
+     * @return the computed score
+     */
+    public int getScore() {
+        return score;
+    }
+}

--- a/src/main/java/shelter/service/model/NotificationRecord.java
+++ b/src/main/java/shelter/service/model/NotificationRecord.java
@@ -1,0 +1,69 @@
+package shelter.service.model;
+
+import shelter.domain.Staff;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents a record of a notification that was dispatched by a staff member.
+ * Captures who sent the notification, what action triggered it, the target identifier, and when it occurred.
+ */
+public class NotificationRecord {
+
+    private final Staff staff;
+    private final String action;
+    private final String targetId;
+    private final LocalDateTime timestamp;
+
+    /**
+     * Constructs a NotificationRecord with the given staff, action, target identifier, and timestamp.
+     * All fields are immutable once set to preserve the integrity of the notification history.
+     *
+     * @param staff     the staff member who dispatched the notification
+     * @param action    a short description of the action that triggered the notification
+     * @param targetId  the identifier of the target object (e.g. request ID)
+     * @param timestamp the date and time the notification was sent
+     */
+    public NotificationRecord(Staff staff, String action, String targetId, LocalDateTime timestamp) {
+        this.staff = staff;
+        this.action = action;
+        this.targetId = targetId;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Returns the staff member who dispatched this notification.
+     *
+     * @return the staff member
+     */
+    public Staff getStaff() {
+        return staff;
+    }
+
+    /**
+     * Returns the action description that triggered this notification.
+     *
+     * @return the action string
+     */
+    public String getAction() {
+        return action;
+    }
+
+    /**
+     * Returns the identifier of the target object this notification relates to.
+     *
+     * @return the target identifier
+     */
+    public String getTargetId() {
+        return targetId;
+    }
+
+    /**
+     * Returns the timestamp of when this notification was dispatched.
+     *
+     * @return the timestamp
+     */
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/shelter/service/model/OverdueVaccination.java
+++ b/src/main/java/shelter/service/model/OverdueVaccination.java
@@ -1,0 +1,57 @@
+package shelter.service.model;
+
+import shelter.domain.VaccineType;
+
+import java.time.LocalDate;
+
+/**
+ * Represents a vaccination that is overdue for a specific animal.
+ * Provides details about when the vaccine was last administered and when it was due.
+ */
+public class OverdueVaccination {
+
+    private final VaccineType vaccineType;
+    private final LocalDate lastAdministered;
+    private final LocalDate dueDate;
+
+    /**
+     * Constructs an OverdueVaccination with the given vaccine type, last administered date, and due date.
+     * {@code lastAdministered} may be null if the animal has never received this vaccine.
+     *
+     * @param vaccineType      the vaccine type that is overdue
+     * @param lastAdministered the date the vaccine was last given, or null if never administered
+     * @param dueDate          the date by which the vaccine should have been administered
+     */
+    public OverdueVaccination(VaccineType vaccineType, LocalDate lastAdministered, LocalDate dueDate) {
+        this.vaccineType = vaccineType;
+        this.lastAdministered = lastAdministered;
+        this.dueDate = dueDate;
+    }
+
+    /**
+     * Returns the vaccine type that is overdue.
+     *
+     * @return the overdue vaccine type
+     */
+    public VaccineType getVaccineType() {
+        return vaccineType;
+    }
+
+    /**
+     * Returns the date the vaccine was last administered, or null if never given.
+     *
+     * @return the last administered date, or null
+     */
+    public LocalDate getLastAdministered() {
+        return lastAdministered;
+    }
+
+    /**
+     * Returns the date by which the vaccine should have been administered.
+     *
+     * @return the due date
+     */
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+}


### PR DESCRIPTION
## Summary
- Define all Service Layer interfaces across 13 service files
- Add `shelter.service.model` subpackage with value objects: `MatchResult`, `ExplanationResult`, `OverdueVaccination`, `AuditEntry`, `NotificationRecord`
- Key design decisions documented in `.notes/cross-layer-decisions.md`

## Services included
`AdoptionService`, `TransferService`, `AdopterBasedMatchingService`, `AnimalBasedMatchingService`, `VaccinationService`, `VaccineTypeCatalogService`, `AnimalService`, `AdopterService`, `ShelterService`, `RequestNotificationService`, `ExplanationService`, `AuditService<T>`, `StaffService`

## Notes
- All interfaces reference Domain classes not yet written (Irene's work) — compile errors are expected until Domain layer is complete
- See `.notes/cross-layer-decisions.md` for cross-layer design decisions that Irene needs to implement