### PR TITLE
feat: complete service layer interfaces and model classes

### DIFF
--- a/src/main/java/shelter/service/AdopterBasedMatchingService.java
+++ b/src/main/java/shelter/service/AdopterBasedMatchingService.java
@@ -15,6 +15,8 @@ public interface AdopterBasedMatchingService {
     /**
      * Evaluates each animal in the provided list against the adopter's preferences and returns
      * a ranked list of match results ordered from highest to lowest score.
+     * Animals with no compatibility with the adopter's preferences may still appear in the result
+     * with a score of zero.
      *
      * @param adopter the adopter to match against
      * @param animals the pool of animals to evaluate

--- a/src/main/java/shelter/service/AdoptionService.java
+++ b/src/main/java/shelter/service/AdoptionService.java
@@ -40,6 +40,14 @@ public interface AdoptionService {
     void reject(AdoptionRequest request);
 
     /**
+     * Cancels a pending adoption request at the adopter's request.
+     * Throws an exception if the request is not in a pending state.
+     *
+     * @param request the adoption request to cancel
+     */
+    void cancel(AdoptionRequest request);
+
+    /**
      * Returns all adoption requests submitted by the given adopter.
      * Returns an empty list if the adopter has no requests on record.
      *

--- a/src/main/java/shelter/service/AnimalBasedMatchingService.java
+++ b/src/main/java/shelter/service/AnimalBasedMatchingService.java
@@ -15,6 +15,8 @@ public interface AnimalBasedMatchingService {
     /**
      * Evaluates each adopter in the provided list against the given animal and returns
      * a ranked list of match results ordered from highest to lowest score.
+     * Adopters with no compatibility with the animal's characteristics may still appear
+     * in the result with a score of zero.
      *
      * @param animal   the animal to match against
      * @param adopters the pool of adopters to evaluate

--- a/src/main/java/shelter/service/AnimalService.java
+++ b/src/main/java/shelter/service/AnimalService.java
@@ -66,6 +66,15 @@ public interface AnimalService {
     List<Animal> adoptedAfter(LocalDate date);
 
     /**
+     * Returns the animal with the given ID.
+     * Throws an exception if no animal with that ID is found.
+     *
+     * @param id the unique identifier of the animal
+     * @return the matching animal
+     */
+    Animal findById(String id);
+
+    /**
      * Returns all animals adopted by the given adopter.
      * Returns an empty list if the adopter has not adopted any animals.
      *

--- a/src/main/java/shelter/service/ExplanationService.java
+++ b/src/main/java/shelter/service/ExplanationService.java
@@ -14,6 +14,8 @@ public interface ExplanationService {
     /**
      * Produces a structured explanation of the top match results, including rationale,
      * confidence assessment, and personalized advice derived from the MatchResult data.
+     * The returned ExplanationResult breaks the explanation into independent components
+     * that callers may display or log separately.
      *
      * @param results the ranked list of match results to explain
      * @return an ExplanationResult containing structured components of the explanation

--- a/src/main/java/shelter/service/ShelterService.java
+++ b/src/main/java/shelter/service/ShelterService.java
@@ -35,6 +35,15 @@ public interface ShelterService {
     void remove(Shelter shelter);
 
     /**
+     * Returns the shelter with the given ID.
+     * Throws an exception if no shelter with that ID is found.
+     *
+     * @param id the unique identifier of the shelter
+     * @return the matching shelter
+     */
+    Shelter findById(String id);
+
+    /**
      * Returns all shelters currently registered in the system.
      * Returns an empty list if no shelters are registered.
      *

--- a/src/main/java/shelter/service/TransferService.java
+++ b/src/main/java/shelter/service/TransferService.java
@@ -40,6 +40,14 @@ public interface TransferService {
     void reject(TransferRequest request);
 
     /**
+     * Dismisses a pending transfer request without approving or rejecting it.
+     * Throws an exception if the request is not in a pending state.
+     *
+     * @param request the transfer request to dismiss
+     */
+    void dismiss(TransferRequest request);
+
+    /**
      * Returns all pending transfer requests involving the given shelter, either as source or destination.
      * Returns an empty list if the shelter has no pending transfer requests.
      *

--- a/src/main/java/shelter/service/VaccinationService.java
+++ b/src/main/java/shelter/service/VaccinationService.java
@@ -1,6 +1,7 @@
 package shelter.service;
 
 import shelter.domain.Animal;
+import shelter.domain.VaccinationRecord;
 import shelter.domain.VaccineType;
 import shelter.service.model.OverdueVaccination;
 
@@ -33,11 +34,20 @@ public interface VaccinationService {
     List<OverdueVaccination> getOverdueVaccinations(Animal animal);
 
     /**
+     * Returns all vaccination records for the given animal.
+     * Returns an empty list if no vaccinations have been recorded for the animal.
+     *
+     * @param animal the animal to query
+     * @return a list of vaccination records for the animal
+     */
+    List<VaccinationRecord> getVaccinationHistory(Animal animal);
+
+    /**
      * Returns the vaccination record for the given unique record ID.
      * Throws an exception if no record with that ID is found.
      *
      * @param id the unique identifier of the vaccination record
      * @return the matching vaccination record
      */
-    shelter.domain.VaccinationRecord findById(String id);
+    VaccinationRecord findById(String id);
 }

