### PR TITLE
Feature: add strategy layer foundation for matching

### DIFF
--- a/src/main/java/shelter/strategy/ActivityLevelStrategy.java
+++ b/src/main/java/shelter/strategy/ActivityLevelStrategy.java
@@ -1,0 +1,62 @@
+package shelter.strategy;
+
+import shelter.domain.ActivityLevel;
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * A concrete matching strategy that evaluates compatibility between the adopter's
+ * preferred activity level and the animal's activity level.
+ */
+public class ActivityLevelStrategy implements IMatchingStrategy {
+
+    /**
+     * Returns the matching criterion handled by this strategy.
+     *
+     * @return {@link MatchingCriterion#ACTIVITY_LEVEL}
+     */
+    @Override
+    public MatchingCriterion getCriterion() {
+        return MatchingCriterion.ACTIVITY_LEVEL;
+    }
+
+    /**
+     * Returns the score contributed by this strategy for the given adopter-animal pair.
+     * An exact activity match returns {@code 1.0}, a nearby match returns {@code 0.5},
+     * and a poor match returns {@code 0.0}.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the compatibility score for activity level
+     * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        ActivityLevel preferredActivity = adopter.getPreferences().getPreferredActivityLevel();
+        ActivityLevel animalActivity = animal.getActivityLevel();
+
+        if (preferredActivity == null) {
+            return 0.0;
+        }
+
+        if (preferredActivity == animalActivity) {
+            return 1.0;
+        }
+
+        if ((preferredActivity == ActivityLevel.LOW && animalActivity == ActivityLevel.MEDIUM)
+                || (preferredActivity == ActivityLevel.MEDIUM && animalActivity == ActivityLevel.LOW)
+                || (preferredActivity == ActivityLevel.MEDIUM && animalActivity == ActivityLevel.HIGH)
+                || (preferredActivity == ActivityLevel.HIGH && animalActivity == ActivityLevel.MEDIUM)) {
+            return 0.5;
+        }
+
+        return 0.0;
+    }
+}

--- a/src/main/java/shelter/strategy/AgePreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/AgePreferenceStrategy.java
@@ -1,0 +1,55 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * A concrete matching strategy that evaluates whether an animal's age
+ * fits the adopter's preferred age range.
+ */
+public class AgePreferenceStrategy implements IMatchingStrategy {
+
+    /**
+     * Returns the matching criterion handled by this strategy.
+     *
+     * @return {@link MatchingCriterion#AGE}
+     */
+    @Override
+    public MatchingCriterion getCriterion() {
+        return MatchingCriterion.AGE;
+    }
+
+    /**
+     * Returns the score contributed by this strategy for the given adopter-animal pair.
+     * An animal within the preferred age range returns {@code 1.0}. An animal
+     * just outside the preferred range returns {@code 0.5}. Otherwise, the score is {@code 0.0}.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the compatibility score for age preference
+     * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        int minAge = adopter.getPreferences().getMinAge();
+        int maxAge = adopter.getPreferences().getMaxAge();
+        int animalAge = animal.getAge();
+
+        if (animalAge >= minAge && animalAge <= maxAge) {
+            return 1.0;
+        }
+
+        if (animalAge == minAge - 1 || animalAge == maxAge + 1) {
+            return 0.5;
+        }
+
+        return 0.0;
+    }
+}

--- a/src/main/java/shelter/strategy/BreedPreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/BreedPreferenceStrategy.java
@@ -1,0 +1,48 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * A concrete matching strategy that evaluates whether an animal's breed
+ * matches the adopter's preferred breed.
+ */
+public class BreedPreferenceStrategy implements IMatchingStrategy {
+
+    /**
+     * Returns the matching criterion handled by this strategy.
+     *
+     * @return {@link MatchingCriterion#BREED}
+     */
+    @Override
+    public MatchingCriterion getCriterion() {
+        return MatchingCriterion.BREED;
+    }
+
+    /**
+     * Returns the score contributed by this strategy for the given adopter-animal pair.
+     * A full match returns {@code 1.0}; otherwise this strategy returns {@code 0.0}.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return {@code 1.0} if the breed matches the adopter's preference;
+     *         {@code 0.0} otherwise
+     * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        String preferredBreed = adopter.getPreferences().getPreferredBreed();
+        if (preferredBreed == null || preferredBreed.isBlank()) {
+            return 0.0;
+        }
+
+        return preferredBreed.equalsIgnoreCase(animal.getBreed()) ? 1.0 : 0.0;
+    }
+}

--- a/src/main/java/shelter/strategy/IMatchingStrategy.java
+++ b/src/main/java/shelter/strategy/IMatchingStrategy.java
@@ -1,0 +1,29 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * Defines a scoring rule applied by the matching system to evaluate one
+ * matching criterion for an adopter-animal pair.
+ */
+public interface IMatchingStrategy {
+
+    /**
+     * Returns the matching criterion handled by this strategy.
+     *
+     * @return the criterion evaluated by this strategy
+     */
+    MatchingCriterion getCriterion();
+
+    /**
+     * Returns the score contributed by this strategy for the given adopter-animal pair.
+     * Implementations should return a normalized value, where larger values
+     * indicate stronger compatibility under this criterion.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal  the animal being evaluated
+     * @return the score contributed by this strategy
+     */
+    double score(Adopter adopter, Animal animal);
+}

--- a/src/main/java/shelter/strategy/LifestyleCompatibilityStrategy.java
+++ b/src/main/java/shelter/strategy/LifestyleCompatibilityStrategy.java
@@ -1,0 +1,120 @@
+/*
+Modificaition on Domain/ActivityLevel is Needed.
+Scoring rule need to be adjuted later. 
+How does this apply to rabbit? 
+Score 1 for rabbit since rabit neither required outdoor activity nor extra space. 
+*/
+
+
+package shelter.strategy;
+
+import shelter.domain.ActivityLevel;
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+import shelter.domain.Cat;
+import shelter.domain.DailySchedule;
+import shelter.domain.Dog;
+import shelter.domain.LivingSpace;
+
+/**
+ * A concrete matching strategy that evaluates whether an animal is a practical
+ * fit for the adopter's living space and daily schedule.
+ */
+public class LifestyleCompatibilityStrategy implements IMatchingStrategy {
+
+    /**
+     * Returns the matching criterion handled by this strategy.
+     *
+     * @return {@link MatchingCriterion#LIFESTYLE}
+     */
+    @Override
+    public MatchingCriterion getCriterion() {
+        return MatchingCriterion.LIFESTYLE;
+    }
+
+    /**
+     * Returns the score contributed by this strategy for the given adopter-animal pair.
+     * The score is based on a simple combination of living-space fit and schedule fit.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the compatibility score for lifestyle fit
+     * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        double livingSpaceScore = calculateLivingSpaceScore(adopter, animal);
+        double scheduleScore = calculateScheduleScore(adopter, animal);
+
+        // Lifestyle fit is treated as a balance between home environment and time availability.
+        return (livingSpaceScore + scheduleScore) / 2.0;
+    }
+
+    private double calculateLivingSpaceScore(Adopter adopter, Animal animal) {
+        LivingSpace livingSpace = adopter.getLivingSpace();
+
+        if (animal instanceof Dog dog) {
+            // Large dogs are the weakest fit for apartment living.
+            if (livingSpace == LivingSpace.APARTMENT && dog.getSize() == Dog.Size.LARGE) {
+                return 0.0;
+            }
+            // Medium dogs may still work in apartments, but the fit is not ideal.
+            if (livingSpace == LivingSpace.APARTMENT && dog.getSize() == Dog.Size.MEDIUM) {
+                return 0.5;
+            }
+            // Large dogs without a yard are possible, but still not the strongest match.
+            if (livingSpace == LivingSpace.HOUSE_NO_YARD && dog.getSize() == Dog.Size.LARGE) {
+                return 0.5;
+            }
+            // A house with a yard is treated as the strongest fit for any dog size.
+            if (livingSpace == LivingSpace.HOUSE_WITH_YARD) {
+                return 1.0;
+            }
+            return 1.0;
+        }
+
+        if (animal instanceof Cat cat) {
+            // Indoor cats are usually a strong fit for apartment-style homes.
+            if (livingSpace == LivingSpace.APARTMENT && cat.isIndoor()) {
+                return 1.0;
+            }
+            return 0.8;
+        }
+
+        // Rabbits are treated as generally adaptable for now.
+        return 0.8;
+    }
+
+    private double calculateScheduleScore(Adopter adopter, Animal animal) {
+        DailySchedule dailySchedule = adopter.getDailySchedule();
+        ActivityLevel activityLevel = animal.getActivityLevel();
+
+        // Being home most of the day gives the strongest schedule fit.
+        if (dailySchedule == DailySchedule.HOME_MOST_OF_DAY) {
+            return 1.0;
+        }
+
+        if (dailySchedule == DailySchedule.AWAY_PART_OF_DAY) {
+            // High-energy animals are harder to support when the adopter is away more often.
+            if (activityLevel == ActivityLevel.HIGH) {
+                return 0.5;
+            }
+            return 1.0;
+        }
+
+        // High-energy animals are the weakest fit when the adopter is away most of the day.
+        if (activityLevel == ActivityLevel.HIGH) {
+            return 0.0;
+        }
+
+        // Lower-energy animals may still work, but the schedule is not ideal.
+        return 0.5;
+    }
+}

--- a/src/main/java/shelter/strategy/MatchingCriterion.java
+++ b/src/main/java/shelter/strategy/MatchingCriterion.java
@@ -1,0 +1,26 @@
+package shelter.strategy;
+
+/**
+ * Represents the supported criteria that may be used in the matching system.
+ * Each criterion corresponds to one strategy implementation and may later be
+ * prioritized by an adopter or shelter staff member.
+ */
+public enum MatchingCriterion {
+    /** Matches animals by species preference. */
+    SPECIES,
+
+    /** Matches animals by breed preference. */
+    BREED,
+
+    /** Matches animals by activity level compatibility. */
+    ACTIVITY_LEVEL,
+
+    /** Matches animals by preferred age or age range. */
+    AGE,
+
+    /** Matches animals by lifestyle fit, such as living space and schedule. */
+    LIFESTYLE,
+
+    /** Matches animals by vaccination status preference. */
+    VACCINATION
+}

--- a/src/main/java/shelter/strategy/MatchingPreferencesPriority.java
+++ b/src/main/java/shelter/strategy/MatchingPreferencesPriority.java
@@ -1,0 +1,47 @@
+package shelter.strategy;
+
+/**
+ * Represents one prioritized matching criterion selected by a user.
+ * A lower rank means higher importance in the later matching process.
+ */
+public class MatchingPreferencesPriority {
+
+    private final MatchingCriterion criterion;
+    private final int rank;
+
+    /**
+     * Constructs one priority entry for the given criterion and rank.
+     *
+     * @param criterion the matching criterion being prioritized
+     * @param rank the rank of importance, where {@code 1} is the highest priority
+     * @throws IllegalArgumentException if {@code criterion} is {@code null} or {@code rank <= 0}
+     */
+    public MatchingPreferencesPriority(MatchingCriterion criterion, int rank) {
+        if (criterion == null) {
+            throw new IllegalArgumentException("Matching criterion must not be null.");
+        }
+        if (rank <= 0) {
+            throw new IllegalArgumentException("Priority rank must be positive.");
+        }
+        this.criterion = criterion;
+        this.rank = rank;
+    }
+
+    /**
+     * Returns the prioritized matching criterion.
+     *
+     * @return the criterion
+     */
+    public MatchingCriterion getCriterion() {
+        return criterion;
+    }
+
+    /**
+     * Returns the priority rank, where {@code 1} means the most important criterion.
+     *
+     * @return the priority rank
+     */
+    public int getRank() {
+        return rank;
+    }
+}

--- a/src/main/java/shelter/strategy/MatchingPreferencesProfile.java
+++ b/src/main/java/shelter/strategy/MatchingPreferencesProfile.java
@@ -1,0 +1,38 @@
+package shelter.strategy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents the full prioritized matching setup selected by a user.
+ * The profile stores only the criteria the user chose to rank, allowing
+ * unselected criteria to be ignored by the matching workflow.
+ */
+public class MatchingPreferencesProfile {
+
+    private final List<MatchingPreferencesPriority> priorities;
+
+    /**
+     * Constructs a matching preferences profile with the given ranked criteria.
+     *
+     * @param priorities the prioritized criteria selected by the user
+     * @throws IllegalArgumentException if {@code priorities} is {@code null}
+     */
+    public MatchingPreferencesProfile(List<MatchingPreferencesPriority> priorities) {
+        if (priorities == null) {
+            throw new IllegalArgumentException("Matching priorities must not be null.");
+        }
+        this.priorities = Collections.unmodifiableList(new ArrayList<>(priorities));
+    }
+
+    /**
+     * Returns all prioritized criteria in this profile.
+     * The returned list cannot be modified by callers.
+     *
+     * @return an unmodifiable list of matching priorities
+     */
+    public List<MatchingPreferencesPriority> getPriorities() {
+        return priorities;
+    }
+}

--- a/src/main/java/shelter/strategy/SpeciesPreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/SpeciesPreferenceStrategy.java
@@ -1,0 +1,49 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * A concrete matching strategy that evaluates whether an animal's species
+ * matches the adopter's preferred species.
+ */
+public class SpeciesPreferenceStrategy implements IMatchingStrategy {
+
+    /**
+     * Returns the matching criterion handled by this strategy.
+     *
+     * @return {@link MatchingCriterion#SPECIES}
+     */
+    @Override
+    public MatchingCriterion getCriterion() {
+        return MatchingCriterion.SPECIES;
+    }
+
+    /**
+     * Returns the score contributed by this strategy for the given adopter-animal pair.
+     * A full match returns {@code 1.0}; otherwise this strategy returns {@code 0.0}.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return {@code 1.0} if the species matches the adopter's preference;
+     *         {@code 0.0} otherwise
+     * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        String preferredSpecies = adopter.getPreferences().getPreferredSpecies();
+        if (preferredSpecies == null || preferredSpecies.isBlank()) {
+            return 0.0;
+        }
+
+        return preferredSpecies.equalsIgnoreCase(animal.getSpecies()) ? 1.0 : 0.0;
+    }
+
+}

--- a/src/main/java/shelter/strategy/VaccinationPreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/VaccinationPreferenceStrategy.java
@@ -1,0 +1,48 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * A concrete matching strategy related to vaccination status.
+ * At this stage, the adopter-side vaccination requirement has not been modeled yet,
+ * so this strategy provisionally rewards animals that are already vaccinated.
+ * TODO: revise this strategy after the team decides where vaccination preference
+ * should be stored in the adopter-side matching data.
+ */
+public class VaccinationPreferenceStrategy implements IMatchingStrategy {
+
+    /**
+     * Returns the matching criterion handled by this strategy.
+     *
+     * @return {@link MatchingCriterion#VACCINATION}
+     */
+    @Override
+    public MatchingCriterion getCriterion() {
+        return MatchingCriterion.VACCINATION;
+    }
+
+    /**
+     * Returns the score contributed by this strategy for the given adopter-animal pair.
+     * Currently, vaccinated animals receive {@code 1.0} and unvaccinated animals
+     * receive {@code 0.0}. This scoring rule can be revised later when a user-side
+     * vaccination preference is added to the design.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the compatibility score for vaccination status
+     * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        // For the current first-stage design, vaccinated animals are treated as the stronger match.
+        return animal.isVaccinated() ? 1.0 : 0.0;
+    }
+}


### PR DESCRIPTION
This PR adds the first-stage strategy layer for the matching feature.
Changes included:
added the matching strategy interface IMatchingStrategy
added MatchingCriterion enum for supported matching criteria
added MatchingPreferencesPriority and MatchingPreferencesProfile to model ranked matching preferences
implemented concrete matching strategies:
SpeciesPreferenceStrategy
BreedPreferenceStrategy
ActivityLevelStrategy
AgePreferenceStrategy
LifestyleCompatibilityStrategy
VaccinationPreferenceStrategy