### PR TITLE
feat: scaffold architecture layers and implement CSV repository

### DIFF
--- a/src/main/java/shelter/application/AdopterApplicationService.java
+++ b/src/main/java/shelter/application/AdopterApplicationService.java
@@ -1,0 +1,73 @@
+package shelter.application;
+
+import shelter.domain.Adopter;
+import shelter.domain.ActivityLevel;
+import shelter.domain.DailySchedule;
+import shelter.domain.LivingSpace;
+import shelter.domain.Species;
+
+import java.util.List;
+
+/**
+ * Application service for adopter management use cases.
+ * Orchestrates adopter registration, updates, and removals,
+ * ensuring that preferences are constructed correctly and audit logging is performed.
+ */
+public interface AdopterApplicationService {
+
+    /**
+     * Registers a new adopter with the given personal details and preferences.
+     * Preference fields ({@code preferredSpecies}, {@code preferredBreed}, {@code preferredActivityLevel})
+     * may be {@code null} to indicate no preference. Throws an exception if the adopter already exists.
+     *
+     * @param name                   the adopter's name; must not be null or blank
+     * @param livingSpace            the adopter's living space type; must not be null
+     * @param dailySchedule          the adopter's daily schedule; must not be null
+     * @param preferredSpecies       the preferred species, or {@code null} for no preference
+     * @param preferredBreed         the preferred breed, or {@code null} for no preference
+     * @param preferredActivityLevel the preferred activity level, or {@code null} for no preference
+     * @param minAge                 the minimum preferred animal age; must be non-negative
+     * @param maxAge                 the maximum preferred animal age; must be &gt;= {@code minAge}
+     * @return the newly created {@link Adopter}
+     */
+    Adopter registerAdopter(String name, LivingSpace livingSpace, DailySchedule dailySchedule,
+                             Species preferredSpecies, String preferredBreed,
+                             ActivityLevel preferredActivityLevel, int minAge, int maxAge);
+
+    /**
+     * Returns a list of all registered adopters in the system.
+     * Returns an empty list if no adopters have been registered.
+     *
+     * @return a list of all adopters
+     */
+    List<Adopter> listAdopters();
+
+    /**
+     * Updates an existing adopter's personal details and preferences with the provided values.
+     * Only non-null parameters are applied; omitted (null) fields retain their current values.
+     * Throws an exception if the adopter is not found.
+     *
+     * @param adopterId              the ID of the adopter to update; must not be null or blank
+     * @param name                   the new name, or {@code null} to keep the current value
+     * @param livingSpace            the new living space, or {@code null} to keep the current value
+     * @param dailySchedule          the new daily schedule, or {@code null} to keep the current value
+     * @param preferredSpecies       the new preferred species, or {@code null} to keep the current value
+     * @param preferredBreed         the new preferred breed, or {@code null} to keep the current value
+     * @param preferredActivityLevel the new preferred activity level, or {@code null} to keep the current value
+     * @param minAge                 the new minimum preferred age, or {@code null} to keep the current value
+     * @param maxAge                 the new maximum preferred age, or {@code null} to keep the current value
+     * @return the updated {@link Adopter}
+     */
+    Adopter updateAdopter(String adopterId, String name, LivingSpace livingSpace,
+                          DailySchedule dailySchedule, Species preferredSpecies,
+                          String preferredBreed, ActivityLevel preferredActivityLevel,
+                          Integer minAge, Integer maxAge);
+
+    /**
+     * Removes an adopter from the system by ID.
+     * Throws an exception if the adopter is not found or has a pending adoption request.
+     *
+     * @param adopterId the ID of the adopter to remove; must not be null or blank
+     */
+    void removeAdopter(String adopterId);
+}

--- a/src/main/java/shelter/application/AdoptionApplicationService.java
+++ b/src/main/java/shelter/application/AdoptionApplicationService.java
@@ -1,0 +1,45 @@
+package shelter.application;
+
+import shelter.domain.AdoptionRequest;
+
+/**
+ * Application service for the adoption request lifecycle.
+ * Orchestrates validation, state transitions, notifications, and audit logging
+ * for each step of the adoption workflow (submit, approve, reject, cancel).
+ */
+public interface AdoptionApplicationService {
+
+    /**
+     * Submits a new adoption request on behalf of the given adopter for the given animal.
+     * Throws an exception if the adopter or animal is not found, or if the animal is not available.
+     *
+     * @param adopterId the ID of the adopter submitting the request; must not be null or blank
+     * @param animalId  the ID of the animal being requested; must not be null or blank
+     * @return the newly created {@link AdoptionRequest}
+     */
+    AdoptionRequest submitRequest(String adopterId, String animalId);
+
+    /**
+     * Approves a pending adoption request, marking the animal as adopted and notifying the adopter.
+     * Throws an exception if the request is not found or is not in a pending state.
+     *
+     * @param requestId the ID of the adoption request to approve; must not be null or blank
+     */
+    void approveRequest(String requestId);
+
+    /**
+     * Rejects a pending adoption request, leaving the animal available for other requests.
+     * Throws an exception if the request is not found or is not in a pending state.
+     *
+     * @param requestId the ID of the adoption request to reject; must not be null or blank
+     */
+    void rejectRequest(String requestId);
+
+    /**
+     * Cancels a pending adoption request before it has been reviewed.
+     * Throws an exception if the request is not found or is not in a pending state.
+     *
+     * @param requestId the ID of the adoption request to cancel; must not be null or blank
+     */
+    void cancelRequest(String requestId);
+}

--- a/src/main/java/shelter/application/AnimalApplicationService.java
+++ b/src/main/java/shelter/application/AnimalApplicationService.java
@@ -1,0 +1,62 @@
+package shelter.application;
+
+import shelter.domain.Animal;
+import shelter.domain.ActivityLevel;
+
+import java.util.List;
+
+/**
+ * Application service for animal management use cases.
+ * Orchestrates shelter capacity checks, animal registration, updates, and removals,
+ * ensuring audit logging is performed for every state-changing operation.
+ */
+public interface AnimalApplicationService {
+
+    /**
+     * Admits a new animal into the specified shelter.
+     * Throws an exception if the shelter is not found or is at full capacity.
+     *
+     * @param species       the species of the animal (e.g., "dog", "cat", "rabbit"); must not be null or blank
+     * @param name          the animal's name; must not be null or blank
+     * @param breed         the animal's breed; must not be null or blank
+     * @param age           the animal's age in years; must be non-negative
+     * @param activityLevel the animal's activity level; must not be null
+     * @param shelterId     the ID of the shelter to admit the animal into; must not be null or blank
+     * @return the newly created {@link Animal}
+     */
+    Animal admitAnimal(String species, String name, String breed, int age,
+                       ActivityLevel activityLevel, String shelterId);
+
+    /**
+     * Returns a list of animals, optionally filtered by shelter.
+     * If {@code shelterId} is {@code null}, all animals in the system are returned.
+     * Returns an empty list if no matching animals are found.
+     *
+     * @param shelterId the ID of the shelter to filter by, or {@code null} for all animals
+     * @return a list of animals matching the filter
+     */
+    List<Animal> listAnimals(String shelterId);
+
+    /**
+     * Updates an existing animal's information with the provided values.
+     * Only non-null parameters are applied; omitted (null) fields retain their current values.
+     * Throws an exception if the animal is not found.
+     *
+     * @param animalId      the ID of the animal to update; must not be null or blank
+     * @param name          the new name, or {@code null} to keep the current value
+     * @param breed         the new breed, or {@code null} to keep the current value
+     * @param age           the new age, or {@code null} to keep the current value
+     * @param activityLevel the new activity level, or {@code null} to keep the current value
+     * @return the updated {@link Animal}
+     */
+    Animal updateAnimal(String animalId, String name, String breed,
+                        Integer age, ActivityLevel activityLevel);
+
+    /**
+     * Removes an animal from the system by ID.
+     * Throws an exception if the animal is not found or has a pending adoption request.
+     *
+     * @param animalId the ID of the animal to remove; must not be null or blank
+     */
+    void removeAnimal(String animalId);
+}

--- a/src/main/java/shelter/application/AuditApplicationService.java
+++ b/src/main/java/shelter/application/AuditApplicationService.java
@@ -1,0 +1,22 @@
+package shelter.application;
+
+import shelter.service.model.AuditEntry;
+
+import java.util.List;
+
+/**
+ * Application service for retrieving the session audit log.
+ * Provides access to the full history of staff actions performed during the current session,
+ * delegating directly to the underlying {@code AuditService}.
+ */
+public interface AuditApplicationService {
+
+    /**
+     * Returns the full audit log for the current session.
+     * Each entry records who performed an action, what was affected, and when it occurred.
+     * Returns an empty list if no actions have been logged in this session.
+     *
+     * @return a list of {@link AuditEntry} records in chronological order
+     */
+    List<AuditEntry<?>> getLog();
+}

--- a/src/main/java/shelter/application/MatchingApplicationService.java
+++ b/src/main/java/shelter/application/MatchingApplicationService.java
@@ -1,0 +1,39 @@
+package shelter.application;
+
+import shelter.service.model.MatchResult;
+
+import java.util.List;
+
+/**
+ * Application service for animal-adopter matching use cases.
+ * Orchestrates scoring across all active matching strategies and optionally
+ * invokes the explanation service to produce natural-language summaries.
+ */
+public interface MatchingApplicationService {
+
+    /**
+     * Finds and ranks available animals in the given shelter for the specified adopter.
+     * Only animals whose {@code adopterId} is null are considered.
+     * If {@code withExplanation} is true, each result is supplemented with a natural-language explanation.
+     * Returns an empty list if no available animals are found.
+     *
+     * @param adopterId       the ID of the adopter to match for; must not be null or blank
+     * @param shelterId       the ID of the shelter to search in; must not be null or blank
+     * @param withExplanation if true, explanation text is generated for each result
+     * @return a ranked list of {@link MatchResult} instances, best match first
+     */
+    List<MatchResult> matchAnimalsForAdopter(String adopterId, String shelterId,
+                                              boolean withExplanation);
+
+    /**
+     * Finds and ranks all registered adopters by compatibility with the given available animal.
+     * Throws an exception if the animal is not found or has already been adopted.
+     * If {@code withExplanation} is true, each result is supplemented with a natural-language explanation.
+     * Returns an empty list if no adopters are registered.
+     *
+     * @param animalId        the ID of the animal to match for; must not be null or blank
+     * @param withExplanation if true, explanation text is generated for each result
+     * @return a ranked list of {@link MatchResult} instances, best match first
+     */
+    List<MatchResult> matchAdoptersForAnimal(String animalId, boolean withExplanation);
+}

--- a/src/main/java/shelter/application/ShelterApplicationService.java
+++ b/src/main/java/shelter/application/ShelterApplicationService.java
@@ -1,0 +1,53 @@
+package shelter.application;
+
+import shelter.domain.Shelter;
+
+import java.util.List;
+
+/**
+ * Application service for shelter management use cases.
+ * Orchestrates underlying service calls to register, update, remove, and list shelters,
+ * ensuring audit logging and consistency across operations.
+ */
+public interface ShelterApplicationService {
+
+    /**
+     * Registers a new shelter with the given name, location, and capacity.
+     * Throws an exception if a shelter with the same name and location already exists.
+     *
+     * @param name     the shelter name; must not be null or blank
+     * @param location the shelter location; must not be null or blank
+     * @param capacity the maximum number of animals the shelter can hold; must be positive
+     * @return the newly created {@link Shelter}
+     */
+    Shelter registerShelter(String name, String location, int capacity);
+
+    /**
+     * Returns a list of all registered shelters in the system.
+     * Returns an empty list if no shelters have been registered.
+     *
+     * @return a list of all shelters
+     */
+    List<Shelter> listShelters();
+
+    /**
+     * Updates an existing shelter's information with the provided values.
+     * Only non-null parameters are applied; omitted (null) fields retain their current values.
+     * Throws an exception if the shelter is not found.
+     *
+     * @param shelterId the ID of the shelter to update; must not be null or blank
+     * @param name      the new name, or {@code null} to keep the current value
+     * @param location  the new location, or {@code null} to keep the current value
+     * @param capacity  the new capacity, or {@code null} to keep the current value
+     * @return the updated {@link Shelter}
+     */
+    Shelter updateShelter(String shelterId, String name, String location, Integer capacity);
+
+    /**
+     * Removes a shelter from the system by ID.
+     * Throws an exception if the shelter is not found, still holds animals, or has pending transfer requests.
+     *
+     * @param shelterId the ID of the shelter to remove; must not be null or blank
+     */
+    void removeShelter(String shelterId);
+}

--- a/src/main/java/shelter/application/SystemStartup.java
+++ b/src/main/java/shelter/application/SystemStartup.java
@@ -1,0 +1,16 @@
+package shelter.application;
+
+/**
+ * Handles system initialization at startup, loading all persisted data and setting up session state.
+ * Implementations are responsible for reading data from the persistent store and establishing
+ * the hardcoded admin staff member as the current session operator.
+ */
+public interface SystemStartup {
+
+    /**
+     * Initializes the system by loading all persisted data from the data directory.
+     * If no data files exist, the system starts with empty state.
+     * After this method returns, all services are ready to accept requests for the current session.
+     */
+    void initialize();
+}

--- a/src/main/java/shelter/application/TransferApplicationService.java
+++ b/src/main/java/shelter/application/TransferApplicationService.java
@@ -1,0 +1,47 @@
+package shelter.application;
+
+import shelter.domain.TransferRequest;
+
+/**
+ * Application service for the inter-shelter transfer request lifecycle.
+ * Orchestrates availability checks, capacity validation, notifications, and audit logging
+ * for each step of the transfer workflow (request, approve, reject, cancel).
+ */
+public interface TransferApplicationService {
+
+    /**
+     * Initiates a transfer request to move an available animal from one shelter to another.
+     * Throws an exception if the animal is not found in the source shelter, is not available,
+     * or if the destination shelter is at capacity.
+     *
+     * @param animalId      the ID of the animal to transfer; must not be null or blank
+     * @param fromShelterId the ID of the source shelter; must not be null or blank
+     * @param toShelterId   the ID of the destination shelter; must not be null or blank
+     * @return the newly created {@link TransferRequest}
+     */
+    TransferRequest requestTransfer(String animalId, String fromShelterId, String toShelterId);
+
+    /**
+     * Approves a pending transfer request and moves the animal to the destination shelter.
+     * Throws an exception if the request is not found or is not in a pending state.
+     *
+     * @param requestId the ID of the transfer request to approve; must not be null or blank
+     */
+    void approveTransfer(String requestId);
+
+    /**
+     * Rejects a pending transfer request, leaving the animal in the source shelter.
+     * Throws an exception if the request is not found or is not in a pending state.
+     *
+     * @param requestId the ID of the transfer request to reject; must not be null or blank
+     */
+    void rejectTransfer(String requestId);
+
+    /**
+     * Cancels a pending transfer request that has not yet been reviewed.
+     * Throws an exception if the request is not found or is not in a pending state.
+     *
+     * @param requestId the ID of the transfer request to cancel; must not be null or blank
+     */
+    void cancelTransfer(String requestId);
+}

--- a/src/main/java/shelter/application/VaccinationApplicationService.java
+++ b/src/main/java/shelter/application/VaccinationApplicationService.java
@@ -1,0 +1,77 @@
+package shelter.application;
+
+import shelter.domain.Species;
+import shelter.domain.VaccineType;
+import shelter.service.model.OverdueVaccination;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Application service for vaccination and vaccine type management use cases.
+ * Orchestrates vaccine catalog lookups, record creation, overdue checks,
+ * and audit logging for all vaccination-related operations.
+ */
+public interface VaccinationApplicationService {
+
+    /**
+     * Records that an animal received a specific vaccine on the given date.
+     * Throws an exception if the animal is not found, the vaccine type name is not in the catalog,
+     * or the vaccine is not applicable to the animal's species.
+     *
+     * @param animalId        the ID of the animal that was vaccinated; must not be null or blank
+     * @param vaccineTypeName the name of the vaccine type administered; must not be null or blank
+     * @param date            the date the vaccine was administered; must not be null
+     */
+    void recordVaccination(String animalId, String vaccineTypeName, LocalDate date);
+
+    /**
+     * Returns a list of vaccinations that are overdue for the given animal.
+     * Throws an exception if the animal is not found.
+     * Returns an empty list if all required vaccines are current.
+     *
+     * @param animalId the ID of the animal to check; must not be null or blank
+     * @return a list of {@link OverdueVaccination} records, ordered by due date ascending
+     */
+    List<OverdueVaccination> getOverdueVaccinations(String animalId);
+
+    /**
+     * Adds a new vaccine type to the catalog with the given name, applicable species, and validity period.
+     * Throws an exception if a vaccine type with the same name already exists.
+     *
+     * @param name              the vaccine type name (e.g., "Rabies"); must not be null or blank
+     * @param applicableSpecies the species the vaccine applies to (e.g., "Dog"); must not be null or blank
+     * @param validityDays      the number of days the vaccine remains valid; must be positive
+     * @return the newly created {@link VaccineType}
+     */
+    VaccineType addVaccineType(String name, Species applicableSpecies, int validityDays);
+
+    /**
+     * Updates an existing vaccine type's fields by ID.
+     * Only non-null parameters are applied; omitted (null) fields retain their current values.
+     * Throws an exception if the vaccine type is not found or if the new name conflicts with an existing one.
+     *
+     * @param id                the ID of the vaccine type to update; must not be null or blank
+     * @param name              the new name, or {@code null} to keep the current value
+     * @param applicableSpecies the new applicable species, or {@code null} to keep the current value
+     * @param validityDays      the new validity period in days, or {@code null} to keep the current value
+     * @return the updated {@link VaccineType}
+     */
+    VaccineType updateVaccineType(String id, String name, Species applicableSpecies, Integer validityDays);
+
+    /**
+     * Removes a vaccine type from the catalog by ID.
+     * Throws an exception if the vaccine type is not found.
+     *
+     * @param id the ID of the vaccine type to remove; must not be null or blank
+     */
+    void removeVaccineType(String id);
+
+    /**
+     * Returns a list of all vaccine types currently in the catalog.
+     * Returns an empty list if no vaccine types have been added.
+     *
+     * @return a list of all {@link VaccineType} entries
+     */
+    List<VaccineType> listVaccineTypes();
+}