--- a/src/main/java/shelter/service/VaccineTypeCatalogService.java
+++ b/src/main/java/shelter/service/VaccineTypeCatalogService.java
@@ -6,7 +6,8 @@ import java.util.List;
 
 /**
  * Manages the catalog of vaccine types available in the system, supporting full CRUD operations.
- * The catalog can be initialized from and persisted to a CSV file for easy configuration.
+ * Each vaccine type is uniquely identified by its ID; name is used for lookup convenience
+ * but may be updated.
  */
 public interface VaccineTypeCatalogService {
 
@@ -20,6 +21,7 @@ public interface VaccineTypeCatalogService {
 
     /**
      * Updates an existing vaccine type in the catalog.
+     * The vaccine type is identified by its ID; all mutable fields are replaced with those of the given object.
      * Throws an exception if the vaccine type is not found.
      *
      * @param vaccineType the vaccine type with updated information
@@ -27,12 +29,21 @@ public interface VaccineTypeCatalogService {
     void update(VaccineType vaccineType);
 
     /**
-     * Removes a vaccine type from the catalog by name.
-     * Throws an exception if the vaccine type is not found.
+     * Removes a vaccine type from the catalog by ID.
+     * Throws an exception if no vaccine type with that ID is found.
      *
-     * @param name the name of the vaccine type to remove
+     * @param id the ID of the vaccine type to remove
      */
-    void remove(String name);
+    void remove(String id);
+
+    /**
+     * Returns the vaccine type with the given ID.
+     * Throws an exception if no matching vaccine type is found.
+     *
+     * @param id the ID to look up
+     * @return the matching vaccine type
+     */
+    VaccineType findById(String id);
 
     /**
      * Returns the vaccine type with the given name.
@@ -50,20 +61,4 @@ public interface VaccineTypeCatalogService {
      * @return a list of all vaccine types
      */
     List<VaccineType> listAll();
-
-    /**
-     * Loads vaccine types from a CSV file, replacing the current catalog contents.
-     * Throws an exception if the file path is invalid or the file format is incorrect.
-     *
-     * @param filePath the path to the CSV file
-     */
-    void loadFromCsv(String filePath);
-
-    /**
-     * Saves the current catalog contents to a CSV file.
-     * Throws an exception if the file cannot be written.
-     *
-     * @param filePath the path to the CSV file
-     */
-    void saveToCsv(String filePath);
 }

--- a/src/main/java/shelter/service/model/AuditEntry.java
+++ b/src/main/java/shelter/service/model/AuditEntry.java
@@ -19,14 +19,27 @@ public class AuditEntry<T> {
 
     /**
      * Constructs an AuditEntry with the given staff, action, target, and timestamp.
-     * The timestamp should represent the moment the action was performed.
+     * The timestamp should represent the moment the action was performed; no argument may be null.
      *
-     * @param staff     the staff member who performed the action
-     * @param action    a short description of the action
-     * @param target    the object that was acted upon
-     * @param timestamp the date and time the action occurred
+     * @param staff     the staff member who performed the action; must not be null
+     * @param action    a short description of the action; must not be null or blank
+     * @param target    the object that was acted upon; must not be null
+     * @param timestamp the date and time the action occurred; must not be null
+     * @throws IllegalArgumentException if any argument is null or {@code action} is blank
      */
     public AuditEntry(Staff staff, String action, T target, LocalDateTime timestamp) {
+        if (staff == null) {
+            throw new IllegalArgumentException("Staff must not be null.");
+        }
+        if (action == null || action.isBlank()) {
+            throw new IllegalArgumentException("Action must not be null or blank.");
+        }
+        if (target == null) {
+            throw new IllegalArgumentException("Target must not be null.");
+        }
+        if (timestamp == null) {
+            throw new IllegalArgumentException("Timestamp must not be null.");
+        }
         this.staff = staff;
         this.action = action;
         this.target = target;
@@ -35,6 +48,7 @@ public class AuditEntry<T> {
 
     /**
      * Returns the staff member who performed the action.
+     * Never null for a validly constructed entry.
      *
      * @return the staff member
      */
@@ -44,6 +58,7 @@ public class AuditEntry<T> {
 
     /**
      * Returns the description of the action performed.
+     * Never null or blank for a validly constructed entry.
      *
      * @return the action string
      */
@@ -53,6 +68,7 @@ public class AuditEntry<T> {
 
     /**
      * Returns the target object that was acted upon.
+     * Never null for a validly constructed entry.
      *
      * @return the target object
      */
@@ -62,10 +78,25 @@ public class AuditEntry<T> {
 
     /**
      * Returns the timestamp of when the action was performed.
+     * Never null for a validly constructed entry.
      *
      * @return the timestamp
      */
     public LocalDateTime getTimestamp() {
         return timestamp;
     }
+
+    /**
+     * Returns a string representation of this audit entry including staff, action, target, and timestamp.
+     *
+     * @return a human-readable description of this audit entry
+     */
+    @Override
+    public String toString() {
+        return "AuditEntry[staff=" + staff.getName()
+                + ", action=" + action
+                + ", target=" + target
+                + ", timestamp=" + timestamp + "]";
+    }
+
 }

--- a/src/main/java/shelter/service/model/ExplanationResult.java
+++ b/src/main/java/shelter/service/model/ExplanationResult.java
@@ -1,7 +1,5 @@
 package shelter.service.model;
 
-// TODO: fields are pending team discussion — confirm what AI should generate before finalizing this class
-
 /**
  * Represents the structured output of an ExplanationService call for a set of match results.
  * Encapsulates multiple aspects of the AI-generated explanation, allowing callers to use
@@ -15,7 +13,8 @@ public class ExplanationResult {
 
     /**
      * Constructs an ExplanationResult with all explanation components.
-     * All fields are immutable once set; use the builder or constructor to supply values.
+     * All fields are immutable once set; use the constructor to supply values.
+     * Any field may be null if the explanation source did not produce that component.
      *
      * @param matchRationale       explanation of why the top matches are good or poor fits
      * @param confidenceAssessment assessment of whether the match scores are reliable and meaningful
@@ -29,8 +28,9 @@ public class ExplanationResult {
 
     /**
      * Returns the rationale explaining why the matched animals are a good or poor fit.
+     * May be null if the explanation source did not produce this component.
      *
-     * @return the match rationale string
+     * @return the match rationale string, or null
      */
     public String getMatchRationale() {
         return matchRationale;
@@ -38,8 +38,9 @@ public class ExplanationResult {
 
     /**
      * Returns an assessment of how reliable and meaningful the match scores are.
+     * May be null if the explanation source did not produce this component.
      *
-     * @return the confidence assessment string
+     * @return the confidence assessment string, or null
      */
     public String getConfidenceAssessment() {
         return confidenceAssessment;
@@ -47,10 +48,24 @@ public class ExplanationResult {
 
     /**
      * Returns personalized advice for the adopter based on their lifestyle and preferences.
+     * May be null if the explanation source did not produce this component.
      *
-     * @return the personalized advice string
+     * @return the personalized advice string, or null
      */
     public String getPersonalizedAdvice() {
         return personalizedAdvice;
     }
+
+    /**
+     * Returns a string representation of this explanation result including all three components.
+     *
+     * @return a human-readable description of this explanation result
+     */
+    @Override
+    public String toString() {
+        return "ExplanationResult[rationale=" + matchRationale
+                + ", confidence=" + confidenceAssessment
+                + ", advice=" + personalizedAdvice + "]";
+    }
+
 }

--- a/src/main/java/shelter/service/model/MatchResult.java
+++ b/src/main/java/shelter/service/model/MatchResult.java
@@ -3,11 +3,14 @@ package shelter.service.model;
 import shelter.domain.Animal;
 import shelter.domain.Adopter;
 
+import java.util.Objects;
+
 /**
  * Represents the result of a single match between an animal and an adopter.
  * Holds both parties and the computed score, supporting both forward and reverse matching directions.
+ * Results are naturally ordered by score descending, allowing ranked lists to be sorted directly.
  */
-public class MatchResult {
+public class MatchResult implements Comparable<MatchResult> {
 
     private final Animal animal;
     private final Adopter adopter;
@@ -16,12 +19,20 @@ public class MatchResult {
     /**
      * Constructs a MatchResult with the given animal, adopter, and score.
      * Higher scores indicate a stronger compatibility between the two parties.
+     * Neither {@code animal} nor {@code adopter} may be null.
      *
-     * @param animal  the animal involved in this match
-     * @param adopter the adopter involved in this match
+     * @param animal  the animal involved in this match; must not be null
+     * @param adopter the adopter involved in this match; must not be null
      * @param score   the computed match score
+     * @throws IllegalArgumentException if {@code animal} or {@code adopter} is null
      */
     public MatchResult(Animal animal, Adopter adopter, int score) {
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
         this.animal = animal;
         this.adopter = adopter;
         this.score = score;
@@ -29,6 +40,7 @@ public class MatchResult {
 
     /**
      * Returns the animal associated with this match result.
+     * Never null for a validly constructed result.
      *
      * @return the matched animal
      */
@@ -38,6 +50,7 @@ public class MatchResult {
 
     /**
      * Returns the adopter associated with this match result.
+     * Never null for a validly constructed result.
      *
      * @return the matched adopter
      */
@@ -47,10 +60,64 @@ public class MatchResult {
 
     /**
      * Returns the match score for this result.
+     * Higher values indicate greater compatibility between the animal and adopter.
      *
      * @return the computed score
      */
     public int getScore() {
         return score;
+    }
+
+    /**
+     * Compares this result to another by score in descending order.
+     * A result with a higher score is ordered before one with a lower score,
+     * so that sorting a list of MatchResults places the best matches first.
+     *
+     * @param other the other MatchResult to compare to
+     * @return a negative number if this result has a higher score, positive if lower, zero if equal
+     */
+    @Override
+    public int compareTo(MatchResult other) {
+        return Integer.compare(other.score, this.score);
+    }
+
+    /**
+     * Returns a string representation of this match result including animal, adopter, and score.
+     *
+     * @return a human-readable description of this match result
+     */
+    @Override
+    public String toString() {
+        return "MatchResult[animal=" + animal.getName()
+                + ", adopter=" + adopter.getName()
+                + ", score=" + score + "]";
+    }
+
+    /**
+     * Returns true if the given object is a MatchResult with the same animal, adopter, and score.
+     * Equality is value-based since match results have no unique ID.
+     *
+     * @param o the object to compare
+     * @return true if all fields are equal
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MatchResult)) return false;
+        MatchResult other = (MatchResult) o;
+        return score == other.score
+                && Objects.equals(animal, other.animal)
+                && Objects.equals(adopter, other.adopter);
+    }
+
+    /**
+     * Returns a hash code based on animal, adopter, and score.
+     * Consistent with {@link #equals(Object)}.
+     *
+     * @return the hash code
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(animal, adopter, score);
     }
 }

--- a/src/main/java/shelter/service/model/NotificationRecord.java
+++ b/src/main/java/shelter/service/model/NotificationRecord.java
@@ -18,13 +18,27 @@ public class NotificationRecord {
     /**
      * Constructs a NotificationRecord with the given staff, action, target identifier, and timestamp.
      * All fields are immutable once set to preserve the integrity of the notification history.
+     * No argument may be null; {@code action} and {@code targetId} must not be blank.
      *
-     * @param staff     the staff member who dispatched the notification
-     * @param action    a short description of the action that triggered the notification
-     * @param targetId  the identifier of the target object (e.g. request ID)
-     * @param timestamp the date and time the notification was sent
+     * @param staff     the staff member who dispatched the notification; must not be null
+     * @param action    a short description of the action that triggered the notification; must not be null or blank
+     * @param targetId  the identifier of the target object (e.g. request ID); must not be null or blank
+     * @param timestamp the date and time the notification was sent; must not be null
+     * @throws IllegalArgumentException if any argument is null or {@code action}/{@code targetId} is blank
      */
     public NotificationRecord(Staff staff, String action, String targetId, LocalDateTime timestamp) {
+        if (staff == null) {
+            throw new IllegalArgumentException("Staff must not be null.");
+        }
+        if (action == null || action.isBlank()) {
+            throw new IllegalArgumentException("Action must not be null or blank.");
+        }
+        if (targetId == null || targetId.isBlank()) {
+            throw new IllegalArgumentException("Target ID must not be null or blank.");
+        }
+        if (timestamp == null) {
+            throw new IllegalArgumentException("Timestamp must not be null.");
+        }
         this.staff = staff;
         this.action = action;
         this.targetId = targetId;
@@ -33,6 +47,7 @@ public class NotificationRecord {
 
     /**
      * Returns the staff member who dispatched this notification.
+     * Never null for a validly constructed record.
      *
      * @return the staff member
      */
@@ -42,6 +57,7 @@ public class NotificationRecord {
 
     /**
      * Returns the action description that triggered this notification.
+     * Never null or blank for a validly constructed record.
      *
      * @return the action string
      */
@@ -51,6 +67,7 @@ public class NotificationRecord {
 
     /**
      * Returns the identifier of the target object this notification relates to.
+     * Never null or blank for a validly constructed record.
      *
      * @return the target identifier
      */
@@ -60,10 +77,25 @@ public class NotificationRecord {
 
     /**
      * Returns the timestamp of when this notification was dispatched.
+     * Never null for a validly constructed record.
      *
      * @return the timestamp
      */
     public LocalDateTime getTimestamp() {
         return timestamp;
     }
+
+    /**
+     * Returns a string representation of this notification record including staff, action, target, and timestamp.
+     *
+     * @return a human-readable description of this notification record
+     */
+    @Override
+    public String toString() {
+        return "NotificationRecord[staff=" + staff.getName()
+                + ", action=" + action
+                + ", targetId=" + targetId
+                + ", timestamp=" + timestamp + "]";
+    }
+
 }

--- a/src/main/java/shelter/service/model/OverdueVaccination.java
+++ b/src/main/java/shelter/service/model/OverdueVaccination.java
@@ -3,12 +3,14 @@ package shelter.service.model;
 import shelter.domain.VaccineType;
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 /**
  * Represents a vaccination that is overdue for a specific animal.
  * Provides details about when the vaccine was last administered and when it was due.
+ * Results are naturally ordered by due date ascending, so the most overdue items appear first when sorted.
  */
-public class OverdueVaccination {
+public class OverdueVaccination implements Comparable<OverdueVaccination> {
 
     private final VaccineType vaccineType;
     private final LocalDate lastAdministered;
@@ -16,13 +18,21 @@ public class OverdueVaccination {
 
     /**
      * Constructs an OverdueVaccination with the given vaccine type, last administered date, and due date.
-     * {@code lastAdministered} may be null if the animal has never received this vaccine.
+     * {@code lastAdministered} may be null if the animal has never received this vaccine;
+     * {@code vaccineType} and {@code dueDate} must not be null.
      *
-     * @param vaccineType      the vaccine type that is overdue
+     * @param vaccineType      the vaccine type that is overdue; must not be null
      * @param lastAdministered the date the vaccine was last given, or null if never administered
-     * @param dueDate          the date by which the vaccine should have been administered
+     * @param dueDate          the date by which the vaccine should have been administered; must not be null
+     * @throws IllegalArgumentException if {@code vaccineType} or {@code dueDate} is null
      */
     public OverdueVaccination(VaccineType vaccineType, LocalDate lastAdministered, LocalDate dueDate) {
+        if (vaccineType == null) {
+            throw new IllegalArgumentException("Vaccine type must not be null.");
+        }
+        if (dueDate == null) {
+            throw new IllegalArgumentException("Due date must not be null.");
+        }
         this.vaccineType = vaccineType;
         this.lastAdministered = lastAdministered;
         this.dueDate = dueDate;
@@ -30,6 +40,7 @@ public class OverdueVaccination {
 
     /**
      * Returns the vaccine type that is overdue.
+     * Never null for a validly constructed record.
      *
      * @return the overdue vaccine type
      */
@@ -39,6 +50,7 @@ public class OverdueVaccination {
 
     /**
      * Returns the date the vaccine was last administered, or null if never given.
+     * A null value indicates the animal has never received this vaccine.
      *
      * @return the last administered date, or null
      */
@@ -48,10 +60,63 @@ public class OverdueVaccination {
 
     /**
      * Returns the date by which the vaccine should have been administered.
+     * Never null for a validly constructed record.
      *
      * @return the due date
      */
     public LocalDate getDueDate() {
         return dueDate;
+    }
+
+    /**
+     * Compares this overdue vaccination to another by due date ascending.
+     * Earlier due dates are ordered first, placing the most overdue items at the top of a sorted list.
+     *
+     * @param other the other OverdueVaccination to compare to
+     * @return a negative number if this due date is earlier, positive if later, zero if equal
+     */
+    @Override
+    public int compareTo(OverdueVaccination other) {
+        return this.dueDate.compareTo(other.dueDate);
+    }
+
+    /**
+     * Returns a string representation of this overdue vaccination including vaccine type, last administered date, and due date.
+     *
+     * @return a human-readable description of this overdue vaccination
+     */
+    @Override
+    public String toString() {
+        return "OverdueVaccination[vaccine=" + vaccineType.getName()
+                + ", lastAdministered=" + (lastAdministered != null ? lastAdministered : "never")
+                + ", dueDate=" + dueDate + "]";
+    }
+
+    /**
+     * Returns true if the given object is an OverdueVaccination with the same vaccine type, last administered date, and due date.
+     * Equality is value-based since overdue vaccination records have no unique ID.
+     *
+     * @param o the object to compare
+     * @return true if all fields are equal
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OverdueVaccination)) return false;
+        OverdueVaccination other = (OverdueVaccination) o;
+        return Objects.equals(vaccineType, other.vaccineType)
+                && Objects.equals(lastAdministered, other.lastAdministered)
+                && Objects.equals(dueDate, other.dueDate);
+    }
+
+    /**
+     * Returns a hash code based on vaccine type, last administered date, and due date.
+     * Consistent with {@link #equals(Object)}.
+     *
+     * @return the hash code
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(vaccineType, lastAdministered, dueDate);
     }
 }


### PR DESCRIPTION
## Summary
- Add `findById` to `AnimalService` and `ShelterService`
- Add `cancel` to `AdoptionService` (UC-05.4) and `dismiss` to `TransferService` (UC-06.4)
- Fix single-sentence Javadoc in matching and explanation service interfaces
- Add constructor validation, `toString`, `hashCode`/`equals`, `compareTo` to service model classes
- Add `role` field to `Staff` to support `StaffService.findByRole()`