### PR TITLE
fix(repository): add findByAnimalId to AdoptionRequestRepository

### DIFF
--- a/src/main/java/shelter/repository/AdoptionRequestRepository.java
+++ b/src/main/java/shelter/repository/AdoptionRequestRepository.java
@@ -51,6 +51,15 @@ public interface AdoptionRequestRepository {
     List<AdoptionRequest> findByAdopterId(String adopterId);
 
     /**
+     * Returns all adoption requests targeting the given animal ID.
+     * Returns an empty list if no requests exist for that animal.
+     *
+     * @param animalId the animal ID to filter by; must not be null or blank
+     * @return a list of adoption requests for the specified animal
+     */
+    List<AdoptionRequest> findByAnimalId(String animalId);
+
+    /**
      * Returns all adoption requests for animals currently housed in the given
      * shelter. Shelter membership is determined by the animal's
      * {@code shelterId} field. Returns an empty list if no requests exist for

--- a/src/main/java/shelter/repository/csv/CsvAdoptionRequestRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAdoptionRequestRepository.java
@@ -204,6 +204,25 @@ public class CsvAdoptionRequestRepository implements AdoptionRequestRepository {
 
     /**
      * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code animalId} is null or blank
+     */
+    @Override
+    public List<AdoptionRequest> findByAnimalId(String animalId) {
+        if (animalId == null || animalId.isBlank()) {
+            throw new IllegalArgumentException("Animal ID must not be null or blank.");
+        }
+        List<AdoptionRequest> result = new ArrayList<>();
+        for (AdoptionRequest req : store.values()) {
+            if (animalId.equals(req.getAnimal().getId())) {
+                result.add(req);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * {@inheritDoc}
      * Shelter membership is determined by comparing the given {@code shelterId} to
      * each request's {@code animal.getShelterId()}.
      *

--- a/src/test/java/shelter/repository/csv/CsvAdoptionRequestRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvAdoptionRequestRepositoryTest.java
@@ -198,6 +198,23 @@ class CsvAdoptionRequestRepositoryTest {
     }
 
     /**
+     * Verifies that findByAnimalId returns only requests for the specified animal,
+     * and returns an empty list for an animal with no requests.
+     */
+    @Test
+    void findByAnimalId_returnsMatchingRequests() {
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        repo.save(req);
+
+        List<AdoptionRequest> found = repo.findByAnimalId(dog.getId());
+        assertEquals(1, found.size());
+        assertEquals(dog.getId(), found.get(0).getAnimal().getId());
+
+        List<AdoptionRequest> none = repo.findByAnimalId("no-such-animal");
+        assertTrue(none.isEmpty());
+    }
+
+    /**
      * Verifies CSV round-trip: requests saved in one instance are readable in a new instance
      * with the original status and timestamp preserved.
      */


### PR DESCRIPTION
AdoptionService.getRequestsByAnimal() requires querying by animal ID, but the method was missing from the interface and CSV implementation. Added findByAnimalId to both, consistent with TransferRequestRepository. Also added a corresponding test case.