--- a/src/main/java/shelter/domain/Adopter.java
+++ b/src/main/java/shelter/domain/Adopter.java
@@ -21,6 +21,46 @@ public class Adopter {
     private final List<String> adoptedAnimalIds;
 
     /**
+     * Reconstruction constructor for deserializing an Adopter from persistent storage.
+     * This constructor accepts an explicit {@code id} and a pre-populated list of adopted
+     * animal IDs so that the full adopter state can be restored from CSV data.
+     *
+     * @param id               the pre-existing unique identifier; must not be null or blank
+     * @param name             the adopter's full name; must not be null or blank
+     * @param livingSpace      the adopter's living space type; must not be null
+     * @param dailySchedule    the adopter's typical daily schedule; must not be null
+     * @param personalNotes    any additional context provided by the adopter; may be null
+     * @param preferences      the adopter's adoption preferences; must not be null
+     * @param adoptedAnimalIds the list of animal IDs this adopter has previously adopted; may be empty
+     * @throws IllegalArgumentException if any required parameter is null or {@code name} is blank
+     */
+    public Adopter(String id, String name, LivingSpace livingSpace, DailySchedule dailySchedule,
+                   String personalNotes, AdopterPreferences preferences, List<String> adoptedAnimalIds) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Adopter ID must not be null or blank.");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Adopter name must not be null or blank.");
+        }
+        if (livingSpace == null) {
+            throw new IllegalArgumentException("Living space must not be null.");
+        }
+        if (dailySchedule == null) {
+            throw new IllegalArgumentException("Daily schedule must not be null.");
+        }
+        if (preferences == null) {
+            throw new IllegalArgumentException("Adopter preferences must not be null.");
+        }
+        this.id = id;
+        this.name = name;
+        this.livingSpace = livingSpace;
+        this.dailySchedule = dailySchedule;
+        this.personalNotes = personalNotes;
+        this.preferences = preferences;
+        this.adoptedAnimalIds = new ArrayList<>(adoptedAnimalIds != null ? adoptedAnimalIds : Collections.emptyList());
+    }
+
+    /**
      * Constructs a new Adopter with the given personal information and preferences.
      * {@code name}, {@code livingSpace}, {@code dailySchedule}, and {@code preferences} are
      * required; {@code personalNotes} may be {@code null} if the adopter provides no extra context.

--- a/src/main/java/shelter/domain/AdopterPreferences.java
+++ b/src/main/java/shelter/domain/AdopterPreferences.java
@@ -8,7 +8,7 @@ package shelter.domain;
  */
 public class AdopterPreferences {
 
-    private final String preferredSpecies;
+    private final Species preferredSpecies;
     private final String preferredBreed;
     private final ActivityLevel preferredActivityLevel;
     private final int minAge;
@@ -19,14 +19,14 @@ public class AdopterPreferences {
      * {@code preferredSpecies}, {@code preferredBreed}, and {@code preferredActivityLevel}
      * may be {@code null} to express no preference; age bounds must be valid.
      *
-     * @param preferredSpecies        the desired species name (e.g., "Dog"), or {@code null}
+     * @param preferredSpecies        the desired {@link Species}, or {@code null} for no preference
      * @param preferredBreed          the desired breed, or {@code null} for no preference
      * @param preferredActivityLevel  the desired activity level, or {@code null} for no preference
      * @param minAge                  the minimum preferred age in years; must be non-negative
      * @param maxAge                  the maximum preferred age in years; must be &gt;= {@code minAge}
      * @throws IllegalArgumentException if {@code minAge} is negative or {@code maxAge} &lt; {@code minAge}
      */
-    public AdopterPreferences(String preferredSpecies, String preferredBreed,
+    public AdopterPreferences(Species preferredSpecies, String preferredBreed,
                                ActivityLevel preferredActivityLevel, int minAge, int maxAge) {
         if (minAge < 0) {
             throw new IllegalArgumentException("Minimum age must be non-negative.");
@@ -45,9 +45,9 @@ public class AdopterPreferences {
     /**
      * Returns the preferred species, or {@code null} if no species preference was set.
      *
-     * @return the preferred species name, or {@code null}
+     * @return the preferred {@link Species}, or {@code null}
      */
-    public String getPreferredSpecies() {
+    public Species getPreferredSpecies() {
         return preferredSpecies;
     }
 

--- a/src/main/java/shelter/domain/AdoptionRequest.java
+++ b/src/main/java/shelter/domain/AdoptionRequest.java
@@ -18,6 +18,42 @@ public class AdoptionRequest {
     private RequestStatus status;
 
     /**
+     * Reconstruction constructor for deserializing an AdoptionRequest from persistent storage.
+     * This constructor accepts an explicit {@code id}, pre-existing status, and submission timestamp
+     * so that the full request state can be restored from CSV data without modification.
+     *
+     * @param id          the pre-existing unique identifier; must not be null or blank
+     * @param adopter     the adopter who submitted the request; must not be null
+     * @param animal      the animal the adopter wishes to adopt; must not be null
+     * @param status      the current status of the request; must not be null
+     * @param submittedAt the original timestamp when the request was submitted; must not be null
+     * @throws IllegalArgumentException if any parameter is null or {@code id} is blank
+     */
+    public AdoptionRequest(String id, Adopter adopter, Animal animal,
+                           RequestStatus status, LocalDateTime submittedAt) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("AdoptionRequest ID must not be null or blank.");
+        }
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("Status must not be null.");
+        }
+        if (submittedAt == null) {
+            throw new IllegalArgumentException("SubmittedAt must not be null.");
+        }
+        this.id = id;
+        this.adopter = adopter;
+        this.animal = animal;
+        this.status = status;
+        this.submittedAt = submittedAt;
+    }
+
+    /**
      * Constructs a new AdoptionRequest in {@link RequestStatus#PENDING} status.
      * Both adopter and animal are required and must not be null.
      *

--- a/src/main/java/shelter/domain/Animal.java
+++ b/src/main/java/shelter/domain/Animal.java
@@ -19,6 +19,49 @@ public abstract class Animal {
     private String shelterId;
 
     /**
+     * Reconstruction constructor for deserializing an Animal from persistent storage.
+     * This constructor accepts an explicit {@code id} so that the original identifier
+     * is preserved when reloading from CSV or other external sources.
+     *
+     * @param id            the pre-existing unique identifier; must not be null or blank
+     * @param name          the animal's name; must not be null or blank
+     * @param breed         the animal's breed; must not be null or blank
+     * @param age           the animal's age in years; must be non-negative
+     * @param activityLevel the animal's activity level; must not be null
+     * @param vaccinated    whether the animal has been vaccinated
+     * @param adopterId     the ID of the adopter who adopted this animal, or {@code null} if available
+     * @param shelterId     the ID of the shelter this animal belongs to, or {@code null} if unassigned
+     * @throws IllegalArgumentException if any required parameter is null, blank, or invalid
+     */
+    protected Animal(String id, String name, String breed, int age,
+                     ActivityLevel activityLevel, boolean vaccinated,
+                     String adopterId, String shelterId) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Animal ID must not be null or blank.");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Animal name must not be null or blank.");
+        }
+        if (breed == null || breed.isBlank()) {
+            throw new IllegalArgumentException("Animal breed must not be null or blank.");
+        }
+        if (age < 0) {
+            throw new IllegalArgumentException("Animal age must be non-negative.");
+        }
+        if (activityLevel == null) {
+            throw new IllegalArgumentException("Activity level must not be null.");
+        }
+        this.id = id;
+        this.name = name;
+        this.breed = breed;
+        this.age = age;
+        this.activityLevel = activityLevel;
+        this.vaccinated = vaccinated;
+        this.adopterId = adopterId;
+        this.shelterId = shelterId;
+    }
+
+    /**
      * Constructs a new Animal with the given core attributes.
      * All parameters are required and validated; age must be non-negative.
      * The animal is initialized as available for adoption ({@code adopterId} is null).

--- a/src/main/java/shelter/domain/Animal.java
+++ b/src/main/java/shelter/domain/Animal.java
@@ -16,6 +16,7 @@ public abstract class Animal {
     private final ActivityLevel activityLevel;
     private boolean vaccinated;
     private String adopterId;
+    private String shelterId;
 
     /**
      * Constructs a new Animal with the given core attributes.
@@ -53,12 +54,12 @@ public abstract class Animal {
     }
 
     /**
-     * Returns the species name of this animal (e.g., "Dog", "Cat", "Rabbit").
-     * Each concrete subclass must provide its own immutable species identifier.
+     * Returns the species of this animal.
+     * Each concrete subclass must return its own immutable {@link Species} constant.
      *
-     * @return the species name as a non-null, non-blank string
+     * @return the {@link Species} of this animal
      */
-    public abstract String getSpecies();
+    public abstract Species getSpecies();
 
     /**
      * Returns the unique identifier of this animal.
@@ -142,6 +143,30 @@ public abstract class Animal {
      */
     public String getAdopterId() {
         return adopterId;
+    }
+
+    /**
+     * Returns the ID of the shelter this animal currently belongs to, or {@code null} if unassigned.
+     * This field is the persistent reference used to associate an animal with its shelter.
+     *
+     * @return the shelter's ID string, or {@code null}
+     */
+    public String getShelterId() {
+        return shelterId;
+    }
+
+    /**
+     * Assigns this animal to the shelter with the given ID.
+     * Typically called by {@code AnimalService} when an animal is admitted or transferred.
+     *
+     * @param shelterId the ID of the shelter; must not be null or blank
+     * @throws IllegalArgumentException if {@code shelterId} is null or blank
+     */
+    public void setShelterId(String shelterId) {
+        if (shelterId == null || shelterId.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        this.shelterId = shelterId;
     }
 
     /**

--- a/src/main/java/shelter/domain/Cat.java
+++ b/src/main/java/shelter/domain/Cat.java
@@ -11,6 +11,30 @@ public class Cat extends Animal {
     private boolean neutered;
 
     /**
+     * Reconstruction constructor for deserializing a Cat from persistent storage.
+     * This constructor preserves the original {@code id} and all fields including
+     * the indoor flag and neutered status, allowing exact round-trip restore from CSV data.
+     *
+     * @param id            the pre-existing unique identifier; must not be null or blank
+     * @param name          the cat's name; must not be null or blank
+     * @param breed         the cat's breed; must not be null or blank
+     * @param age           the cat's age in years; must be non-negative
+     * @param activityLevel the cat's activity level; must not be null
+     * @param vaccinated    whether the cat has been vaccinated
+     * @param adopterId     the ID of the adopter, or {@code null} if not adopted
+     * @param shelterId     the ID of the shelter, or {@code null} if unassigned
+     * @param indoor        whether the cat is suited for indoor-only living
+     * @param neutered      whether the cat has been neutered
+     * @throws IllegalArgumentException if any {@link Animal} parameter is invalid
+     */
+    public Cat(String id, String name, String breed, int age, ActivityLevel activityLevel,
+               boolean vaccinated, String adopterId, String shelterId, boolean indoor, boolean neutered) {
+        super(id, name, breed, age, activityLevel, vaccinated, adopterId, shelterId);
+        this.indoor = indoor;
+        this.neutered = neutered;
+    }
+
+    /**
      * Constructs a new Cat with the given attributes.
      * All parameters are validated at construction time per {@link Animal} rules.
      *

--- a/src/main/java/shelter/domain/Cat.java
+++ b/src/main/java/shelter/domain/Cat.java
@@ -34,8 +34,8 @@ public class Cat extends Animal {
      * {@inheritDoc}
      */
     @Override
-    public String getSpecies() {
-        return "Cat";
+    public Species getSpecies() {
+        return Species.CAT;
     }
 
     /**

--- a/src/main/java/shelter/domain/Dog.java
+++ b/src/main/java/shelter/domain/Dog.java
@@ -51,8 +51,8 @@ public class Dog extends Animal {
      * {@inheritDoc}
      */
     @Override
-    public String getSpecies() {
-        return "Dog";
+    public Species getSpecies() {
+        return Species.DOG;
     }
 
     /**

--- a/src/main/java/shelter/domain/Dog.java
+++ b/src/main/java/shelter/domain/Dog.java
@@ -25,6 +25,33 @@ public class Dog extends Animal {
     private boolean neutered;
 
     /**
+     * Reconstruction constructor for deserializing a Dog from persistent storage.
+     * This constructor preserves the original {@code id} and all fields including
+     * species-specific attributes, allowing exact round-trip restore from CSV data.
+     *
+     * @param id            the pre-existing unique identifier; must not be null or blank
+     * @param name          the dog's name; must not be null or blank
+     * @param breed         the dog's breed; must not be null or blank
+     * @param age           the dog's age in years; must be non-negative
+     * @param activityLevel the dog's activity level; must not be null
+     * @param vaccinated    whether the dog has been vaccinated
+     * @param adopterId     the ID of the adopter, or {@code null} if not adopted
+     * @param shelterId     the ID of the shelter, or {@code null} if unassigned
+     * @param size          the dog's size classification; must not be null
+     * @param neutered      whether the dog has been neutered
+     * @throws IllegalArgumentException if size is null or any {@link Animal} parameter is invalid
+     */
+    public Dog(String id, String name, String breed, int age, ActivityLevel activityLevel,
+               boolean vaccinated, String adopterId, String shelterId, Size size, boolean neutered) {
+        super(id, name, breed, age, activityLevel, vaccinated, adopterId, shelterId);
+        if (size == null) {
+            throw new IllegalArgumentException("Dog size must not be null.");
+        }
+        this.size = size;
+        this.neutered = neutered;
+    }
+
+    /**
      * Constructs a new Dog with the given attributes.
      * All parameters are required and validated at construction time.
      *

--- a/src/main/java/shelter/domain/Rabbit.java
+++ b/src/main/java/shelter/domain/Rabbit.java
@@ -46,8 +46,8 @@ public class Rabbit extends Animal {
      * {@inheritDoc}
      */
     @Override
-    public String getSpecies() {
-        return "Rabbit";
+    public Species getSpecies() {
+        return Species.RABBIT;
     }
 
     /**

--- a/src/main/java/shelter/domain/Rabbit.java
+++ b/src/main/java/shelter/domain/Rabbit.java
@@ -22,6 +22,31 @@ public class Rabbit extends Animal {
     private final FurLength furLength;
 
     /**
+     * Reconstruction constructor for deserializing a Rabbit from persistent storage.
+     * This constructor preserves the original {@code id} and all fields including
+     * the fur length, allowing exact round-trip restore from CSV data.
+     *
+     * @param id            the pre-existing unique identifier; must not be null or blank
+     * @param name          the rabbit's name; must not be null or blank
+     * @param breed         the rabbit's breed; must not be null or blank
+     * @param age           the rabbit's age in years; must be non-negative
+     * @param activityLevel the rabbit's activity level; must not be null
+     * @param vaccinated    whether the rabbit has been vaccinated
+     * @param adopterId     the ID of the adopter, or {@code null} if not adopted
+     * @param shelterId     the ID of the shelter, or {@code null} if unassigned
+     * @param furLength     the rabbit's fur length; must not be null
+     * @throws IllegalArgumentException if furLength is null or any {@link Animal} parameter is invalid
+     */
+    public Rabbit(String id, String name, String breed, int age, ActivityLevel activityLevel,
+                  boolean vaccinated, String adopterId, String shelterId, FurLength furLength) {
+        super(id, name, breed, age, activityLevel, vaccinated, adopterId, shelterId);
+        if (furLength == null) {
+            throw new IllegalArgumentException("Rabbit fur length must not be null.");
+        }
+        this.furLength = furLength;
+    }
+
+    /**
      * Constructs a new Rabbit with the given attributes.
      * All parameters are required and validated at construction time.
      *

--- a/src/main/java/shelter/domain/Shelter.java
+++ b/src/main/java/shelter/domain/Shelter.java
@@ -19,6 +19,37 @@ public class Shelter {
     private final List<Animal> animals;
 
     /**
+     * Reconstruction constructor for deserializing a Shelter from persistent storage.
+     * This constructor preserves the original {@code id} so that cross-references between
+     * animals and shelters remain consistent after a round-trip through CSV.
+     *
+     * @param id       the pre-existing unique identifier; must not be null or blank
+     * @param name     the shelter's name; must not be null or blank
+     * @param location the shelter's physical address or city; must not be null or blank
+     * @param capacity the maximum number of animals the shelter can hold; must be positive
+     * @throws IllegalArgumentException if any parameter is null, blank, or capacity is not positive
+     */
+    public Shelter(String id, String name, String location, int capacity) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Shelter name must not be null or blank.");
+        }
+        if (location == null || location.isBlank()) {
+            throw new IllegalArgumentException("Shelter location must not be null or blank.");
+        }
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Shelter capacity must be a positive integer.");
+        }
+        this.id = id;
+        this.name = name;
+        this.location = location;
+        this.capacity = capacity;
+        this.animals = new ArrayList<>();
+    }
+
+    /**
      * Constructs a new Shelter with the given name, location, and capacity.
      * Name and location must be non-null and non-blank; capacity must be a positive integer.
      *

--- a/src/main/java/shelter/domain/Species.java
+++ b/src/main/java/shelter/domain/Species.java
@@ -1,0 +1,21 @@
+package shelter.domain;
+
+/**
+ * Represents the species of an animal in the shelter system.
+ * Used to enforce type-safe species comparisons across matching, vaccination,
+ * and preference logic, replacing error-prone string literals.
+ */
+public enum Species {
+
+    /** A domestic dog. */
+    DOG,
+
+    /** A domestic cat. */
+    CAT,
+
+    /** A domestic rabbit. */
+    RABBIT,
+
+    /** Any other species not explicitly categorized. */
+    OTHER
+}

--- a/src/main/java/shelter/domain/TransferRequest.java
+++ b/src/main/java/shelter/domain/TransferRequest.java
@@ -19,6 +19,51 @@ public class TransferRequest {
     private RequestStatus status;
 
     /**
+     * Reconstruction constructor for deserializing a TransferRequest from persistent storage.
+     * This constructor accepts an explicit {@code id}, pre-existing status, and request timestamp
+     * so that the full transfer state can be restored from CSV data without modification.
+     *
+     * @param id          the pre-existing unique identifier; must not be null or blank
+     * @param animal      the animal to be transferred; must not be null
+     * @param from        the source shelter; must not be null
+     * @param to          the destination shelter; must not be null and must differ from {@code from}
+     * @param status      the current status of the request; must not be null
+     * @param requestedAt the original timestamp when the request was submitted; must not be null
+     * @throws IllegalArgumentException if any parameter is null, {@code id} is blank, or shelters
+     *                                  are the same
+     */
+    public TransferRequest(String id, Animal animal, Shelter from, Shelter to,
+                           RequestStatus status, LocalDateTime requestedAt) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("TransferRequest ID must not be null or blank.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+        if (from == null) {
+            throw new IllegalArgumentException("Source shelter must not be null.");
+        }
+        if (to == null) {
+            throw new IllegalArgumentException("Destination shelter must not be null.");
+        }
+        if (from.getId().equals(to.getId())) {
+            throw new IllegalArgumentException("Source and destination shelters must be different.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("Status must not be null.");
+        }
+        if (requestedAt == null) {
+            throw new IllegalArgumentException("RequestedAt must not be null.");
+        }
+        this.id = id;
+        this.animal = animal;
+        this.from = from;
+        this.to = to;
+        this.status = status;
+        this.requestedAt = requestedAt;
+    }
+
+    /**
      * Constructs a new TransferRequest in {@link RequestStatus#PENDING} status.
      * All parameters are required, and the source and destination shelters must differ.
      *

--- a/src/main/java/shelter/domain/VaccinationRecord.java
+++ b/src/main/java/shelter/domain/VaccinationRecord.java
@@ -16,6 +16,36 @@ public class VaccinationRecord {
     private final LocalDate dateAdministered;
 
     /**
+     * Reconstruction constructor for deserializing a VaccinationRecord from persistent storage.
+     * This constructor accepts an explicit {@code id} so the original record identifier is
+     * preserved when reloading vaccination history from CSV data.
+     *
+     * @param id               the pre-existing unique identifier; must not be null or blank
+     * @param animalId         the ID of the animal that received the vaccine; must not be null or blank
+     * @param vaccineTypeId    the ID of the vaccine type administered; must not be null or blank
+     * @param dateAdministered the date the vaccine was given; must not be null
+     * @throws IllegalArgumentException if any parameter is null or blank
+     */
+    public VaccinationRecord(String id, String animalId, String vaccineTypeId, LocalDate dateAdministered) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("VaccinationRecord ID must not be null or blank.");
+        }
+        if (animalId == null || animalId.isBlank()) {
+            throw new IllegalArgumentException("Animal ID must not be null or blank.");
+        }
+        if (vaccineTypeId == null || vaccineTypeId.isBlank()) {
+            throw new IllegalArgumentException("Vaccine type ID must not be null or blank.");
+        }
+        if (dateAdministered == null) {
+            throw new IllegalArgumentException("Date administered must not be null.");
+        }
+        this.id = id;
+        this.animalId = animalId;
+        this.vaccineTypeId = vaccineTypeId;
+        this.dateAdministered = dateAdministered;
+    }
+
+    /**
      * Constructs a new VaccinationRecord for the given animal, vaccine type, and date.
      * A unique ID is generated automatically at construction time.
      *

--- a/src/main/java/shelter/domain/VaccineType.java
+++ b/src/main/java/shelter/domain/VaccineType.java
@@ -15,6 +15,36 @@ public class VaccineType {
     private int validityDays;
 
     /**
+     * Reconstruction constructor for deserializing a VaccineType from persistent storage.
+     * This constructor accepts an explicit {@code id} so the original identifier is preserved
+     * when reloading the vaccine type catalog from CSV data.
+     *
+     * @param id                the pre-existing unique identifier; must not be null or blank
+     * @param name              the name of the vaccine (e.g., "Rabies", "FVRCP"); must not be null or blank
+     * @param applicableSpecies the species this vaccine applies to; must not be null
+     * @param validityDays      the number of days the vaccine remains valid; must be positive
+     * @throws IllegalArgumentException if any parameter is null, blank, or invalid
+     */
+    public VaccineType(String id, String name, Species applicableSpecies, int validityDays) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("VaccineType ID must not be null or blank.");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Vaccine type name must not be null or blank.");
+        }
+        if (applicableSpecies == null) {
+            throw new IllegalArgumentException("Applicable species must not be null.");
+        }
+        if (validityDays <= 0) {
+            throw new IllegalArgumentException("Validity days must be positive.");
+        }
+        this.id = id;
+        this.name = name;
+        this.applicableSpecies = applicableSpecies;
+        this.validityDays = validityDays;
+    }
+
+    /**
      * Constructs a new VaccineType with the given name, applicable species, and validity period.
      * A unique ID is generated automatically at construction time.
      *

--- a/src/main/java/shelter/domain/VaccineType.java
+++ b/src/main/java/shelter/domain/VaccineType.java
@@ -11,7 +11,7 @@ public class VaccineType {
 
     private final String id;
     private String name;
-    private String applicableSpecies;
+    private Species applicableSpecies;
     private int validityDays;
 
     /**
@@ -19,16 +19,16 @@ public class VaccineType {
      * A unique ID is generated automatically at construction time.
      *
      * @param name              the name of the vaccine (e.g., "Rabies", "FVRCP"); must not be null or blank
-     * @param applicableSpecies the species this vaccine applies to (e.g., "Dog", "Cat"); must not be null or blank
+     * @param applicableSpecies the species this vaccine applies to; must not be null
      * @param validityDays      the number of days the vaccine remains valid; must be positive
      * @throws IllegalArgumentException if any parameter is null, blank, or invalid
      */
-    public VaccineType(String name, String applicableSpecies, int validityDays) {
+    public VaccineType(String name, Species applicableSpecies, int validityDays) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("Vaccine type name must not be null or blank.");
         }
-        if (applicableSpecies == null || applicableSpecies.isBlank()) {
-            throw new IllegalArgumentException("Applicable species must not be null or blank.");
+        if (applicableSpecies == null) {
+            throw new IllegalArgumentException("Applicable species must not be null.");
         }
         if (validityDays <= 0) {
             throw new IllegalArgumentException("Validity days must be positive.");
@@ -75,21 +75,21 @@ public class VaccineType {
     /**
      * Returns the species this vaccine type applies to.
      *
-     * @return the applicable species name
+     * @return the applicable {@link Species}
      */
-    public String getApplicableSpecies() {
+    public Species getApplicableSpecies() {
         return applicableSpecies;
     }
 
     /**
      * Updates the applicable species of this vaccine type.
      *
-     * @param applicableSpecies the new applicable species; must not be null or blank
-     * @throws IllegalArgumentException if {@code applicableSpecies} is null or blank
+     * @param applicableSpecies the new applicable species; must not be null
+     * @throws IllegalArgumentException if {@code applicableSpecies} is null
      */
-    public void setApplicableSpecies(String applicableSpecies) {
-        if (applicableSpecies == null || applicableSpecies.isBlank()) {
-            throw new IllegalArgumentException("Applicable species must not be null or blank.");
+    public void setApplicableSpecies(Species applicableSpecies) {
+        if (applicableSpecies == null) {
+            throw new IllegalArgumentException("Applicable species must not be null.");
         }
         this.applicableSpecies = applicableSpecies;
     }

--- a/src/main/java/shelter/repository/AdopterRepository.java
+++ b/src/main/java/shelter/repository/AdopterRepository.java
@@ -1,0 +1,47 @@
+package shelter.repository;
+
+import shelter.domain.Adopter;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Defines persistence operations for {@link Adopter} records.
+ * Implementations are responsible for reading and writing adopter data to the underlying store,
+ * without exposing any storage details to the service layer.
+ */
+public interface AdopterRepository {
+
+    /**
+     * Persists a new adopter or overwrites the existing record with the same ID.
+     * Callers are responsible for ensuring the adopter is fully constructed before saving.
+     *
+     * @param adopter the adopter to save; must not be null
+     */
+    void save(Adopter adopter);
+
+    /**
+     * Returns the adopter with the given ID, or an empty optional if not found.
+     * Does not throw if the ID is absent — callers decide how to handle the missing case.
+     *
+     * @param id the unique identifier to look up; must not be null or blank
+     * @return an {@link Optional} containing the adopter, or empty if not found
+     */
+    Optional<Adopter> findById(String id);
+
+    /**
+     * Returns all adopters currently persisted in the store.
+     * Returns an empty list if no adopters have been saved.
+     *
+     * @return a list of all adopters
+     */
+    List<Adopter> findAll();
+
+    /**
+     * Removes the adopter record with the given ID from the store.
+     * Does nothing if no adopter with that ID exists.
+     *
+     * @param id the unique identifier of the adopter to delete; must not be null or blank
+     */
+    void delete(String id);
+}

--- a/src/main/java/shelter/repository/AdoptionRequestRepository.java
+++ b/src/main/java/shelter/repository/AdoptionRequestRepository.java
@@ -1,0 +1,105 @@
+package shelter.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import shelter.domain.AdoptionRequest;
+import shelter.domain.RequestStatus;
+
+/**
+ * Defines persistence operations for {@link AdoptionRequest} records.
+ * Implementations are responsible for reading and writing adoption request data
+ * to the underlying store, without exposing any storage details to the service
+ * layer.
+ */
+public interface AdoptionRequestRepository {
+
+    /**
+     * Persists a new adoption request or overwrites the existing record with
+     * the same ID. Callers are responsible for ensuring the request is fully
+     * constructed before saving.
+     *
+     * @param request the adoption request to save; must not be null
+     */
+    void save(AdoptionRequest request);
+
+    /**
+     * Returns the adoption request with the given ID, or an empty optional if
+     * not found. Does not throw if the ID is absent — callers decide how to
+     * handle the missing case.
+     *
+     * @param id the unique identifier to look up; must not be null or blank
+     * @return an {@link Optional} containing the request, or empty if not found
+     */
+    Optional<AdoptionRequest> findById(String id);
+
+    /**
+     * Returns all adoption requests currently persisted in the store. Returns
+     * an empty list if no requests have been saved.
+     *
+     * @return a list of all adoption requests
+     */
+    List<AdoptionRequest> findAll();
+
+    /**
+     * Returns all adoption requests associated with the given adopter ID.
+     * Returns an empty list if the adopter has no requests on record.
+     *
+     * @param adopterId the adopter ID to filter by; must not be null or blank
+     * @return a list of adoption requests for the specified adopter
+     */
+    List<AdoptionRequest> findByAdopterId(String adopterId);
+
+    /**
+     * Returns all adoption requests for animals currently housed in the given
+     * shelter. Shelter membership is determined by the animal's
+     * {@code shelterId} field. Returns an empty list if no requests exist for
+     * animals in that shelter.
+     *
+     * @param shelterId the shelter ID to filter by; must not be null or blank
+     * @return a list of adoption requests for animals in the specified shelter
+     */
+    List<AdoptionRequest> findByShelterId(String shelterId);
+
+    /**
+     * Returns all adoption requests with the given status. Returns an empty
+     * list if no requests match the given status.
+     *
+     * @param status the request status to filter by; must not be null
+     * @return a list of adoption requests with the specified status
+     */
+    List<AdoptionRequest> findByStatus(RequestStatus status);
+
+    /**
+     * Returns all adoption requests associated with the given adopter ID and
+     * status. Returns an empty list if no requests match the given criteria.
+     *
+     * @param adopterId the adopter ID to filter by; must not be null or blank
+     * @param status the request status to filter by; must not be null
+     * @return a list of adoption requests for the specified adopter with the
+     * specified status
+     */
+    List<AdoptionRequest> findByAdopterIdAndStatus(String adopterId, RequestStatus status);
+
+    /**
+     * Returns all adoption requests for animals in the given shelter that match
+     * the given status. Combines shelter and status filtering in one query to
+     * avoid secondary filtering in the service layer. Returns an empty list if
+     * no matching requests are found.
+     *
+     * @param shelterId the shelter ID to filter by; must not be null or blank
+     * @param status the request status to filter by; must not be null
+     * @return a list of adoption requests for the specified shelter with the
+     * specified status
+     */
+    List<AdoptionRequest> findByShelterIdAndStatus(String shelterId, RequestStatus status);
+
+    /**
+     * Removes the adoption request record with the given ID from the store.
+     * Does nothing if no request with that ID exists.
+     *
+     * @param id the unique identifier of the request to delete; must not be
+     * null or blank
+     */
+    void delete(String id);
+}

--- a/src/main/java/shelter/repository/AnimalRepository.java
+++ b/src/main/java/shelter/repository/AnimalRepository.java
@@ -1,0 +1,65 @@
+package shelter.repository;
+
+import shelter.domain.Animal;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Defines persistence operations for {@link Animal} records.
+ * Implementations are responsible for reading and writing animal data to the underlying store,
+ * without exposing any storage details to the service layer.
+ */
+public interface AnimalRepository {
+
+    /**
+     * Persists a new animal or overwrites the existing record with the same ID.
+     * Callers are responsible for ensuring the animal is fully constructed before saving.
+     *
+     * @param animal the animal to save; must not be null
+     */
+    void save(Animal animal);
+
+    /**
+     * Returns the animal with the given ID, or an empty optional if not found.
+     * Does not throw if the ID is absent — callers decide how to handle the missing case.
+     *
+     * @param id the unique identifier to look up; must not be null or blank
+     * @return an {@link Optional} containing the animal, or empty if not found
+     */
+    Optional<Animal> findById(String id);
+
+    /**
+     * Returns all animals currently persisted in the store.
+     * Returns an empty list if no animals have been saved.
+     *
+     * @return a list of all animals
+     */
+    List<Animal> findAll();
+
+    /**
+     * Returns all animals whose shelter ID matches the given value.
+     * Returns an empty list if no animals are associated with that shelter.
+     *
+     * @param shelterId the shelter ID to filter by; must not be null or blank
+     * @return a list of animals in the specified shelter
+     */
+    List<Animal> findByShelterId(String shelterId);
+
+    /**
+     * Returns all animals that have been adopted by the adopter with the given ID.
+     * Returns an empty list if the adopter has not adopted any animals.
+     *
+     * @param adopterId the adopter ID to filter by; must not be null or blank
+     * @return a list of animals adopted by the specified adopter
+     */
+    List<Animal> findByAdopterId(String adopterId);
+
+    /**
+     * Removes the animal record with the given ID from the store.
+     * Does nothing if no animal with that ID exists.
+     *
+     * @param id the unique identifier of the animal to delete; must not be null or blank
+     */
+    void delete(String id);
+}

--- a/src/main/java/shelter/repository/ShelterRepository.java
+++ b/src/main/java/shelter/repository/ShelterRepository.java
@@ -1,0 +1,47 @@
+package shelter.repository;
+
+import shelter.domain.Shelter;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Defines persistence operations for {@link Shelter} records.
+ * Implementations are responsible for reading and writing shelter data to the underlying store,
+ * without exposing any storage details to the service layer.
+ */
+public interface ShelterRepository {
+
+    /**
+     * Persists a new shelter or overwrites the existing record with the same ID.
+     * Callers are responsible for ensuring the shelter is fully constructed before saving.
+     *
+     * @param shelter the shelter to save; must not be null
+     */
+    void save(Shelter shelter);
+
+    /**
+     * Returns the shelter with the given ID, or an empty optional if not found.
+     * Does not throw if the ID is absent — callers decide how to handle the missing case.
+     *
+     * @param id the unique identifier to look up; must not be null or blank
+     * @return an {@link Optional} containing the shelter, or empty if not found
+     */
+    Optional<Shelter> findById(String id);
+
+    /**
+     * Returns all shelters currently persisted in the store.
+     * Returns an empty list if no shelters have been saved.
+     *
+     * @return a list of all shelters
+     */
+    List<Shelter> findAll();
+
+    /**
+     * Removes the shelter record with the given ID from the store.
+     * Does nothing if no shelter with that ID exists.
+     *
+     * @param id the unique identifier of the shelter to delete; must not be null or blank
+     */
+    void delete(String id);
+}

--- a/src/main/java/shelter/repository/TransferRequestRepository.java
+++ b/src/main/java/shelter/repository/TransferRequestRepository.java
@@ -1,0 +1,106 @@
+package shelter.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import shelter.domain.RequestStatus;
+import shelter.domain.TransferRequest;
+
+/**
+ * Defines persistence operations for {@link TransferRequest} records.
+ * Implementations are responsible for reading and writing transfer request data to the underlying store,
+ * without exposing any storage details to the service layer.
+ */
+public interface TransferRequestRepository {
+
+    /**
+     * Persists a new transfer request or overwrites the existing record with the same ID.
+     * Callers are responsible for ensuring the request is fully constructed before saving.
+     *
+     * @param request the transfer request to save; must not be null
+     */
+    void save(TransferRequest request);
+
+    /**
+     * Returns the transfer request with the given ID, or an empty optional if not found.
+     * Does not throw if the ID is absent — callers decide how to handle the missing case.
+     *
+     * @param id the unique identifier to look up; must not be null or blank
+     * @return an {@link Optional} containing the request, or empty if not found
+     */
+    Optional<TransferRequest> findById(String id);
+
+    /**
+     * Returns all transfer requests currently persisted in the store.
+     * Returns an empty list if no requests have been saved.
+     *
+     * @return a list of all transfer requests
+     */
+    List<TransferRequest> findAll();
+
+    /**
+     * Returns all transfer requests associated with the given animal ID.
+     * Returns an empty list if no requests exist for that animal.
+     *
+     * @param animalId the animal ID to filter by; must not be null or blank
+     * @return a list of transfer requests for the specified animal
+     */
+    List<TransferRequest> findByAnimalId(String animalId);
+
+    /**
+     * Returns all transfer requests originating from the given shelter ID.
+     * Returns an empty list if no requests originated from that shelter.
+     *
+     * @param shelterId the source shelter ID to filter by; must not be null or blank
+     * @return a list of transfer requests from the specified shelter
+     */
+    List<TransferRequest> findByFromShelterId(String shelterId);
+
+    /**
+     * Returns all transfer requests targeting the given shelter ID as the destination.
+     * Returns an empty list if no requests are destined for that shelter.
+     *
+     * @param shelterId the destination shelter ID to filter by; must not be null or blank
+     * @return a list of transfer requests targeting the specified shelter
+     */
+    List<TransferRequest> findByToShelterId(String shelterId);
+
+    /**
+     * Returns all transfer requests with the given status.
+     * Returns an empty list if no requests match the given status.
+     *
+     * @param status the request status to filter by; must not be null
+     * @return a list of transfer requests with the specified status
+     */
+    List<TransferRequest> findByStatus(RequestStatus status);
+
+    /**
+     * Returns all transfer requests involving the given shelter as either source or destination, with the given status.
+     * Combines shelter and status filtering in one query to avoid secondary filtering in the service layer.
+     * Returns an empty list if no matching requests are found.
+     *
+     * @param shelterId the shelter ID to filter by (matched against both source and destination); must not be null or blank
+     * @param status    the request status to filter by; must not be null
+     * @return a list of transfer requests involving the specified shelter with the specified status
+     */
+    List<TransferRequest> findByShelterIdAndStatus(String shelterId, RequestStatus status);
+
+    /**
+     * Returns all transfer requests for the given animal ID with the given status.
+     * Combines animal and status filtering in one query to avoid secondary filtering in the service layer.
+     * Returns an empty list if no matching requests are found.
+     *
+     * @param animalId the animal ID to filter by; must not be null or blank
+     * @param status   the request status to filter by; must not be null
+     * @return a list of transfer requests for the specified animal with the specified status
+     */
+    List<TransferRequest> findByAnimalIdAndStatus(String animalId, RequestStatus status);
+
+    /**
+     * Removes the transfer request record with the given ID from the store.
+     * Does nothing if no request with that ID exists.
+     *
+     * @param id the unique identifier of the request to delete; must not be null or blank
+     */
+    void delete(String id);
+}

--- a/src/main/java/shelter/repository/VaccinationRecordRepository.java
+++ b/src/main/java/shelter/repository/VaccinationRecordRepository.java
@@ -1,9 +1,9 @@
 package shelter.repository;
 
-import shelter.domain.VaccinationRecord;
-
 import java.util.List;
 import java.util.Optional;
+
+import shelter.domain.VaccinationRecord;
 
 /**
  * Defines persistence operations for {@link VaccinationRecord} records.
@@ -45,6 +45,15 @@ public interface VaccinationRecordRepository {
      * @return a list of all vaccination records
      */
     List<VaccinationRecord> findAll();
+
+    /**
+     * Returns all vaccination records for the given shelter ID.
+     * Returns an empty list if the shelter has no vaccination history.
+     *
+     * @param shelterId the shelter ID to filter by; must not be null or blank
+     * @return a list of vaccination records for the specified shelter
+     */
+    List<VaccinationRecord> findByShelterId(String shelterId);
 
     /**
      * Removes the vaccination record with the given ID from the store.

--- a/src/main/java/shelter/repository/VaccinationRecordRepository.java
+++ b/src/main/java/shelter/repository/VaccinationRecordRepository.java
@@ -1,0 +1,56 @@
+package shelter.repository;
+
+import shelter.domain.VaccinationRecord;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Defines persistence operations for {@link VaccinationRecord} records.
+ * Implementations are responsible for reading and writing vaccination history to the underlying store,
+ * without exposing any storage details to the service layer.
+ */
+public interface VaccinationRecordRepository {
+
+    /**
+     * Persists a new vaccination record or overwrites the existing record with the same ID.
+     * Callers are responsible for ensuring the record is fully constructed before saving.
+     *
+     * @param record the vaccination record to save; must not be null
+     */
+    void save(VaccinationRecord record);
+
+    /**
+     * Returns the vaccination record with the given ID, or an empty optional if not found.
+     * Does not throw if the ID is absent — callers decide how to handle the missing case.
+     *
+     * @param id the unique identifier to look up; must not be null or blank
+     * @return an {@link Optional} containing the record, or empty if not found
+     */
+    Optional<VaccinationRecord> findById(String id);
+
+    /**
+     * Returns all vaccination records for the given animal ID.
+     * Returns an empty list if the animal has no vaccination history.
+     *
+     * @param animalId the animal ID to filter by; must not be null or blank
+     * @return a list of vaccination records for the specified animal
+     */
+    List<VaccinationRecord> findByAnimalId(String animalId);
+
+    /**
+     * Returns all vaccination records currently persisted in the store.
+     * Returns an empty list if no records have been saved.
+     *
+     * @return a list of all vaccination records
+     */
+    List<VaccinationRecord> findAll();
+
+    /**
+     * Removes the vaccination record with the given ID from the store.
+     * Does nothing if no record with that ID exists.
+     *
+     * @param id the unique identifier of the record to delete; must not be null or blank
+     */
+    void delete(String id);
+}

--- a/src/main/java/shelter/repository/VaccineTypeRepository.java
+++ b/src/main/java/shelter/repository/VaccineTypeRepository.java
@@ -1,0 +1,66 @@
+package shelter.repository;
+
+import shelter.domain.Species;
+import shelter.domain.VaccineType;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Defines persistence operations for {@link VaccineType} records.
+ * Implementations are responsible for reading and writing vaccine type catalog data to the underlying store,
+ * without exposing any storage details to the service layer.
+ */
+public interface VaccineTypeRepository {
+
+    /**
+     * Persists a new vaccine type or overwrites the existing record with the same ID.
+     * Callers are responsible for ensuring the vaccine type is fully constructed before saving.
+     *
+     * @param vaccineType the vaccine type to save; must not be null
+     */
+    void save(VaccineType vaccineType);
+
+    /**
+     * Returns the vaccine type with the given ID, or an empty optional if not found.
+     * Does not throw if the ID is absent — callers decide how to handle the missing case.
+     *
+     * @param id the unique identifier to look up; must not be null or blank
+     * @return an {@link Optional} containing the vaccine type, or empty if not found
+     */
+    Optional<VaccineType> findById(String id);
+
+    /**
+     * Returns the vaccine type with the given name, or an empty optional if not found.
+     * Name matching is case-insensitive to prevent near-duplicate entries in the catalog.
+     *
+     * @param name the vaccine type name to look up; must not be null or blank
+     * @return an {@link Optional} containing the vaccine type, or empty if not found
+     */
+    Optional<VaccineType> findByName(String name);
+
+    /**
+     * Returns all vaccine types applicable to the given species.
+     * Returns an empty list if no vaccine types are defined for that species.
+     *
+     * @param species the {@link Species} to filter by; must not be null
+     * @return a list of vaccine types applicable to the specified species
+     */
+    List<VaccineType> findByApplicableSpecies(Species species);
+
+    /**
+     * Returns all vaccine types currently persisted in the store.
+     * Returns an empty list if the catalog is empty.
+     *
+     * @return a list of all vaccine types
+     */
+    List<VaccineType> findAll();
+
+    /**
+     * Removes the vaccine type record with the given ID from the store.
+     * Does nothing if no vaccine type with that ID exists.
+     *
+     * @param id the unique identifier of the vaccine type to delete; must not be null or blank
+     */
+    void delete(String id);
+}

--- a/src/main/java/shelter/repository/csv/CsvAdopterRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAdopterRepository.java
@@ -1,0 +1,196 @@
+package shelter.repository.csv;
+
+import shelter.domain.ActivityLevel;
+import shelter.domain.Adopter;
+import shelter.domain.AdopterPreferences;
+import shelter.domain.DailySchedule;
+import shelter.domain.LivingSpace;
+import shelter.domain.Species;
+import shelter.repository.AdopterRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CSV-backed implementation of {@link AdopterRepository} that persists adopter records to a flat
+ * file named {@code adopters.csv}.
+ * Records are loaded into an in-memory {@link LinkedHashMap} at construction time and written back
+ * to disk on every {@link #save(Adopter)} or {@link #delete(String)} call.
+ */
+public class CsvAdopterRepository implements AdopterRepository {
+
+    private static final String FILE_NAME = "adopters.csv";
+    private static final String HEADER =
+            "id,name,livingSpace,dailySchedule,personalNotes,"
+            + "preferredSpecies,preferredBreed,preferredActivityLevel,"
+            + "minAge,maxAge,adoptedAnimalIds";
+
+    private final Path filePath;
+    private final Map<String, Adopter> store;
+
+    /**
+     * Constructs a new CsvAdopterRepository that reads from and writes to the given data directory.
+     * If the CSV file does not yet exist it is created with just the header row; existing data
+     * is loaded into memory immediately upon construction.
+     *
+     * @param dataDir the path to the directory that contains (or will contain) the CSV file;
+     *                must not be null or blank
+     * @throws IllegalArgumentException if {@code dataDir} is null or blank
+     * @throws RuntimeException         if the directory cannot be created or the file cannot be read
+     */
+    public CsvAdopterRepository(String dataDir) {
+        if (dataDir == null || dataDir.isBlank()) {
+            throw new IllegalArgumentException("Data directory must not be null or blank.");
+        }
+        this.filePath = Paths.get(dataDir, FILE_NAME);
+        this.store = new LinkedHashMap<>();
+        initAndLoad();
+    }
+
+    /** Ensures the data directory and file exist, then loads all rows into memory. */
+    private void initAndLoad() {
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, HEADER + System.lineSeparator());
+            } else {
+                loadAll();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize CsvAdopterRepository: " + e.getMessage(), e);
+        }
+    }
+
+    /** Reads all CSV rows and reconstructs Adopter objects into the in-memory store. */
+    private void loadAll() {
+        try {
+            List<String> lines = Files.readAllLines(filePath);
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+                if (line.isEmpty()) continue;
+                try {
+                    Adopter a = parseLine(line);
+                    store.put(a.getId(), a);
+                } catch (Exception e) {
+                    System.err.println("Skipping malformed adopter CSV row " + i + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load adopters from CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a single CSV row into an Adopter using the reconstruction constructor.
+     * Fields are in order: id, name, livingSpace, dailySchedule, personalNotes,
+     * preferredSpecies, preferredBreed, preferredActivityLevel, minAge, maxAge, adoptedAnimalIds.
+     *
+     * @param line a non-empty CSV row
+     * @return the reconstructed {@link Adopter}
+     */
+    private Adopter parseLine(String line) {
+        String[] parts = CsvUtils.splitCsv(line);
+        String id              = CsvUtils.unescapeCsv(parts[0]);
+        String name            = CsvUtils.unescapeCsv(parts[1]);
+        LivingSpace living     = LivingSpace.valueOf(parts[2].trim());
+        DailySchedule schedule = DailySchedule.valueOf(parts[3].trim());
+        String notes           = CsvUtils.unescapeCsv(parts[4]);
+
+        String speciesRaw      = parts[5].trim();
+        Species prefSpecies    = speciesRaw.isEmpty() ? null : Species.valueOf(speciesRaw);
+        String prefBreed       = CsvUtils.unescapeCsv(parts[6]);
+
+        String actRaw          = parts[7].trim();
+        ActivityLevel prefAct  = actRaw.isEmpty() ? null : ActivityLevel.valueOf(actRaw);
+
+        int minAge             = Integer.parseInt(parts[8].trim());
+        int maxAge             = Integer.parseInt(parts[9].trim());
+
+        List<String> adoptedIds = CsvUtils.decodeList(CsvUtils.unescapeCsv(parts[10]));
+
+        AdopterPreferences prefs = new AdopterPreferences(prefSpecies, prefBreed, prefAct, minAge, maxAge);
+        return new Adopter(id, name, living, schedule, notes, prefs, adoptedIds);
+    }
+
+    /** Writes the entire in-memory store back to the CSV file. */
+    private void flush() {
+        try {
+            StringBuilder sb = new StringBuilder(HEADER).append(System.lineSeparator());
+            for (Adopter a : store.values()) {
+                AdopterPreferences p = a.getPreferences();
+                sb.append(CsvUtils.escapeCsv(a.getId())).append(',')
+                  .append(CsvUtils.escapeCsv(a.getName())).append(',')
+                  .append(a.getLivingSpace().name()).append(',')
+                  .append(a.getDailySchedule().name()).append(',')
+                  .append(CsvUtils.escapeCsv(a.getPersonalNotes())).append(',')
+                  .append(p.getPreferredSpecies() != null ? p.getPreferredSpecies().name() : "").append(',')
+                  .append(CsvUtils.escapeCsv(p.getPreferredBreed())).append(',')
+                  .append(p.getPreferredActivityLevel() != null ? p.getPreferredActivityLevel().name() : "").append(',')
+                  .append(p.getMinAge()).append(',')
+                  .append(p.getMaxAge()).append(',')
+                  .append(CsvUtils.escapeCsv(CsvUtils.encodeList(a.getAdoptedAnimalIds())))
+                  .append(System.lineSeparator());
+            }
+            Files.writeString(filePath, sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to flush adopters to CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code adopter} is null
+     */
+    @Override
+    public void save(Adopter adopter) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        store.put(adopter.getId(), adopter);
+        flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public Optional<Adopter> findById(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        return Optional.ofNullable(store.get(id));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Adopter> findAll() {
+        return Collections.unmodifiableList(new ArrayList<>(store.values()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public void delete(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        store.remove(id);
+        flush();
+    }
+}

--- a/src/main/java/shelter/repository/csv/CsvAdoptionRequestRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAdoptionRequestRepository.java
@@ -1,0 +1,302 @@
+package shelter.repository.csv;
+
+import shelter.domain.Adopter;
+import shelter.domain.AdoptionRequest;
+import shelter.domain.Animal;
+import shelter.domain.RequestStatus;
+import shelter.repository.AdopterRepository;
+import shelter.repository.AdoptionRequestRepository;
+import shelter.repository.AnimalRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CSV-backed implementation of {@link AdoptionRequestRepository} that persists adoption request
+ * records to a flat file named {@code adoption-requests.csv}.
+ * The repository requires injected {@link AnimalRepository} and {@link AdopterRepository} instances
+ * to reconstruct full object graphs when loading from CSV.
+ * Records are kept in memory and flushed to disk on every mutation.
+ */
+public class CsvAdoptionRequestRepository implements AdoptionRequestRepository {
+
+    private static final String FILE_NAME = "adoption-requests.csv";
+    private static final String HEADER = "id,adopterId,animalId,status,submittedAt";
+
+    private final Path filePath;
+    private final Map<String, AdoptionRequest> store;
+    private final AnimalRepository animalRepository;
+    private final AdopterRepository adopterRepository;
+
+    /**
+     * Constructs a new CsvAdoptionRequestRepository backed by the given data directory.
+     * The {@code animalRepository} and {@code adopterRepository} are used to resolve full objects
+     * when loading adoption requests from CSV rows.
+     * If the CSV file does not yet exist it is created with just the header row.
+     *
+     * @param dataDir           the path to the directory for the CSV file; must not be null or blank
+     * @param animalRepository  used to look up animals by ID during CSV deserialization; must not be null
+     * @param adopterRepository used to look up adopters by ID during CSV deserialization; must not be null
+     * @throws IllegalArgumentException if any parameter is null or {@code dataDir} is blank
+     * @throws RuntimeException         if the directory cannot be created or the file cannot be read
+     */
+    public CsvAdoptionRequestRepository(String dataDir,
+                                        AnimalRepository animalRepository,
+                                        AdopterRepository adopterRepository) {
+        if (dataDir == null || dataDir.isBlank()) {
+            throw new IllegalArgumentException("Data directory must not be null or blank.");
+        }
+        if (animalRepository == null) {
+            throw new IllegalArgumentException("AnimalRepository must not be null.");
+        }
+        if (adopterRepository == null) {
+            throw new IllegalArgumentException("AdopterRepository must not be null.");
+        }
+        this.filePath = Paths.get(dataDir, FILE_NAME);
+        this.store = new LinkedHashMap<>();
+        this.animalRepository = animalRepository;
+        this.adopterRepository = adopterRepository;
+        initAndLoad();
+    }
+
+    /** Ensures the data directory and file exist, then loads all rows into memory. */
+    private void initAndLoad() {
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, HEADER + System.lineSeparator());
+            } else {
+                loadAll();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize CsvAdoptionRequestRepository: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Reads all CSV rows and reconstructs AdoptionRequest objects into the in-memory store.
+     * Rows whose referenced animal or adopter cannot be found are skipped with a warning.
+     */
+    private void loadAll() {
+        try {
+            List<String> lines = Files.readAllLines(filePath);
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+                if (line.isEmpty()) continue;
+                try {
+                    AdoptionRequest req = parseLine(line);
+                    store.put(req.getId(), req);
+                } catch (Exception e) {
+                    System.err.println("Skipping malformed adoption-request CSV row " + i + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load adoption requests from CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a single CSV row and reconstructs a full {@link AdoptionRequest}.
+     * Fields are in order: id, adopterId, animalId, status, submittedAt.
+     *
+     * @param line a non-empty CSV row
+     * @return the reconstructed {@link AdoptionRequest}
+     * @throws IllegalStateException if the referenced adopter or animal is not found
+     */
+    private AdoptionRequest parseLine(String line) {
+        String[] parts = CsvUtils.splitCsv(line);
+        String id          = CsvUtils.unescapeCsv(parts[0]);
+        String adopterId   = CsvUtils.unescapeCsv(parts[1]);
+        String animalId    = CsvUtils.unescapeCsv(parts[2]);
+        RequestStatus status = RequestStatus.valueOf(parts[3].trim());
+        LocalDateTime submittedAt = LocalDateTime.parse(parts[4].trim());
+
+        Adopter adopter = adopterRepository.findById(adopterId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Adopter not found for adoption request: " + adopterId));
+        Animal animal = animalRepository.findById(animalId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Animal not found for adoption request: " + animalId));
+
+        return new AdoptionRequest(id, adopter, animal, status, submittedAt);
+    }
+
+    /** Writes the entire in-memory store back to the CSV file. */
+    private void flush() {
+        try {
+            StringBuilder sb = new StringBuilder(HEADER).append(System.lineSeparator());
+            for (AdoptionRequest req : store.values()) {
+                sb.append(CsvUtils.escapeCsv(req.getId())).append(',')
+                  .append(CsvUtils.escapeCsv(req.getAdopter().getId())).append(',')
+                  .append(CsvUtils.escapeCsv(req.getAnimal().getId())).append(',')
+                  .append(req.getStatus().name()).append(',')
+                  .append(req.getSubmittedAt().toString())
+                  .append(System.lineSeparator());
+            }
+            Files.writeString(filePath, sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to flush adoption requests to CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code request} is null
+     */
+    @Override
+    public void save(AdoptionRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("AdoptionRequest must not be null.");
+        }
+        store.put(request.getId(), request);
+        flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public Optional<AdoptionRequest> findById(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        return Optional.ofNullable(store.get(id));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<AdoptionRequest> findAll() {
+        return Collections.unmodifiableList(new ArrayList<>(store.values()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code adopterId} is null or blank
+     */
+    @Override
+    public List<AdoptionRequest> findByAdopterId(String adopterId) {
+        if (adopterId == null || adopterId.isBlank()) {
+            throw new IllegalArgumentException("Adopter ID must not be null or blank.");
+        }
+        List<AdoptionRequest> result = new ArrayList<>();
+        for (AdoptionRequest req : store.values()) {
+            if (adopterId.equals(req.getAdopter().getId())) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     * Shelter membership is determined by comparing the given {@code shelterId} to
+     * each request's {@code animal.getShelterId()}.
+     *
+     * @throws IllegalArgumentException if {@code shelterId} is null or blank
+     */
+    @Override
+    public List<AdoptionRequest> findByShelterId(String shelterId) {
+        if (shelterId == null || shelterId.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        List<AdoptionRequest> result = new ArrayList<>();
+        for (AdoptionRequest req : store.values()) {
+            if (shelterId.equals(req.getAnimal().getShelterId())) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code status} is null
+     */
+    @Override
+    public List<AdoptionRequest> findByStatus(RequestStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("Status must not be null.");
+        }
+        List<AdoptionRequest> result = new ArrayList<>();
+        for (AdoptionRequest req : store.values()) {
+            if (req.getStatus() == status) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code adopterId} is null or blank, or {@code status} is null
+     */
+    @Override
+    public List<AdoptionRequest> findByAdopterIdAndStatus(String adopterId, RequestStatus status) {
+        if (adopterId == null || adopterId.isBlank()) {
+            throw new IllegalArgumentException("Adopter ID must not be null or blank.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("Status must not be null.");
+        }
+        List<AdoptionRequest> result = new ArrayList<>();
+        for (AdoptionRequest req : store.values()) {
+            if (adopterId.equals(req.getAdopter().getId()) && req.getStatus() == status) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code shelterId} is null or blank, or {@code status} is null
+     */
+    @Override
+    public List<AdoptionRequest> findByShelterIdAndStatus(String shelterId, RequestStatus status) {
+        if (shelterId == null || shelterId.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("Status must not be null.");
+        }
+        List<AdoptionRequest> result = new ArrayList<>();
+        for (AdoptionRequest req : store.values()) {
+            if (shelterId.equals(req.getAnimal().getShelterId()) && req.getStatus() == status) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public void delete(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        store.remove(id);
+        flush();
+    }
+}

--- a/src/main/java/shelter/repository/csv/CsvAnimalRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAnimalRepository.java
@@ -1,0 +1,276 @@
+package shelter.repository.csv;
+
+import shelter.domain.ActivityLevel;
+import shelter.domain.Animal;
+import shelter.domain.Cat;
+import shelter.domain.Dog;
+import shelter.domain.Rabbit;
+import shelter.domain.Species;
+import shelter.repository.AnimalRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CSV-backed implementation of {@link AnimalRepository} that persists animal records to a flat file
+ * named {@code animals.csv}.
+ * All concrete animal types ({@link Dog}, {@link Cat}, {@link Rabbit}) are stored in the same file
+ * using a species discriminator column; species-specific columns are left empty for non-applicable
+ * types. Records are loaded into memory at construction and flushed on every mutation.
+ */
+public class CsvAnimalRepository implements AnimalRepository {
+
+    private static final String FILE_NAME = "animals.csv";
+    /**
+     * Column layout: id, species, name, breed, age, activityLevel, vaccinated,
+     * adopterId, shelterId, size(dog only), neutered(dog/cat), indoor(cat only), furLength(rabbit only)
+     */
+    private static final String HEADER =
+            "id,species,name,breed,age,activityLevel,vaccinated,adopterId,shelterId,size,neutered,indoor,furLength";
+
+    private final Path filePath;
+    private final Map<String, Animal> store;
+
+    /**
+     * Constructs a new CsvAnimalRepository that reads from and writes to the given data directory.
+     * If the CSV file does not yet exist it is created with just the header row; existing data
+     * is loaded into memory immediately upon construction.
+     *
+     * @param dataDir the path to the directory that contains (or will contain) the CSV file;
+     *                must not be null or blank
+     * @throws IllegalArgumentException if {@code dataDir} is null or blank
+     * @throws RuntimeException         if the directory cannot be created or the file cannot be read
+     */
+    public CsvAnimalRepository(String dataDir) {
+        if (dataDir == null || dataDir.isBlank()) {
+            throw new IllegalArgumentException("Data directory must not be null or blank.");
+        }
+        this.filePath = Paths.get(dataDir, FILE_NAME);
+        this.store = new LinkedHashMap<>();
+        initAndLoad();
+    }
+
+    /** Ensures the data directory and file exist, then loads all rows into memory. */
+    private void initAndLoad() {
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, HEADER + System.lineSeparator());
+            } else {
+                loadAll();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize CsvAnimalRepository: " + e.getMessage(), e);
+        }
+    }
+
+    /** Reads all CSV rows and reconstructs Animal objects into the in-memory store. */
+    private void loadAll() {
+        try {
+            List<String> lines = Files.readAllLines(filePath);
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+                if (line.isEmpty()) continue;
+                try {
+                    Animal a = parseLine(line);
+                    store.put(a.getId(), a);
+                } catch (Exception e) {
+                    System.err.println("Skipping malformed animal CSV row " + i + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load animals from CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a single CSV row into the appropriate Animal subclass based on the species column.
+     * Fields are in order: id, species, name, breed, age, activityLevel, vaccinated,
+     * adopterId, shelterId, size, neutered, indoor, furLength.
+     * Species-specific columns that do not apply are stored as empty strings.
+     *
+     * @param line a non-empty CSV row
+     * @return the reconstructed {@link Animal} (a {@link Dog}, {@link Cat}, or {@link Rabbit})
+     * @throws IllegalArgumentException if the species value is unrecognized
+     */
+    private Animal parseLine(String line) {
+        String[] p = CsvUtils.splitCsv(line);
+        String id            = CsvUtils.unescapeCsv(p[0]);
+        Species species      = Species.valueOf(p[1].trim());
+        String name          = CsvUtils.unescapeCsv(p[2]);
+        String breed         = CsvUtils.unescapeCsv(p[3]);
+        int age              = Integer.parseInt(p[4].trim());
+        ActivityLevel act    = ActivityLevel.valueOf(p[5].trim());
+        boolean vaccinated   = Boolean.parseBoolean(p[6].trim());
+        String adopterId     = CsvUtils.unescapeCsv(p[7]);  // null if empty
+        String shelterId     = CsvUtils.unescapeCsv(p[8]);  // null if empty
+
+        // columns 9–12 are species-specific
+        String sizeRaw      = p.length > 9  ? p[9].trim()  : "";
+        String neuteredRaw  = p.length > 10 ? p[10].trim() : "";
+        String indoorRaw    = p.length > 11 ? p[11].trim() : "";
+        String furRaw       = p.length > 12 ? p[12].trim() : "";
+
+        switch (species) {
+            case DOG: {
+                Dog.Size size = sizeRaw.isEmpty() ? Dog.Size.MEDIUM : Dog.Size.valueOf(sizeRaw);
+                boolean neutered = !neuteredRaw.isEmpty() && Boolean.parseBoolean(neuteredRaw);
+                return new Dog(id, name, breed, age, act, vaccinated, adopterId, shelterId, size, neutered);
+            }
+            case CAT: {
+                boolean indoor   = !indoorRaw.isEmpty() && Boolean.parseBoolean(indoorRaw);
+                boolean neutered = !neuteredRaw.isEmpty() && Boolean.parseBoolean(neuteredRaw);
+                return new Cat(id, name, breed, age, act, vaccinated, adopterId, shelterId, indoor, neutered);
+            }
+            case RABBIT: {
+                Rabbit.FurLength fur = furRaw.isEmpty() ? Rabbit.FurLength.SHORT : Rabbit.FurLength.valueOf(furRaw);
+                return new Rabbit(id, name, breed, age, act, vaccinated, adopterId, shelterId, fur);
+            }
+            default:
+                throw new IllegalArgumentException("Unsupported species in CSV: " + species);
+        }
+    }
+
+    /** Serialises a single Animal to the 13-column CSV row format. */
+    private String toRow(Animal a) {
+        String sizeVal     = "";
+        String neuteredVal = "";
+        String indoorVal   = "";
+        String furVal      = "";
+
+        if (a instanceof Dog) {
+            Dog d = (Dog) a;
+            sizeVal     = d.getSize().name();
+            neuteredVal = String.valueOf(d.isNeutered());
+        } else if (a instanceof Cat) {
+            Cat c = (Cat) a;
+            neuteredVal = String.valueOf(c.isNeutered());
+            indoorVal   = String.valueOf(c.isIndoor());
+        } else if (a instanceof Rabbit) {
+            Rabbit r = (Rabbit) a;
+            furVal = r.getFurLength().name();
+        }
+
+        return CsvUtils.escapeCsv(a.getId()) + ','
+             + a.getSpecies().name() + ','
+             + CsvUtils.escapeCsv(a.getName()) + ','
+             + CsvUtils.escapeCsv(a.getBreed()) + ','
+             + a.getAge() + ','
+             + a.getActivityLevel().name() + ','
+             + a.isVaccinated() + ','
+             + CsvUtils.escapeCsv(a.getAdopterId()) + ','
+             + CsvUtils.escapeCsv(a.getShelterId()) + ','
+             + sizeVal + ','
+             + neuteredVal + ','
+             + indoorVal + ','
+             + furVal;
+    }
+
+    /** Writes the entire in-memory store back to the CSV file. */
+    private void flush() {
+        try {
+            StringBuilder sb = new StringBuilder(HEADER).append(System.lineSeparator());
+            for (Animal a : store.values()) {
+                sb.append(toRow(a)).append(System.lineSeparator());
+            }
+            Files.writeString(filePath, sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to flush animals to CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code animal} is null
+     */
+    @Override
+    public void save(Animal animal) {
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+        store.put(animal.getId(), animal);
+        flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public Optional<Animal> findById(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        return Optional.ofNullable(store.get(id));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Animal> findAll() {
+        return Collections.unmodifiableList(new ArrayList<>(store.values()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code shelterId} is null or blank
+     */
+    @Override
+    public List<Animal> findByShelterId(String shelterId) {
+        if (shelterId == null || shelterId.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        List<Animal> result = new ArrayList<>();
+        for (Animal a : store.values()) {
+            if (shelterId.equals(a.getShelterId())) {
+                result.add(a);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code adopterId} is null or blank
+     */
+    @Override
+    public List<Animal> findByAdopterId(String adopterId) {
+        if (adopterId == null || adopterId.isBlank()) {
+            throw new IllegalArgumentException("Adopter ID must not be null or blank.");
+        }
+        List<Animal> result = new ArrayList<>();
+        for (Animal a : store.values()) {
+            if (adopterId.equals(a.getAdopterId())) {
+                result.add(a);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public void delete(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        store.remove(id);
+        flush();
+    }
+}

--- a/src/main/java/shelter/repository/csv/CsvShelterRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvShelterRepository.java
@@ -1,0 +1,174 @@
+package shelter.repository.csv;
+
+import shelter.domain.Shelter;
+import shelter.repository.ShelterRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CSV-backed implementation of {@link ShelterRepository} that persists shelter records to a flat file.
+ * Records are loaded into an in-memory {@link LinkedHashMap} at construction time and written back to
+ * disk on every {@link #save(Shelter)} or {@link #delete(String)} call to ensure durability.
+ */
+public class CsvShelterRepository implements ShelterRepository {
+
+    private static final String FILE_NAME = "shelters.csv";
+    private static final String HEADER = "id,name,location,capacity";
+
+    private final Path filePath;
+    private final Map<String, Shelter> store;
+
+    /**
+     * Constructs a new CsvShelterRepository that reads from and writes to the given data directory.
+     * If the CSV file does not yet exist it is created with just the header row; existing data is
+     * loaded into memory immediately.
+     *
+     * @param dataDir the path to the directory that contains (or will contain) the CSV file;
+     *                must not be null or blank
+     * @throws IllegalArgumentException if {@code dataDir} is null or blank
+     * @throws RuntimeException         if the data directory cannot be created or the file cannot be read
+     */
+    public CsvShelterRepository(String dataDir) {
+        if (dataDir == null || dataDir.isBlank()) {
+            throw new IllegalArgumentException("Data directory must not be null or blank.");
+        }
+        this.filePath = Paths.get(dataDir, FILE_NAME);
+        this.store = new LinkedHashMap<>();
+        initAndLoad();
+    }
+
+    /**
+     * Initializes the data directory and loads existing records into memory.
+     * Creates the CSV file with a header if it does not already exist.
+     */
+    private void initAndLoad() {
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, HEADER + System.lineSeparator());
+            } else {
+                loadAll();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize CsvShelterRepository: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Reads all CSV rows and reconstructs Shelter objects into the in-memory store.
+     * Rows that cannot be parsed are skipped with a warning printed to stderr.
+     */
+    private void loadAll() {
+        try {
+            List<String> lines = Files.readAllLines(filePath);
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+                try {
+                    Shelter s = parseLine(line);
+                    store.put(s.getId(), s);
+                } catch (Exception e) {
+                    System.err.println("Skipping malformed shelter CSV row " + i + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load shelters from CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a single CSV row into a Shelter object using the reconstruction constructor.
+     * Fields are expected in the order: id, name, location, capacity.
+     *
+     * @param line a non-empty CSV row
+     * @return the reconstructed {@link Shelter}
+     */
+    private Shelter parseLine(String line) {
+        String[] parts = CsvUtils.splitCsv(line);
+        String id = CsvUtils.unescapeCsv(parts[0]);
+        String name = CsvUtils.unescapeCsv(parts[1]);
+        String location = CsvUtils.unescapeCsv(parts[2]);
+        int capacity = Integer.parseInt(parts[3].trim());
+        return new Shelter(id, name, location, capacity);
+    }
+
+    /**
+     * Flushes the entire in-memory store back to the CSV file on disk.
+     * Called after every mutating operation to keep the file consistent with memory.
+     */
+    private void flush() {
+        try {
+            StringBuilder sb = new StringBuilder(HEADER).append(System.lineSeparator());
+            for (Shelter s : store.values()) {
+                sb.append(CsvUtils.escapeCsv(s.getId())).append(',')
+                  .append(CsvUtils.escapeCsv(s.getName())).append(',')
+                  .append(CsvUtils.escapeCsv(s.getLocation())).append(',')
+                  .append(s.getCapacity())
+                  .append(System.lineSeparator());
+            }
+            Files.writeString(filePath, sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to flush shelters to CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code shelter} is null
+     */
+    @Override
+    public void save(Shelter shelter) {
+        if (shelter == null) {
+            throw new IllegalArgumentException("Shelter must not be null.");
+        }
+        store.put(shelter.getId(), shelter);
+        flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public Optional<Shelter> findById(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        return Optional.ofNullable(store.get(id));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Shelter> findAll() {
+        return Collections.unmodifiableList(new ArrayList<>(store.values()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public void delete(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        store.remove(id);
+        flush();
+    }
+}

--- a/src/main/java/shelter/repository/csv/CsvTransferRequestRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvTransferRequestRepository.java
@@ -1,0 +1,327 @@
+package shelter.repository.csv;
+
+import shelter.domain.Animal;
+import shelter.domain.RequestStatus;
+import shelter.domain.Shelter;
+import shelter.domain.TransferRequest;
+import shelter.repository.AnimalRepository;
+import shelter.repository.ShelterRepository;
+import shelter.repository.TransferRequestRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CSV-backed implementation of {@link TransferRequestRepository} that persists transfer request
+ * records to a flat file named {@code transfer-requests.csv}.
+ * Requires injected {@link AnimalRepository} and {@link ShelterRepository} instances to reconstruct
+ * full object graphs when loading from CSV.
+ * Records are kept in memory and flushed to disk on every mutation.
+ */
+public class CsvTransferRequestRepository implements TransferRequestRepository {
+
+    private static final String FILE_NAME = "transfer-requests.csv";
+    private static final String HEADER = "id,animalId,fromShelterId,toShelterId,status,requestedAt";
+
+    private final Path filePath;
+    private final Map<String, TransferRequest> store;
+    private final AnimalRepository animalRepository;
+    private final ShelterRepository shelterRepository;
+
+    /**
+     * Constructs a new CsvTransferRequestRepository backed by the given data directory.
+     * The {@code animalRepository} and {@code shelterRepository} are used to resolve full objects
+     * when loading transfer requests from CSV rows.
+     * If the CSV file does not yet exist it is created with just the header row.
+     *
+     * @param dataDir           the path to the directory for the CSV file; must not be null or blank
+     * @param animalRepository  used to look up animals by ID during CSV deserialization; must not be null
+     * @param shelterRepository used to look up shelters by ID during CSV deserialization; must not be null
+     * @throws IllegalArgumentException if any parameter is null or {@code dataDir} is blank
+     * @throws RuntimeException         if the directory cannot be created or the file cannot be read
+     */
+    public CsvTransferRequestRepository(String dataDir,
+                                        AnimalRepository animalRepository,
+                                        ShelterRepository shelterRepository) {
+        if (dataDir == null || dataDir.isBlank()) {
+            throw new IllegalArgumentException("Data directory must not be null or blank.");
+        }
+        if (animalRepository == null) {
+            throw new IllegalArgumentException("AnimalRepository must not be null.");
+        }
+        if (shelterRepository == null) {
+            throw new IllegalArgumentException("ShelterRepository must not be null.");
+        }
+        this.filePath = Paths.get(dataDir, FILE_NAME);
+        this.store = new LinkedHashMap<>();
+        this.animalRepository = animalRepository;
+        this.shelterRepository = shelterRepository;
+        initAndLoad();
+    }
+
+    /** Ensures the data directory and file exist, then loads all rows into memory. */
+    private void initAndLoad() {
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, HEADER + System.lineSeparator());
+            } else {
+                loadAll();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize CsvTransferRequestRepository: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Reads all CSV rows and reconstructs TransferRequest objects into the in-memory store.
+     * Rows whose referenced animal or shelters cannot be found are skipped with a warning.
+     */
+    private void loadAll() {
+        try {
+            List<String> lines = Files.readAllLines(filePath);
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+                if (line.isEmpty()) continue;
+                try {
+                    TransferRequest req = parseLine(line);
+                    store.put(req.getId(), req);
+                } catch (Exception e) {
+                    System.err.println("Skipping malformed transfer-request CSV row " + i + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load transfer requests from CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a single CSV row and reconstructs a full {@link TransferRequest}.
+     * Fields are in order: id, animalId, fromShelterId, toShelterId, status, requestedAt.
+     *
+     * @param line a non-empty CSV row
+     * @return the reconstructed {@link TransferRequest}
+     * @throws IllegalStateException if the referenced animal or shelters are not found
+     */
+    private TransferRequest parseLine(String line) {
+        String[] parts = CsvUtils.splitCsv(line);
+        String id             = CsvUtils.unescapeCsv(parts[0]);
+        String animalId       = CsvUtils.unescapeCsv(parts[1]);
+        String fromShelterId  = CsvUtils.unescapeCsv(parts[2]);
+        String toShelterId    = CsvUtils.unescapeCsv(parts[3]);
+        RequestStatus status  = RequestStatus.valueOf(parts[4].trim());
+        LocalDateTime requestedAt = LocalDateTime.parse(parts[5].trim());
+
+        Animal animal = animalRepository.findById(animalId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Animal not found for transfer request: " + animalId));
+        Shelter from = shelterRepository.findById(fromShelterId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Source shelter not found for transfer request: " + fromShelterId));
+        Shelter to = shelterRepository.findById(toShelterId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Destination shelter not found for transfer request: " + toShelterId));
+
+        return new TransferRequest(id, animal, from, to, status, requestedAt);
+    }
+
+    /** Writes the entire in-memory store back to the CSV file. */
+    private void flush() {
+        try {
+            StringBuilder sb = new StringBuilder(HEADER).append(System.lineSeparator());
+            for (TransferRequest req : store.values()) {
+                sb.append(CsvUtils.escapeCsv(req.getId())).append(',')
+                  .append(CsvUtils.escapeCsv(req.getAnimal().getId())).append(',')
+                  .append(CsvUtils.escapeCsv(req.getFrom().getId())).append(',')
+                  .append(CsvUtils.escapeCsv(req.getTo().getId())).append(',')
+                  .append(req.getStatus().name()).append(',')
+                  .append(req.getRequestedAt().toString())
+                  .append(System.lineSeparator());
+            }
+            Files.writeString(filePath, sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to flush transfer requests to CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code request} is null
+     */
+    @Override
+    public void save(TransferRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("TransferRequest must not be null.");
+        }
+        store.put(request.getId(), request);
+        flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public Optional<TransferRequest> findById(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        return Optional.ofNullable(store.get(id));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<TransferRequest> findAll() {
+        return Collections.unmodifiableList(new ArrayList<>(store.values()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code animalId} is null or blank
+     */
+    @Override
+    public List<TransferRequest> findByAnimalId(String animalId) {
+        if (animalId == null || animalId.isBlank()) {
+            throw new IllegalArgumentException("Animal ID must not be null or blank.");
+        }
+        List<TransferRequest> result = new ArrayList<>();
+        for (TransferRequest req : store.values()) {
+            if (animalId.equals(req.getAnimal().getId())) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code shelterId} is null or blank
+     */
+    @Override
+    public List<TransferRequest> findByFromShelterId(String shelterId) {
+        if (shelterId == null || shelterId.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        List<TransferRequest> result = new ArrayList<>();
+        for (TransferRequest req : store.values()) {
+            if (shelterId.equals(req.getFrom().getId())) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code shelterId} is null or blank
+     */
+    @Override
+    public List<TransferRequest> findByToShelterId(String shelterId) {
+        if (shelterId == null || shelterId.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        List<TransferRequest> result = new ArrayList<>();
+        for (TransferRequest req : store.values()) {
+            if (shelterId.equals(req.getTo().getId())) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code status} is null
+     */
+    @Override
+    public List<TransferRequest> findByStatus(RequestStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("Status must not be null.");
+        }
+        List<TransferRequest> result = new ArrayList<>();
+        for (TransferRequest req : store.values()) {
+            if (req.getStatus() == status) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     * Matches {@code shelterId} against both the source and destination shelter of each request.
+     *
+     * @throws IllegalArgumentException if {@code shelterId} is null or blank, or {@code status} is null
+     */
+    @Override
+    public List<TransferRequest> findByShelterIdAndStatus(String shelterId, RequestStatus status) {
+        if (shelterId == null || shelterId.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("Status must not be null.");
+        }
+        List<TransferRequest> result = new ArrayList<>();
+        for (TransferRequest req : store.values()) {
+            boolean matchesShelter = shelterId.equals(req.getFrom().getId())
+                                  || shelterId.equals(req.getTo().getId());
+            if (matchesShelter && req.getStatus() == status) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code animalId} is null or blank, or {@code status} is null
+     */
+    @Override
+    public List<TransferRequest> findByAnimalIdAndStatus(String animalId, RequestStatus status) {
+        if (animalId == null || animalId.isBlank()) {
+            throw new IllegalArgumentException("Animal ID must not be null or blank.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("Status must not be null.");
+        }
+        List<TransferRequest> result = new ArrayList<>();
+        for (TransferRequest req : store.values()) {
+            if (animalId.equals(req.getAnimal().getId()) && req.getStatus() == status) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public void delete(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        store.remove(id);
+        flush();
+    }
+}

--- a/src/main/java/shelter/repository/csv/CsvUtils.java
+++ b/src/main/java/shelter/repository/csv/CsvUtils.java
@@ -1,0 +1,143 @@
+package shelter.repository.csv;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class providing static helper methods for reading and writing CSV data.
+ * Handles quoting, escaping, splitting, and null-value encoding used uniformly
+ * by all CSV-backed repository implementations in this package.
+ */
+public final class CsvUtils {
+
+    /** Sentinel string used to represent a {@code null} value in CSV fields. */
+    static final String NULL_MARKER = "";
+
+    /**
+     * Private constructor preventing instantiation of this utility class.
+     * All methods are static and no state is held.
+     */
+    private CsvUtils() {
+        // utility class — not instantiable
+    }
+
+    /**
+     * Escapes a single field value for inclusion in a CSV row.
+     * If the value is {@code null} an empty string is written; if the value contains
+     * a comma, double-quote, or newline it is wrapped in double-quotes with any
+     * embedded double-quotes doubled.
+     *
+     * @param value the field value to escape; may be {@code null}
+     * @return the CSV-safe representation of {@code value}
+     */
+    public static String escapeCsv(String value) {
+        if (value == null) {
+            return NULL_MARKER;
+        }
+        if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    /**
+     * Reverses the escaping applied by {@link #escapeCsv(String)}.
+     * An empty string is returned as {@code null}; quoted strings are unquoted and
+     * doubled double-quotes are collapsed back to single double-quotes.
+     *
+     * @param value the raw CSV token to unescape; must not be {@code null}
+     * @return the original string value, or {@code null} if the field was empty
+     */
+    public static String unescapeCsv(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        if (value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2) {
+            String inner = value.substring(1, value.length() - 1);
+            return inner.replace("\"\"", "\"");
+        }
+        return value;
+    }
+
+    /**
+     * Splits a CSV row into individual field tokens, correctly handling quoted fields
+     * that may contain embedded commas or double-quotes.
+     * The number of tokens returned equals the number of comma-separated fields in
+     * {@code line}, including empty fields at either end.
+     *
+     * @param line a single CSV row; must not be {@code null}
+     * @return an array of raw (still-escaped) field tokens
+     */
+    public static String[] splitCsv(String line) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inQuotes) {
+                if (c == '"') {
+                    // check for escaped quote ""
+                    if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                        current.append('"');
+                        i++; // skip the second quote
+                    } else {
+                        inQuotes = false;
+                        current.append(c); // keep the closing quote for unescapeCsv
+                    }
+                } else {
+                    current.append(c);
+                }
+            } else {
+                if (c == '"') {
+                    inQuotes = true;
+                    current.append(c); // keep the opening quote for unescapeCsv
+                } else if (c == ',') {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                } else {
+                    current.append(c);
+                }
+            }
+        }
+        tokens.add(current.toString());
+        return tokens.toArray(new String[0]);
+    }
+
+    /**
+     * Encodes a list of strings into a single semicolon-delimited field value for CSV storage.
+     * An empty or {@code null} list is encoded as an empty string. Individual entries that
+     * contain semicolons are not further escaped — callers must ensure entry values do not
+     * contain the delimiter character.
+     *
+     * @param items the list to encode; may be {@code null} or empty
+     * @return a semicolon-delimited string, or an empty string if the list is empty
+     */
+    public static String encodeList(List<String> items) {
+        if (items == null || items.isEmpty()) {
+            return "";
+        }
+        return String.join(";", items);
+    }
+
+    /**
+     * Decodes a semicolon-delimited field value back into a list of strings.
+     * An empty or {@code null} input returns an empty list. Each token is trimmed
+     * of surrounding whitespace before being added to the result.
+     *
+     * @param value the encoded field value; may be {@code null} or empty
+     * @return a mutable list of decoded string values, never {@code null}
+     */
+    public static List<String> decodeList(String value) {
+        List<String> result = new ArrayList<>();
+        if (value == null || value.isBlank()) {
+            return result;
+        }
+        for (String part : value.split(";", -1)) {
+            String trimmed = part.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/shelter/repository/csv/CsvVaccinationRecordRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvVaccinationRecordRepository.java
@@ -1,0 +1,218 @@
+package shelter.repository.csv;
+
+import shelter.domain.VaccinationRecord;
+import shelter.repository.AnimalRepository;
+import shelter.repository.VaccinationRecordRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CSV-backed implementation of {@link VaccinationRecordRepository} that persists vaccination
+ * history to a flat file named {@code vaccination-records.csv}.
+ * Records are loaded into an in-memory {@link LinkedHashMap} at construction time and written back
+ * to disk on every {@link #save(VaccinationRecord)} or {@link #delete(String)} call.
+ */
+public class CsvVaccinationRecordRepository implements VaccinationRecordRepository {
+
+    private static final String FILE_NAME = "vaccination-records.csv";
+    private static final String HEADER = "id,animalId,vaccineTypeId,dateAdministered";
+
+    private final Path filePath;
+    private final Map<String, VaccinationRecord> store;
+    private final AnimalRepository animalRepository;
+
+    /**
+     * Constructs a new CsvVaccinationRecordRepository that reads from and writes to the given directory.
+     * The {@code animalRepository} is used when resolving shelter membership for
+     * {@link #findByShelterId(String)} queries.
+     * If the CSV file does not yet exist it is created with just the header row.
+     *
+     * @param dataDir          the path to the directory containing the CSV file; must not be null or blank
+     * @param animalRepository the repository used to look up animals by their shelter ID;
+     *                         must not be null
+     * @throws IllegalArgumentException if any parameter is null or {@code dataDir} is blank
+     * @throws RuntimeException         if the directory cannot be created or the file cannot be read
+     */
+    public CsvVaccinationRecordRepository(String dataDir, AnimalRepository animalRepository) {
+        if (dataDir == null || dataDir.isBlank()) {
+            throw new IllegalArgumentException("Data directory must not be null or blank.");
+        }
+        if (animalRepository == null) {
+            throw new IllegalArgumentException("AnimalRepository must not be null.");
+        }
+        this.filePath = Paths.get(dataDir, FILE_NAME);
+        this.store = new LinkedHashMap<>();
+        this.animalRepository = animalRepository;
+        initAndLoad();
+    }
+
+    /** Ensures the data directory and file exist, then loads all rows into memory. */
+    private void initAndLoad() {
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, HEADER + System.lineSeparator());
+            } else {
+                loadAll();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize CsvVaccinationRecordRepository: " + e.getMessage(), e);
+        }
+    }
+
+    /** Reads all CSV rows and reconstructs VaccinationRecord objects into the in-memory store. */
+    private void loadAll() {
+        try {
+            List<String> lines = Files.readAllLines(filePath);
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+                if (line.isEmpty()) continue;
+                try {
+                    VaccinationRecord rec = parseLine(line);
+                    store.put(rec.getId(), rec);
+                } catch (Exception e) {
+                    System.err.println("Skipping malformed vaccination-record CSV row " + i + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load vaccination records from CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a single CSV row into a VaccinationRecord using the reconstruction constructor.
+     * Fields are expected in order: id, animalId, vaccineTypeId, dateAdministered.
+     *
+     * @param line a non-empty CSV row
+     * @return the reconstructed {@link VaccinationRecord}
+     */
+    private VaccinationRecord parseLine(String line) {
+        String[] parts = CsvUtils.splitCsv(line);
+        String id = CsvUtils.unescapeCsv(parts[0]);
+        String animalId = CsvUtils.unescapeCsv(parts[1]);
+        String vaccineTypeId = CsvUtils.unescapeCsv(parts[2]);
+        LocalDate date = LocalDate.parse(parts[3].trim());
+        return new VaccinationRecord(id, animalId, vaccineTypeId, date);
+    }
+
+    /** Writes the entire in-memory store back to the CSV file. */
+    private void flush() {
+        try {
+            StringBuilder sb = new StringBuilder(HEADER).append(System.lineSeparator());
+            for (VaccinationRecord rec : store.values()) {
+                sb.append(CsvUtils.escapeCsv(rec.getId())).append(',')
+                  .append(CsvUtils.escapeCsv(rec.getAnimalId())).append(',')
+                  .append(CsvUtils.escapeCsv(rec.getVaccineTypeId())).append(',')
+                  .append(rec.getDateAdministered().toString())
+                  .append(System.lineSeparator());
+            }
+            Files.writeString(filePath, sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to flush vaccination records to CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code record} is null
+     */
+    @Override
+    public void save(VaccinationRecord record) {
+        if (record == null) {
+            throw new IllegalArgumentException("VaccinationRecord must not be null.");
+        }
+        store.put(record.getId(), record);
+        flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public Optional<VaccinationRecord> findById(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        return Optional.ofNullable(store.get(id));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code animalId} is null or blank
+     */
+    @Override
+    public List<VaccinationRecord> findByAnimalId(String animalId) {
+        if (animalId == null || animalId.isBlank()) {
+            throw new IllegalArgumentException("Animal ID must not be null or blank.");
+        }
+        List<VaccinationRecord> result = new ArrayList<>();
+        for (VaccinationRecord rec : store.values()) {
+            if (animalId.equals(rec.getAnimalId())) {
+                result.add(rec);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<VaccinationRecord> findAll() {
+        return Collections.unmodifiableList(new ArrayList<>(store.values()));
+    }
+
+    /**
+     * Returns all vaccination records for animals currently housed in the given shelter.
+     * The lookup is performed by finding all animals with the matching shelter ID via the
+     * injected {@link AnimalRepository}, then filtering records by those animal IDs.
+     *
+     * @param shelterId the shelter ID to filter by; must not be null or blank
+     * @return a list of vaccination records for animals in the specified shelter
+     * @throws IllegalArgumentException if {@code shelterId} is null or blank
+     */
+    @Override
+    public List<VaccinationRecord> findByShelterId(String shelterId) {
+        if (shelterId == null || shelterId.isBlank()) {
+            throw new IllegalArgumentException("Shelter ID must not be null or blank.");
+        }
+        List<String> animalIds = new ArrayList<>();
+        animalRepository.findByShelterId(shelterId).forEach(a -> animalIds.add(a.getId()));
+
+        List<VaccinationRecord> result = new ArrayList<>();
+        for (VaccinationRecord rec : store.values()) {
+            if (animalIds.contains(rec.getAnimalId())) {
+                result.add(rec);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public void delete(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        store.remove(id);
+        flush();
+    }
+}

--- a/src/main/java/shelter/repository/csv/CsvVaccineTypeRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvVaccineTypeRepository.java
@@ -1,0 +1,200 @@
+package shelter.repository.csv;
+
+import shelter.domain.Species;
+import shelter.domain.VaccineType;
+import shelter.repository.VaccineTypeRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CSV-backed implementation of {@link VaccineTypeRepository} that persists vaccine type catalog
+ * entries to a flat file named {@code vaccine-types.csv}.
+ * Records are loaded into an in-memory {@link LinkedHashMap} at construction time and written back
+ * to disk on every {@link #save(VaccineType)} or {@link #delete(String)} call.
+ */
+public class CsvVaccineTypeRepository implements VaccineTypeRepository {
+
+    private static final String FILE_NAME = "vaccine-types.csv";
+    private static final String HEADER = "id,name,applicableSpecies,validityDays";
+
+    private final Path filePath;
+    private final Map<String, VaccineType> store;
+
+    /**
+     * Constructs a new CsvVaccineTypeRepository that reads from and writes to the given directory.
+     * If the CSV file does not yet exist it is created with just the header row; existing data
+     * is loaded into memory immediately upon construction.
+     *
+     * @param dataDir the path to the directory that contains (or will contain) the CSV file;
+     *                must not be null or blank
+     * @throws IllegalArgumentException if {@code dataDir} is null or blank
+     * @throws RuntimeException         if the directory cannot be created or the file cannot be read
+     */
+    public CsvVaccineTypeRepository(String dataDir) {
+        if (dataDir == null || dataDir.isBlank()) {
+            throw new IllegalArgumentException("Data directory must not be null or blank.");
+        }
+        this.filePath = Paths.get(dataDir, FILE_NAME);
+        this.store = new LinkedHashMap<>();
+        initAndLoad();
+    }
+
+    /** Ensures the data directory and file exist, then loads all rows into memory. */
+    private void initAndLoad() {
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, HEADER + System.lineSeparator());
+            } else {
+                loadAll();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize CsvVaccineTypeRepository: " + e.getMessage(), e);
+        }
+    }
+
+    /** Reads all CSV rows and reconstructs VaccineType objects into the in-memory store. */
+    private void loadAll() {
+        try {
+            List<String> lines = Files.readAllLines(filePath);
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+                if (line.isEmpty()) continue;
+                try {
+                    VaccineType vt = parseLine(line);
+                    store.put(vt.getId(), vt);
+                } catch (Exception e) {
+                    System.err.println("Skipping malformed vaccine-type CSV row " + i + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load vaccine types from CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a single CSV row into a VaccineType using the reconstruction constructor.
+     * Fields are expected in the order: id, name, applicableSpecies, validityDays.
+     *
+     * @param line a non-empty CSV row
+     * @return the reconstructed {@link VaccineType}
+     */
+    private VaccineType parseLine(String line) {
+        String[] parts = CsvUtils.splitCsv(line);
+        String id = CsvUtils.unescapeCsv(parts[0]);
+        String name = CsvUtils.unescapeCsv(parts[1]);
+        Species species = Species.valueOf(parts[2].trim());
+        int validityDays = Integer.parseInt(parts[3].trim());
+        return new VaccineType(id, name, species, validityDays);
+    }
+
+    /** Writes the entire in-memory store back to the CSV file. */
+    private void flush() {
+        try {
+            StringBuilder sb = new StringBuilder(HEADER).append(System.lineSeparator());
+            for (VaccineType vt : store.values()) {
+                sb.append(CsvUtils.escapeCsv(vt.getId())).append(',')
+                  .append(CsvUtils.escapeCsv(vt.getName())).append(',')
+                  .append(vt.getApplicableSpecies().name()).append(',')
+                  .append(vt.getValidityDays())
+                  .append(System.lineSeparator());
+            }
+            Files.writeString(filePath, sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to flush vaccine types to CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code vaccineType} is null
+     */
+    @Override
+    public void save(VaccineType vaccineType) {
+        if (vaccineType == null) {
+            throw new IllegalArgumentException("VaccineType must not be null.");
+        }
+        store.put(vaccineType.getId(), vaccineType);
+        flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public Optional<VaccineType> findById(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        return Optional.ofNullable(store.get(id));
+    }
+
+    /**
+     * {@inheritDoc}
+     * Name matching is case-insensitive as required by the interface contract.
+     *
+     * @throws IllegalArgumentException if {@code name} is null or blank
+     */
+    @Override
+    public Optional<VaccineType> findByName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Name must not be null or blank.");
+        }
+        return store.values().stream()
+                .filter(vt -> vt.getName().equalsIgnoreCase(name))
+                .findFirst();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code species} is null
+     */
+    @Override
+    public List<VaccineType> findByApplicableSpecies(Species species) {
+        if (species == null) {
+            throw new IllegalArgumentException("Species must not be null.");
+        }
+        List<VaccineType> result = new ArrayList<>();
+        for (VaccineType vt : store.values()) {
+            if (vt.getApplicableSpecies() == species) {
+                result.add(vt);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<VaccineType> findAll() {
+        return Collections.unmodifiableList(new ArrayList<>(store.values()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code id} is null or blank
+     */
+    @Override
+    public void delete(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID must not be null or blank.");
+        }
+        store.remove(id);
+        flush();
+    }
+}

--- a/src/main/java/shelter/strategy/SpeciesPreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/SpeciesPreferenceStrategy.java
@@ -2,6 +2,7 @@ package shelter.strategy;
 
 import shelter.domain.Adopter;
 import shelter.domain.Animal;
+import shelter.domain.Species;
 
 /**
  * A concrete matching strategy that evaluates whether an animal's species
@@ -38,12 +39,12 @@ public class SpeciesPreferenceStrategy implements IMatchingStrategy {
             throw new IllegalArgumentException("Animal must not be null.");
         }
 
-        String preferredSpecies = adopter.getPreferences().getPreferredSpecies();
-        if (preferredSpecies == null || preferredSpecies.isBlank()) {
+        Species preferredSpecies = adopter.getPreferences().getPreferredSpecies();
+        if (preferredSpecies == null) {
             return 0.0;
         }
 
-        return preferredSpecies.equalsIgnoreCase(animal.getSpecies()) ? 1.0 : 0.0;
+        return preferredSpecies == animal.getSpecies() ? 1.0 : 0.0;
     }
 
 }

--- a/src/test/java/shelter/domain/AdopterTest.java
+++ b/src/test/java/shelter/domain/AdopterTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AdopterTest {
 
     private AdopterPreferences defaultPrefs() {
-        return new AdopterPreferences("Dog", "Labrador", ActivityLevel.HIGH, 1, 5);
+        return new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, 1, 5);
     }
 
     // -------------------------------------------------------------------------
@@ -94,9 +94,9 @@ class AdopterTest {
 
     @Test
     void adopterPreferences_storesAllFields() {
-        AdopterPreferences prefs = new AdopterPreferences("Cat", "Persian",
+        AdopterPreferences prefs = new AdopterPreferences(Species.CAT, "Persian",
                 ActivityLevel.LOW, 0, 8);
-        assertEquals("Cat", prefs.getPreferredSpecies());
+        assertEquals(Species.CAT, prefs.getPreferredSpecies());
         assertEquals("Persian", prefs.getPreferredBreed());
         assertEquals(ActivityLevel.LOW, prefs.getPreferredActivityLevel());
         assertEquals(0, prefs.getMinAge());
@@ -125,12 +125,12 @@ class AdopterTest {
     @Test
     void adopterPreferences_throwsIllegalArgumentException_whenMinAgeIsNegative() {
         assertThrows(IllegalArgumentException.class, () ->
-                new AdopterPreferences("Dog", "Labrador", ActivityLevel.HIGH, -1, 5));
+                new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, -1, 5));
     }
 
     @Test
     void adopterPreferences_throwsIllegalArgumentException_whenMaxAgeLessThanMinAge() {
         assertThrows(IllegalArgumentException.class, () ->
-                new AdopterPreferences("Dog", "Labrador", ActivityLevel.HIGH, 5, 3));
+                new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, 5, 3));
     }
 }

--- a/src/test/java/shelter/domain/AdoptionRequestTest.java
+++ b/src/test/java/shelter/domain/AdoptionRequestTest.java
@@ -17,7 +17,7 @@ class AdoptionRequestTest {
 
     @BeforeEach
     void setUp() {
-        AdopterPreferences prefs = new AdopterPreferences("Dog", null, ActivityLevel.HIGH, 0, 10);
+        AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, ActivityLevel.HIGH, 0, 10);
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null, prefs);
         animal = new Dog("Rex", "Labrador", 3, ActivityLevel.HIGH, true, Dog.Size.LARGE, false);

--- a/src/test/java/shelter/domain/AnimalTest.java
+++ b/src/test/java/shelter/domain/AnimalTest.java
@@ -24,7 +24,7 @@ class AnimalTest {
         assertTrue(dog.isVaccinated());
         assertEquals(Dog.Size.LARGE, dog.getSize());
         assertFalse(dog.isNeutered());
-        assertEquals("Dog", dog.getSpecies());
+        assertEquals(Species.DOG, dog.getSpecies());
         assertNotNull(dog.getId());
     }
 
@@ -102,7 +102,7 @@ class AnimalTest {
     @Test
     void cat_createsSuccessfully_withValidArguments() {
         Cat cat = new Cat("Miso", "Persian", 2, ActivityLevel.LOW, true, true, true);
-        assertEquals("Cat", cat.getSpecies());
+        assertEquals(Species.CAT, cat.getSpecies());
         assertEquals("Miso", cat.getName());
         assertTrue(cat.isIndoor());
         assertTrue(cat.isNeutered());
@@ -140,7 +140,7 @@ class AnimalTest {
     void rabbit_createsSuccessfully_withValidArguments() {
         Rabbit rabbit = new Rabbit("Bun", "Holland Lop", 1, ActivityLevel.MEDIUM,
                 false, Rabbit.FurLength.SHORT);
-        assertEquals("Rabbit", rabbit.getSpecies());
+        assertEquals(Species.RABBIT, rabbit.getSpecies());
         assertEquals("Bun", rabbit.getName());
         assertEquals(Rabbit.FurLength.SHORT, rabbit.getFurLength());
         assertNotNull(rabbit.getId());

--- a/src/test/java/shelter/repository/csv/CsvAdopterRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvAdopterRepositoryTest.java
@@ -1,0 +1,206 @@
+package shelter.repository.csv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Adopter;
+import shelter.domain.AdopterPreferences;
+import shelter.domain.DailySchedule;
+import shelter.domain.LivingSpace;
+import shelter.domain.Species;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CsvAdopterRepository}, verifying all CRUD operations and CSV round-trip
+ * fidelity using a JUnit {@code @TempDir}.
+ */
+class CsvAdopterRepositoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CsvAdopterRepository repo;
+
+    /**
+     * Creates a fresh repository backed by the JUnit temp directory before each test.
+     * This guarantees tests are isolated and never share persisted state.
+     */
+    @BeforeEach
+    void setUp() {
+        repo = new CsvAdopterRepository(tempDir.toString());
+    }
+
+    /** Builds a simple Adopter with no species/breed/activity preference and age range 0–10. */
+    private Adopter buildAdopter(String name) {
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, 0, 10);
+        return new Adopter(name, LivingSpace.APARTMENT, DailySchedule.HOME_MOST_OF_DAY, null, prefs);
+    }
+
+    /**
+     * Verifies that a saved Adopter can be retrieved by ID with all fields intact.
+     */
+    @Test
+    void saveAndFindById_returnsCorrectAdopter() {
+        AdopterPreferences prefs = new AdopterPreferences(
+                Species.DOG, "Labrador", ActivityLevel.HIGH, 1, 5);
+        Adopter a = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, "Loves dogs", prefs);
+        repo.save(a);
+
+        Optional<Adopter> found = repo.findById(a.getId());
+        assertTrue(found.isPresent());
+        Adopter loaded = found.get();
+        assertEquals(a.getId(), loaded.getId());
+        assertEquals("Alice", loaded.getName());
+        assertEquals(LivingSpace.HOUSE_WITH_YARD, loaded.getLivingSpace());
+        assertEquals(DailySchedule.HOME_MOST_OF_DAY, loaded.getDailySchedule());
+        assertEquals("Loves dogs", loaded.getPersonalNotes());
+        assertEquals(Species.DOG, loaded.getPreferences().getPreferredSpecies());
+        assertEquals("Labrador", loaded.getPreferences().getPreferredBreed());
+        assertEquals(ActivityLevel.HIGH, loaded.getPreferences().getPreferredActivityLevel());
+        assertEquals(1, loaded.getPreferences().getMinAge());
+        assertEquals(5, loaded.getPreferences().getMaxAge());
+    }
+
+    /**
+     * Verifies that findAll returns all saved adopters.
+     */
+    @Test
+    void findAll_returnsAllSaved() {
+        repo.save(buildAdopter("Alice"));
+        repo.save(buildAdopter("Bob"));
+
+        List<Adopter> all = repo.findAll();
+        assertEquals(2, all.size());
+    }
+
+    /**
+     * Verifies that delete removes the adopter from the store.
+     */
+    @Test
+    void delete_removesAdopter() {
+        Adopter a = buildAdopter("ToDelete");
+        repo.save(a);
+        repo.delete(a.getId());
+
+        assertTrue(repo.findById(a.getId()).isEmpty());
+        assertEquals(0, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that findById returns empty for an ID that was never saved.
+     */
+    @Test
+    void findById_unknownId_returnsEmpty() {
+        assertTrue(repo.findById("no-such-id").isEmpty());
+    }
+
+    /**
+     * Verifies that null preferences fields (species, breed, activity) are stored and restored
+     * as null rather than throwing or producing garbage values.
+     */
+    @Test
+    void nullPreferences_roundTrip() {
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, 0, 15);
+        Adopter a = new Adopter("NoPrefs", LivingSpace.APARTMENT,
+                DailySchedule.AWAY_MOST_OF_DAY, null, prefs);
+        repo.save(a);
+
+        Adopter loaded = repo.findById(a.getId()).orElseThrow();
+        assertNull(loaded.getPreferences().getPreferredSpecies());
+        assertNull(loaded.getPreferences().getPreferredBreed());
+        assertNull(loaded.getPreferences().getPreferredActivityLevel());
+        assertNull(loaded.getPersonalNotes());
+    }
+
+    /**
+     * Verifies that adoptedAnimalIds are preserved through a CSV round-trip.
+     */
+    @Test
+    void adoptedAnimalIds_roundTrip() {
+        Adopter a = buildAdopter("WithAdoptions");
+        a.addAdoptedAnimalId("animal-1");
+        a.addAdoptedAnimalId("animal-2");
+        repo.save(a);
+
+        CsvAdopterRepository repo2 = new CsvAdopterRepository(tempDir.toString());
+        Adopter loaded = repo2.findById(a.getId()).orElseThrow();
+        assertEquals(List.of("animal-1", "animal-2"), loaded.getAdoptedAnimalIds());
+    }
+
+    /**
+     * Verifies that an adopter with an empty adoptedAnimalIds list is stored and restored correctly.
+     */
+    @Test
+    void emptyAdoptedAnimalIds_roundTrip() {
+        Adopter a = buildAdopter("NoAdoptions");
+        repo.save(a);
+
+        CsvAdopterRepository repo2 = new CsvAdopterRepository(tempDir.toString());
+        assertTrue(repo2.findById(a.getId()).orElseThrow().getAdoptedAnimalIds().isEmpty());
+    }
+
+    /**
+     * Verifies CSV round-trip: data saved in one instance is readable in a new instance.
+     */
+    @Test
+    void persistence_roundTrip() {
+        Adopter a = buildAdopter("Persistent");
+        repo.save(a);
+
+        CsvAdopterRepository repo2 = new CsvAdopterRepository(tempDir.toString());
+        assertTrue(repo2.findById(a.getId()).isPresent());
+        assertEquals("Persistent", repo2.findById(a.getId()).get().getName());
+    }
+
+    /**
+     * Verifies that saving an adopter with the same ID twice overwrites the first record.
+     * This confirms the upsert semantics of save: the most recently saved state is the truth.
+     */
+    @Test
+    void save_upsert_overwritesExistingRecord() {
+        Adopter a = buildAdopter("Original");
+        repo.save(a);
+
+        Adopter updated = new Adopter(
+                a.getId(), "Updated", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.AWAY_PART_OF_DAY, "updated notes",
+                new AdopterPreferences(Species.CAT, null, null, 0, 10),
+                List.of());
+        repo.save(updated);
+
+        assertEquals(1, repo.findAll().size());
+        Adopter loaded = repo.findById(a.getId()).orElseThrow();
+        assertEquals("Updated", loaded.getName());
+        assertEquals(LivingSpace.HOUSE_WITH_YARD, loaded.getLivingSpace());
+        assertEquals(Species.CAT, loaded.getPreferences().getPreferredSpecies());
+    }
+
+    /**
+     * Verifies that deleting a non-existent ID does not throw an exception.
+     * The operation should be a silent no-op when the record is not found.
+     */
+    @Test
+    void delete_nonExistentId_doesNotThrow() {
+        assertDoesNotThrow(() -> repo.delete("id-that-does-not-exist"));
+    }
+
+    /**
+     * Verifies that adopter names containing commas and quotes survive a CSV round-trip.
+     * This guards against CSV parsing bugs where special characters break field boundaries.
+     */
+    @Test
+    void specialCharactersInName_roundTrip() {
+        Adopter a = buildAdopter("Smith, John \"JJ\"");
+        repo.save(a);
+
+        Adopter loaded = repo.findById(a.getId()).orElseThrow();
+        assertEquals("Smith, John \"JJ\"", loaded.getName());
+    }
+}

--- a/src/test/java/shelter/repository/csv/CsvAdoptionRequestRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvAdoptionRequestRepositoryTest.java
@@ -1,0 +1,216 @@
+package shelter.repository.csv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Adopter;
+import shelter.domain.AdopterPreferences;
+import shelter.domain.AdoptionRequest;
+import shelter.domain.DailySchedule;
+import shelter.domain.Dog;
+import shelter.domain.LivingSpace;
+import shelter.domain.RequestStatus;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CsvAdoptionRequestRepository}, verifying all CRUD and query operations
+ * including shelter-based and status-based filtering.
+ * Uses a JUnit {@code @TempDir} and real backing CSV repositories to avoid mocking complexity.
+ */
+class CsvAdoptionRequestRepositoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CsvAnimalRepository animalRepo;
+    private CsvAdopterRepository adopterRepo;
+    private CsvAdoptionRequestRepository repo;
+
+    /** A reusable adopter instance saved to the backing adopter repository. */
+    private Adopter adopter;
+    /** A reusable dog instance saved to the backing animal repository. */
+    private Dog dog;
+
+    /**
+     * Sets up fresh backing repositories and seeds one adopter and one dog before each test.
+     * The seeded entities provide valid cross-repository references for request construction.
+     */
+    @BeforeEach
+    void setUp() {
+        animalRepo  = new CsvAnimalRepository(tempDir.toString());
+        adopterRepo = new CsvAdopterRepository(tempDir.toString());
+        repo        = new CsvAdoptionRequestRepository(tempDir.toString(), animalRepo, adopterRepo);
+
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, 0, 20);
+        adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, null, prefs);
+        adopterRepo.save(adopter);
+
+        dog = new Dog("Rex", "Lab", 3, ActivityLevel.HIGH, true, Dog.Size.LARGE, false);
+        dog.setShelterId("shelter-1");
+        animalRepo.save(dog);
+    }
+
+    /**
+     * Verifies that a saved AdoptionRequest can be retrieved by ID with all fields preserved.
+     */
+    @Test
+    void saveAndFindById_returnsSameRequest() {
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        repo.save(req);
+
+        Optional<AdoptionRequest> found = repo.findById(req.getId());
+        assertTrue(found.isPresent());
+        AdoptionRequest loaded = found.get();
+        assertEquals(req.getId(), loaded.getId());
+        assertEquals(adopter.getId(), loaded.getAdopter().getId());
+        assertEquals(dog.getId(), loaded.getAnimal().getId());
+        assertEquals(RequestStatus.PENDING, loaded.getStatus());
+        assertNotNull(loaded.getSubmittedAt());
+    }
+
+    /**
+     * Verifies that findAll returns all saved requests.
+     */
+    @Test
+    void findAll_returnsAllSaved() {
+        repo.save(new AdoptionRequest(adopter, dog));
+        Dog dog2 = new Dog("Buddy", "Poodle", 2, ActivityLevel.LOW, false, Dog.Size.SMALL, true);
+        dog2.setShelterId("shelter-1");
+        animalRepo.save(dog2);
+        repo.save(new AdoptionRequest(adopter, dog2));
+
+        assertEquals(2, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that delete removes the request from the store.
+     */
+    @Test
+    void delete_removesRequest() {
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        repo.save(req);
+        repo.delete(req.getId());
+
+        assertTrue(repo.findById(req.getId()).isEmpty());
+    }
+
+    /**
+     * Verifies that findById returns empty for an unknown ID.
+     */
+    @Test
+    void findById_unknownId_returnsEmpty() {
+        assertTrue(repo.findById("no-such-id").isEmpty());
+    }
+
+    /**
+     * Verifies that findByAdopterId returns requests only for the given adopter.
+     */
+    @Test
+    void findByAdopterId_filtersCorrectly() {
+        repo.save(new AdoptionRequest(adopter, dog));
+
+        List<AdoptionRequest> result = repo.findByAdopterId(adopter.getId());
+        assertEquals(1, result.size());
+        assertEquals(adopter.getId(), result.get(0).getAdopter().getId());
+    }
+
+    /**
+     * Verifies that findByShelterId returns requests for animals in the given shelter.
+     */
+    @Test
+    void findByShelterId_filtersCorrectly() {
+        repo.save(new AdoptionRequest(adopter, dog)); // dog is in shelter-1
+
+        // Dog in a different shelter
+        Dog dog2 = new Dog("Other", "Mutt", 1, ActivityLevel.LOW, false, Dog.Size.SMALL, false);
+        dog2.setShelterId("shelter-2");
+        animalRepo.save(dog2);
+        repo.save(new AdoptionRequest(adopter, dog2));
+
+        List<AdoptionRequest> s1Requests = repo.findByShelterId("shelter-1");
+        assertEquals(1, s1Requests.size());
+        assertEquals(dog.getId(), s1Requests.get(0).getAnimal().getId());
+    }
+
+    /**
+     * Verifies that findByStatus returns only requests matching the given status.
+     */
+    @Test
+    void findByStatus_filtersCorrectly() {
+        AdoptionRequest pending = new AdoptionRequest(adopter, dog);
+        repo.save(pending);
+
+        Dog dog2 = new Dog("Buddy2", "Beagle", 2, ActivityLevel.MEDIUM, true, Dog.Size.MEDIUM, false);
+        dog2.setShelterId("shelter-1");
+        animalRepo.save(dog2);
+        AdoptionRequest approved = new AdoptionRequest(adopter, dog2);
+        approved.approve();
+        repo.save(approved);
+
+        List<AdoptionRequest> pendingList = repo.findByStatus(RequestStatus.PENDING);
+        assertEquals(1, pendingList.size());
+        assertEquals(pending.getId(), pendingList.get(0).getId());
+
+        List<AdoptionRequest> approvedList = repo.findByStatus(RequestStatus.APPROVED);
+        assertEquals(1, approvedList.size());
+        assertEquals(approved.getId(), approvedList.get(0).getId());
+    }
+
+    /**
+     * Verifies findByAdopterIdAndStatus combines both filters correctly.
+     */
+    @Test
+    void findByAdopterIdAndStatus_combinedFilter() {
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        repo.save(req);
+
+        List<AdoptionRequest> result =
+                repo.findByAdopterIdAndStatus(adopter.getId(), RequestStatus.PENDING);
+        assertEquals(1, result.size());
+
+        List<AdoptionRequest> noMatch =
+                repo.findByAdopterIdAndStatus(adopter.getId(), RequestStatus.APPROVED);
+        assertEquals(0, noMatch.size());
+    }
+
+    /**
+     * Verifies findByShelterIdAndStatus combines shelter and status filters.
+     */
+    @Test
+    void findByShelterIdAndStatus_combinedFilter() {
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        repo.save(req);
+
+        List<AdoptionRequest> pending =
+                repo.findByShelterIdAndStatus("shelter-1", RequestStatus.PENDING);
+        assertEquals(1, pending.size());
+
+        List<AdoptionRequest> approved =
+                repo.findByShelterIdAndStatus("shelter-1", RequestStatus.APPROVED);
+        assertEquals(0, approved.size());
+    }
+
+    /**
+     * Verifies CSV round-trip: requests saved in one instance are readable in a new instance
+     * with the original status and timestamp preserved.
+     */
+    @Test
+    void persistence_roundTrip() {
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        repo.save(req);
+
+        CsvAdoptionRequestRepository repo2 =
+                new CsvAdoptionRequestRepository(tempDir.toString(), animalRepo, adopterRepo);
+        Optional<AdoptionRequest> found = repo2.findById(req.getId());
+        assertTrue(found.isPresent());
+        assertEquals(RequestStatus.PENDING, found.get().getStatus());
+        assertEquals(req.getSubmittedAt(), found.get().getSubmittedAt());
+    }
+}

--- a/src/test/java/shelter/repository/csv/CsvAnimalRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvAnimalRepositoryTest.java
@@ -1,0 +1,183 @@
+package shelter.repository.csv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Animal;
+import shelter.domain.Cat;
+import shelter.domain.Dog;
+import shelter.domain.Rabbit;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CsvAnimalRepository}, verifying CRUD operations and query methods
+ * for all three concrete animal types using a JUnit {@code @TempDir}.
+ */
+class CsvAnimalRepositoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CsvAnimalRepository repo;
+
+    /**
+     * Creates a fresh repository backed by the JUnit temp directory before each test.
+     * This guarantees tests are isolated and never share persisted state.
+     */
+    @BeforeEach
+    void setUp() {
+        repo = new CsvAnimalRepository(tempDir.toString());
+    }
+
+    /**
+     * Verifies that a saved Dog can be retrieved by ID with all base and species-specific
+     * fields intact, including size and neutered status.
+     */
+    @Test
+    void saveAndFindById_dog_returnsCorrectFields() {
+        Dog dog = new Dog("Rex", "Labrador", 3, ActivityLevel.HIGH, true, Dog.Size.LARGE, true);
+        dog.setShelterId("shelter-1");
+        repo.save(dog);
+
+        Optional<Animal> found = repo.findById(dog.getId());
+        assertTrue(found.isPresent());
+        Dog loaded = (Dog) found.get();
+        assertEquals(dog.getId(), loaded.getId());
+        assertEquals("Rex", loaded.getName());
+        assertEquals("Labrador", loaded.getBreed());
+        assertEquals(3, loaded.getAge());
+        assertEquals(ActivityLevel.HIGH, loaded.getActivityLevel());
+        assertTrue(loaded.isVaccinated());
+        assertEquals(Dog.Size.LARGE, loaded.getSize());
+        assertTrue(loaded.isNeutered());
+        assertEquals("shelter-1", loaded.getShelterId());
+    }
+
+    /**
+     * Verifies that a saved Cat is round-tripped with its indoor and neutered flags preserved.
+     */
+    @Test
+    void saveAndFindById_cat_returnsCorrectFields() {
+        Cat cat = new Cat("Whiskers", "Siamese", 2, ActivityLevel.LOW, false, true, false);
+        cat.setShelterId("shelter-2");
+        repo.save(cat);
+
+        Cat loaded = (Cat) repo.findById(cat.getId()).orElseThrow();
+        assertEquals("Whiskers", loaded.getName());
+        assertTrue(loaded.isIndoor());
+        assertFalse(loaded.isNeutered());
+        assertEquals("shelter-2", loaded.getShelterId());
+    }
+
+    /**
+     * Verifies that a saved Rabbit is round-tripped with its fur length preserved.
+     */
+    @Test
+    void saveAndFindById_rabbit_returnsCorrectFields() {
+        Rabbit rabbit = new Rabbit("Fluffy", "Holland Lop", 1, ActivityLevel.MEDIUM, true, Rabbit.FurLength.LONG);
+        rabbit.setShelterId("shelter-3");
+        repo.save(rabbit);
+
+        Rabbit loaded = (Rabbit) repo.findById(rabbit.getId()).orElseThrow();
+        assertEquals("Fluffy", loaded.getName());
+        assertEquals(Rabbit.FurLength.LONG, loaded.getFurLength());
+    }
+
+    /**
+     * Verifies that findAll returns all animals across all species.
+     */
+    @Test
+    void findAll_returnsAllSavedAnimals() {
+        repo.save(new Dog("Dog1", "Breed", 1, ActivityLevel.LOW, false, Dog.Size.SMALL, false));
+        repo.save(new Cat("Cat1", "Breed", 2, ActivityLevel.MEDIUM, true, false, true));
+        repo.save(new Rabbit("Rabbit1", "Breed", 3, ActivityLevel.HIGH, false, Rabbit.FurLength.SHORT));
+
+        assertEquals(3, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that delete removes the animal from the store and findById returns empty.
+     */
+    @Test
+    void delete_removesAnimal() {
+        Dog dog = new Dog("ToDelete", "Breed", 2, ActivityLevel.MEDIUM, false, Dog.Size.MEDIUM, false);
+        repo.save(dog);
+        repo.delete(dog.getId());
+
+        assertTrue(repo.findById(dog.getId()).isEmpty());
+        assertEquals(0, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that findById returns empty for an unknown ID.
+     */
+    @Test
+    void findById_unknownId_returnsEmpty() {
+        assertTrue(repo.findById("no-such-id").isEmpty());
+    }
+
+    /**
+     * Verifies that findByShelterId filters animals by their shelter ID.
+     */
+    @Test
+    void findByShelterId_filtersCorrectly() {
+        Dog dog1 = new Dog("D1", "Breed", 1, ActivityLevel.LOW, false, Dog.Size.SMALL, false);
+        dog1.setShelterId("shelter-A");
+        Dog dog2 = new Dog("D2", "Breed", 2, ActivityLevel.LOW, false, Dog.Size.SMALL, false);
+        dog2.setShelterId("shelter-B");
+        repo.save(dog1);
+        repo.save(dog2);
+
+        List<Animal> inA = repo.findByShelterId("shelter-A");
+        assertEquals(1, inA.size());
+        assertEquals("D1", inA.get(0).getName());
+    }
+
+    /**
+     * Verifies that findByAdopterId returns only animals adopted by the specified adopter.
+     */
+    @Test
+    void findByAdopterId_filtersCorrectly() {
+        Dog dog = new Dog("Buddy", "Breed", 4, ActivityLevel.MEDIUM, true, Dog.Size.MEDIUM, true);
+        dog.setShelterId("shelter-X");
+        dog.setAdopterId("adopter-99");
+        repo.save(dog);
+
+        List<Animal> adopted = repo.findByAdopterId("adopter-99");
+        assertEquals(1, adopted.size());
+        assertEquals("Buddy", adopted.get(0).getName());
+    }
+
+    /**
+     * Verifies that an animal with a null adopterId (available) is not returned by findByAdopterId.
+     */
+    @Test
+    void findByAdopterId_availableAnimal_notReturned() {
+        Dog dog = new Dog("Available", "Breed", 2, ActivityLevel.LOW, false, Dog.Size.SMALL, false);
+        dog.setShelterId("shelter-X");
+        repo.save(dog);
+
+        assertTrue(repo.findByAdopterId("some-adopter").isEmpty());
+    }
+
+    /**
+     * Verifies CSV round-trip: animals saved in one instance are readable in a new instance.
+     */
+    @Test
+    void persistence_roundTrip() {
+        Dog dog = new Dog("Persistent", "Beagle", 5, ActivityLevel.MEDIUM, true, Dog.Size.SMALL, false);
+        dog.setShelterId("s1");
+        repo.save(dog);
+
+        CsvAnimalRepository repo2 = new CsvAnimalRepository(tempDir.toString());
+        Optional<Animal> found = repo2.findById(dog.getId());
+        assertTrue(found.isPresent());
+        assertEquals("Persistent", found.get().getName());
+    }
+}

--- a/src/test/java/shelter/repository/csv/CsvShelterRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvShelterRepositoryTest.java
@@ -1,0 +1,128 @@
+package shelter.repository.csv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.Shelter;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CsvShelterRepository}, verifying all CRUD operations and query methods
+ * using a temporary directory so no real filesystem state is affected by the tests.
+ */
+class CsvShelterRepositoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CsvShelterRepository repo;
+
+    /**
+     * Creates a fresh repository backed by the JUnit temp directory before each test.
+     * This guarantees tests are isolated and never share persisted state.
+     */
+    @BeforeEach
+    void setUp() {
+        repo = new CsvShelterRepository(tempDir.toString());
+    }
+
+    /**
+     * Verifies that a saved shelter can be retrieved by its ID with all fields intact.
+     */
+    @Test
+    void saveAndFindById_returnsSameShelter() {
+        Shelter s = new Shelter("Happy Paws", "Boston", 20);
+        repo.save(s);
+
+        Optional<Shelter> found = repo.findById(s.getId());
+        assertTrue(found.isPresent());
+        assertEquals(s.getId(), found.get().getId());
+        assertEquals("Happy Paws", found.get().getName());
+        assertEquals("Boston", found.get().getLocation());
+        assertEquals(20, found.get().getCapacity());
+    }
+
+    /**
+     * Verifies that findAll returns all shelters that have been saved.
+     */
+    @Test
+    void findAll_returnsAllSavedShelters() {
+        Shelter s1 = new Shelter("Alpha", "City A", 10);
+        Shelter s2 = new Shelter("Beta",  "City B", 15);
+        repo.save(s1);
+        repo.save(s2);
+
+        List<Shelter> all = repo.findAll();
+        assertEquals(2, all.size());
+    }
+
+    /**
+     * Verifies that deleting a shelter removes it from the store and findById returns empty.
+     */
+    @Test
+    void delete_removesFromStore() {
+        Shelter s = new Shelter("ToDelete", "Somewhere", 5);
+        repo.save(s);
+        repo.delete(s.getId());
+
+        assertTrue(repo.findById(s.getId()).isEmpty());
+        assertEquals(0, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that findById returns an empty Optional for an ID that was never saved.
+     */
+    @Test
+    void findById_unknownId_returnsEmpty() {
+        assertTrue(repo.findById("nonexistent-id").isEmpty());
+    }
+
+    /**
+     * Verifies that data persisted in one repository instance is readable by a second instance
+     * pointing to the same directory, confirming CSV round-trip correctness.
+     */
+    @Test
+    void persistence_roundTrip_surviveNewInstance() {
+        Shelter s = new Shelter("Persisted", "Testville", 8);
+        repo.save(s);
+
+        CsvShelterRepository repo2 = new CsvShelterRepository(tempDir.toString());
+        Optional<Shelter> found = repo2.findById(s.getId());
+        assertTrue(found.isPresent());
+        assertEquals("Persisted", found.get().getName());
+    }
+
+    /**
+     * Verifies that saving a shelter twice (same ID) overwrites the previous record.
+     */
+    @Test
+    void save_overwritesExistingRecord() {
+        Shelter s = new Shelter("Original", "Place", 10);
+        repo.save(s);
+        // shelters are immutable after construction, so just save again (upsert path)
+        repo.save(s);
+        assertEquals(1, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that constructing the repository with a null dataDir throws
+     * {@link IllegalArgumentException}.
+     */
+    @Test
+    void constructor_nullDataDir_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> new CsvShelterRepository(null));
+    }
+
+    /**
+     * Verifies that findById with a null ID throws {@link IllegalArgumentException}.
+     */
+    @Test
+    void findById_nullId_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> repo.findById(null));
+    }
+}

--- a/src/test/java/shelter/repository/csv/CsvTransferRequestRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvTransferRequestRepositoryTest.java
@@ -1,0 +1,227 @@
+package shelter.repository.csv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Dog;
+import shelter.domain.RequestStatus;
+import shelter.domain.Shelter;
+import shelter.domain.TransferRequest;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CsvTransferRequestRepository}, verifying all CRUD and query operations
+ * including shelter-based and animal-based filtering.
+ * Uses real backing CSV repositories to avoid mocking complexity.
+ */
+class CsvTransferRequestRepositoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CsvAnimalRepository animalRepo;
+    private CsvShelterRepository shelterRepo;
+    private CsvTransferRequestRepository repo;
+
+    /** Reusable shelters and animal seeded before each test. */
+    private Shelter shelterA;
+    private Shelter shelterB;
+    private Dog dog;
+
+    /**
+     * Creates fresh backing repositories and seeds two shelters and one dog before each test.
+     * The seeded entities provide valid cross-repository references for request construction.
+     */
+    @BeforeEach
+    void setUp() {
+        animalRepo  = new CsvAnimalRepository(tempDir.toString());
+        shelterRepo = new CsvShelterRepository(tempDir.toString());
+        repo        = new CsvTransferRequestRepository(tempDir.toString(), animalRepo, shelterRepo);
+
+        shelterA = new Shelter("Shelter Alpha", "City A", 20);
+        shelterB = new Shelter("Shelter Beta",  "City B", 20);
+        shelterRepo.save(shelterA);
+        shelterRepo.save(shelterB);
+
+        dog = new Dog("Rex", "Lab", 3, ActivityLevel.HIGH, true, Dog.Size.LARGE, false);
+        dog.setShelterId(shelterA.getId());
+        animalRepo.save(dog);
+    }
+
+    /**
+     * Verifies that a saved TransferRequest can be retrieved by ID with all fields preserved.
+     */
+    @Test
+    void saveAndFindById_returnsSameRequest() {
+        TransferRequest req = new TransferRequest(dog, shelterA, shelterB);
+        repo.save(req);
+
+        Optional<TransferRequest> found = repo.findById(req.getId());
+        assertTrue(found.isPresent());
+        TransferRequest loaded = found.get();
+        assertEquals(req.getId(), loaded.getId());
+        assertEquals(dog.getId(), loaded.getAnimal().getId());
+        assertEquals(shelterA.getId(), loaded.getFrom().getId());
+        assertEquals(shelterB.getId(), loaded.getTo().getId());
+        assertEquals(RequestStatus.PENDING, loaded.getStatus());
+        assertNotNull(loaded.getRequestedAt());
+    }
+
+    /**
+     * Verifies that findAll returns all saved requests.
+     */
+    @Test
+    void findAll_returnsAllSaved() {
+        repo.save(new TransferRequest(dog, shelterA, shelterB));
+        Dog dog2 = new Dog("Buddy", "Poodle", 2, ActivityLevel.LOW, false, Dog.Size.SMALL, false);
+        dog2.setShelterId(shelterB.getId());
+        animalRepo.save(dog2);
+        repo.save(new TransferRequest(dog2, shelterB, shelterA));
+
+        assertEquals(2, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that delete removes the request from the store.
+     */
+    @Test
+    void delete_removesRequest() {
+        TransferRequest req = new TransferRequest(dog, shelterA, shelterB);
+        repo.save(req);
+        repo.delete(req.getId());
+
+        assertTrue(repo.findById(req.getId()).isEmpty());
+    }
+
+    /**
+     * Verifies that findById returns empty for an unknown ID.
+     */
+    @Test
+    void findById_unknownId_returnsEmpty() {
+        assertTrue(repo.findById("unknown").isEmpty());
+    }
+
+    /**
+     * Verifies that findByAnimalId returns requests only for the given animal.
+     */
+    @Test
+    void findByAnimalId_filtersCorrectly() {
+        repo.save(new TransferRequest(dog, shelterA, shelterB));
+
+        List<TransferRequest> result = repo.findByAnimalId(dog.getId());
+        assertEquals(1, result.size());
+        assertEquals(dog.getId(), result.get(0).getAnimal().getId());
+    }
+
+    /**
+     * Verifies that findByFromShelterId returns requests whose source matches the given shelter.
+     */
+    @Test
+    void findByFromShelterId_filtersCorrectly() {
+        repo.save(new TransferRequest(dog, shelterA, shelterB));
+
+        assertEquals(1, repo.findByFromShelterId(shelterA.getId()).size());
+        assertEquals(0, repo.findByFromShelterId(shelterB.getId()).size());
+    }
+
+    /**
+     * Verifies that findByToShelterId returns requests whose destination matches the given shelter.
+     */
+    @Test
+    void findByToShelterId_filtersCorrectly() {
+        repo.save(new TransferRequest(dog, shelterA, shelterB));
+
+        assertEquals(1, repo.findByToShelterId(shelterB.getId()).size());
+        assertEquals(0, repo.findByToShelterId(shelterA.getId()).size());
+    }
+
+    /**
+     * Verifies that findByStatus returns only requests with the matching status.
+     */
+    @Test
+    void findByStatus_filtersCorrectly() {
+        TransferRequest pending = new TransferRequest(dog, shelterA, shelterB);
+        repo.save(pending);
+
+        Dog dog2 = new Dog("Dog2", "Mutt", 1, ActivityLevel.LOW, false, Dog.Size.SMALL, false);
+        dog2.setShelterId(shelterB.getId());
+        animalRepo.save(dog2);
+        TransferRequest approved = new TransferRequest(dog2, shelterB, shelterA);
+        approved.approve();
+        repo.save(approved);
+
+        assertEquals(1, repo.findByStatus(RequestStatus.PENDING).size());
+        assertEquals(1, repo.findByStatus(RequestStatus.APPROVED).size());
+    }
+
+    /**
+     * Verifies findByShelterIdAndStatus matches the shelter ID against BOTH from and to fields.
+     */
+    @Test
+    void findByShelterIdAndStatus_matchesBothFromAndTo() {
+        // shelterA is the source
+        TransferRequest fromA = new TransferRequest(dog, shelterA, shelterB);
+        repo.save(fromA);
+
+        // shelterA is the destination
+        Dog dog2 = new Dog("Dog2", "Breed", 2, ActivityLevel.LOW, false, Dog.Size.SMALL, false);
+        dog2.setShelterId(shelterB.getId());
+        animalRepo.save(dog2);
+        TransferRequest toA = new TransferRequest(dog2, shelterB, shelterA);
+        repo.save(toA);
+
+        List<TransferRequest> result =
+                repo.findByShelterIdAndStatus(shelterA.getId(), RequestStatus.PENDING);
+        assertEquals(2, result.size(), "Both from-A and to-A requests should be found");
+    }
+
+    /**
+     * Verifies findByAnimalIdAndStatus combines both filters correctly.
+     */
+    @Test
+    void findByAnimalIdAndStatus_combinedFilter() {
+        TransferRequest req = new TransferRequest(dog, shelterA, shelterB);
+        repo.save(req);
+
+        List<TransferRequest> pending =
+                repo.findByAnimalIdAndStatus(dog.getId(), RequestStatus.PENDING);
+        assertEquals(1, pending.size());
+
+        List<TransferRequest> approved =
+                repo.findByAnimalIdAndStatus(dog.getId(), RequestStatus.APPROVED);
+        assertEquals(0, approved.size());
+    }
+
+    /**
+     * Verifies CSV round-trip: requests saved in one instance are readable in a new instance
+     * with status and timestamp preserved.
+     */
+    @Test
+    void persistence_roundTrip() {
+        TransferRequest req = new TransferRequest(dog, shelterA, shelterB);
+        repo.save(req);
+
+        CsvTransferRequestRepository repo2 =
+                new CsvTransferRequestRepository(tempDir.toString(), animalRepo, shelterRepo);
+        Optional<TransferRequest> found = repo2.findById(req.getId());
+        assertTrue(found.isPresent());
+        assertEquals(RequestStatus.PENDING, found.get().getStatus());
+        assertEquals(req.getRequestedAt(), found.get().getRequestedAt());
+    }
+
+    /**
+     * Verifies that constructing the repository with a null ShelterRepository throws
+     * {@link IllegalArgumentException}.
+     */
+    @Test
+    void constructor_nullShelterRepository_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CsvTransferRequestRepository(tempDir.toString(), animalRepo, null));
+    }
+}

--- a/src/test/java/shelter/repository/csv/CsvVaccinationRecordRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvVaccinationRecordRepositoryTest.java
@@ -1,0 +1,150 @@
+package shelter.repository.csv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Dog;
+import shelter.domain.VaccinationRecord;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CsvVaccinationRecordRepository}, verifying all CRUD and query operations
+ * using a JUnit {@code @TempDir} so tests never touch the real filesystem.
+ */
+class CsvVaccinationRecordRepositoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CsvAnimalRepository animalRepo;
+    private CsvVaccinationRecordRepository repo;
+
+    /**
+     * Creates fresh backing repositories before each test.
+     * Uses a real {@link CsvAnimalRepository} so the shelter-based lookup is exercised end-to-end.
+     */
+    @BeforeEach
+    void setUp() {
+        animalRepo = new CsvAnimalRepository(tempDir.toString());
+        repo = new CsvVaccinationRecordRepository(tempDir.toString(), animalRepo);
+    }
+
+    /**
+     * Verifies that a saved VaccinationRecord can be retrieved by ID with all fields intact.
+     */
+    @Test
+    void saveAndFindById_returnsSameRecord() {
+        VaccinationRecord rec = new VaccinationRecord("animal-1", "vaccine-1", LocalDate.of(2025, 1, 15));
+        repo.save(rec);
+
+        Optional<VaccinationRecord> found = repo.findById(rec.getId());
+        assertTrue(found.isPresent());
+        assertEquals(rec.getId(), found.get().getId());
+        assertEquals("animal-1", found.get().getAnimalId());
+        assertEquals("vaccine-1", found.get().getVaccineTypeId());
+        assertEquals(LocalDate.of(2025, 1, 15), found.get().getDateAdministered());
+    }
+
+    /**
+     * Verifies that findAll returns all saved records.
+     */
+    @Test
+    void findAll_returnsAllSaved() {
+        repo.save(new VaccinationRecord("a1", "v1", LocalDate.of(2025, 1, 1)));
+        repo.save(new VaccinationRecord("a2", "v2", LocalDate.of(2025, 2, 1)));
+
+        assertEquals(2, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that delete removes the record from the store.
+     */
+    @Test
+    void delete_removesRecord() {
+        VaccinationRecord rec = new VaccinationRecord("a1", "v1", LocalDate.of(2025, 1, 1));
+        repo.save(rec);
+        repo.delete(rec.getId());
+
+        assertTrue(repo.findById(rec.getId()).isEmpty());
+    }
+
+    /**
+     * Verifies that findById returns empty for an unknown ID.
+     */
+    @Test
+    void findById_unknownId_returnsEmpty() {
+        assertTrue(repo.findById("no-such-id").isEmpty());
+    }
+
+    /**
+     * Verifies that findByAnimalId returns only records for the requested animal.
+     */
+    @Test
+    void findByAnimalId_filtersCorrectly() {
+        repo.save(new VaccinationRecord("animal-A", "v1", LocalDate.of(2025, 1, 1)));
+        repo.save(new VaccinationRecord("animal-A", "v2", LocalDate.of(2025, 3, 1)));
+        repo.save(new VaccinationRecord("animal-B", "v1", LocalDate.of(2025, 2, 1)));
+
+        List<VaccinationRecord> forA = repo.findByAnimalId("animal-A");
+        assertEquals(2, forA.size());
+        forA.forEach(r -> assertEquals("animal-A", r.getAnimalId()));
+    }
+
+    /**
+     * Verifies that findByAnimalId returns an empty list when there are no records for that animal.
+     */
+    @Test
+    void findByAnimalId_noMatch_returnsEmpty() {
+        assertTrue(repo.findByAnimalId("unknown-animal").isEmpty());
+    }
+
+    /**
+     * Verifies findByShelterId returns records for animals in the specified shelter.
+     */
+    @Test
+    void findByShelterId_returnsRecordsForAnimalsInShelter() {
+        Dog dog = new Dog("Rex", "Lab", 3, ActivityLevel.HIGH, true, Dog.Size.LARGE, false);
+        dog.setShelterId("shelter-X");
+        animalRepo.save(dog);
+
+        VaccinationRecord rec = new VaccinationRecord(dog.getId(), "v1", LocalDate.of(2025, 1, 1));
+        repo.save(rec);
+
+        // Record for a different shelter
+        repo.save(new VaccinationRecord("other-animal", "v2", LocalDate.of(2025, 1, 1)));
+
+        List<VaccinationRecord> result = repo.findByShelterId("shelter-X");
+        assertEquals(1, result.size());
+        assertEquals(dog.getId(), result.get(0).getAnimalId());
+    }
+
+    /**
+     * Verifies CSV round-trip: records saved in one instance are readable in a new instance.
+     */
+    @Test
+    void persistence_roundTrip() {
+        VaccinationRecord rec = new VaccinationRecord("a1", "v1", LocalDate.of(2025, 6, 15));
+        repo.save(rec);
+
+        CsvVaccinationRecordRepository repo2 =
+                new CsvVaccinationRecordRepository(tempDir.toString(), animalRepo);
+        assertTrue(repo2.findById(rec.getId()).isPresent());
+        assertEquals(LocalDate.of(2025, 6, 15), repo2.findById(rec.getId()).get().getDateAdministered());
+    }
+
+    /**
+     * Verifies that constructing the repository with a null AnimalRepository throws
+     * {@link IllegalArgumentException}.
+     */
+    @Test
+    void constructor_nullAnimalRepository_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CsvVaccinationRecordRepository(tempDir.toString(), null));
+    }
+}

--- a/src/test/java/shelter/repository/csv/CsvVaccineTypeRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvVaccineTypeRepositoryTest.java
@@ -1,0 +1,128 @@
+package shelter.repository.csv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.Species;
+import shelter.domain.VaccineType;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CsvVaccineTypeRepository}, verifying all CRUD operations and query methods
+ * using a temporary directory so no real filesystem state is affected.
+ */
+class CsvVaccineTypeRepositoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CsvVaccineTypeRepository repo;
+
+    /**
+     * Creates a fresh repository backed by the JUnit temp directory before each test.
+     * This guarantees tests are isolated and never share persisted state.
+     */
+    @BeforeEach
+    void setUp() {
+        repo = new CsvVaccineTypeRepository(tempDir.toString());
+    }
+
+    /**
+     * Verifies that a saved VaccineType can be retrieved by ID with all fields intact.
+     */
+    @Test
+    void saveAndFindById_returnsSameVaccineType() {
+        VaccineType vt = new VaccineType("Rabies", Species.DOG, 365);
+        repo.save(vt);
+
+        Optional<VaccineType> found = repo.findById(vt.getId());
+        assertTrue(found.isPresent());
+        assertEquals(vt.getId(), found.get().getId());
+        assertEquals("Rabies", found.get().getName());
+        assertEquals(Species.DOG, found.get().getApplicableSpecies());
+        assertEquals(365, found.get().getValidityDays());
+    }
+
+    /**
+     * Verifies that findAll returns all saved VaccineType records.
+     */
+    @Test
+    void findAll_returnsAllSaved() {
+        repo.save(new VaccineType("Rabies", Species.DOG, 365));
+        repo.save(new VaccineType("FVRCP", Species.CAT, 365));
+
+        assertEquals(2, repo.findAll().size());
+    }
+
+    /**
+     * Verifies that delete removes a VaccineType from the store.
+     */
+    @Test
+    void delete_removesRecord() {
+        VaccineType vt = new VaccineType("ToDelete", Species.RABBIT, 180);
+        repo.save(vt);
+        repo.delete(vt.getId());
+
+        assertTrue(repo.findById(vt.getId()).isEmpty());
+    }
+
+    /**
+     * Verifies that findById returns empty for an unknown ID.
+     */
+    @Test
+    void findById_unknownId_returnsEmpty() {
+        assertTrue(repo.findById("unknown").isEmpty());
+    }
+
+    /**
+     * Verifies that findByName performs a case-insensitive lookup.
+     */
+    @Test
+    void findByName_caseInsensitive() {
+        repo.save(new VaccineType("Rabies", Species.DOG, 365));
+
+        Optional<VaccineType> found = repo.findByName("rabies");
+        assertTrue(found.isPresent());
+        assertEquals("Rabies", found.get().getName());
+    }
+
+    /**
+     * Verifies that findByName returns empty when no match exists.
+     */
+    @Test
+    void findByName_noMatch_returnsEmpty() {
+        assertTrue(repo.findByName("Unknown Vaccine").isEmpty());
+    }
+
+    /**
+     * Verifies that findByApplicableSpecies filters correctly by species.
+     */
+    @Test
+    void findByApplicableSpecies_filtersCorrectly() {
+        repo.save(new VaccineType("Rabies", Species.DOG, 365));
+        repo.save(new VaccineType("FVRCP", Species.CAT, 365));
+        repo.save(new VaccineType("DogBooster", Species.DOG, 180));
+
+        List<VaccineType> dogs = repo.findByApplicableSpecies(Species.DOG);
+        assertEquals(2, dogs.size());
+        dogs.forEach(vt -> assertEquals(Species.DOG, vt.getApplicableSpecies()));
+    }
+
+    /**
+     * Verifies CSV round-trip: records saved in one instance are readable in a new instance.
+     */
+    @Test
+    void persistence_roundTrip() {
+        VaccineType vt = new VaccineType("FVRCP", Species.CAT, 365);
+        repo.save(vt);
+
+        CsvVaccineTypeRepository repo2 = new CsvVaccineTypeRepository(tempDir.toString());
+        assertTrue(repo2.findById(vt.getId()).isPresent());
+        assertEquals("FVRCP", repo2.findById(vt.getId()).get().getName());
+    }
+}


### PR DESCRIPTION
## Summary

- **Species enum**: Replace error-prone `String` species literals with a type-safe `Species` enum (`DOG`, `CAT`, `RABBIT`, `OTHER`) across domain, strategy, and test layers
- **Application Layer interfaces**: Add 9 interfaces (`shelter.application`) covering all use cases UC-00 through UC-08
- **Repository Layer interfaces**: Add 7 interfaces (`shelter.repository`) with typed query methods for all domain entities
- **Domain reconstruction constructors**: Add full constructors accepting `id` as first parameter to all entity classes, enabling exact CSV round-trip deserialization
- **CSV repository implementations**: Add `CsvUtils` + 7 `CsvXxxRepository` classes under `shelter.repository.csv`, each persisting to `~/shelter/data/` with in-memory caching
- **140 passing tests**: Full JUnit 5 coverage for all CSV repositories including CRUD, upsert, null round-trips, special characters, and cross-instance persistence

## Test plan
- [ ] Run `./gradlew test` — all 140 tests pass, 0 failures
- [ ] Verify no compilation errors across all layers
- [ ] Confirm no raw `"Dog"`/`"Cat"`/`"Rabbit"` string literals remain in production code
