### PR TITLE
Implement audit and notification infrastructure in services

### DIFF
--- a/src/main/java/shelter/repository/AuditRepository.java
+++ b/src/main/java/shelter/repository/AuditRepository.java
@@ -1,0 +1,44 @@
+package shelter.repository;
+
+import shelter.service.model.AuditEntry;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Defines persistence operations for audit log entries across all service operations.
+ * Implementations store entries durably so the audit trail survives beyond a single command execution.
+ * The target object is stored as its string representation, since typed reconstruction is not required
+ * for audit display purposes.
+ */
+public interface AuditRepository {
+
+    /**
+     * Appends a new audit log entry to the persistent store.
+     * All parameters are required; no argument may be null or blank.
+     *
+     * @param staffId           the unique identifier of the staff member who performed the action
+     * @param staffName         the display name of the staff member
+     * @param action            a short description of the action performed (e.g. "approved adoption")
+     * @param targetDescription the string representation of the target object acted upon
+     * @param timestamp         the date and time the action occurred
+     * @throws IllegalArgumentException if any string argument is null or blank, or timestamp is null
+     */
+    void append(String staffId, String staffName, String action,
+                String targetDescription, LocalDateTime timestamp);
+
+    /**
+     * Returns all audit log entries ever persisted, ordered by timestamp ascending.
+     * Returns an empty list if no entries have been recorded.
+     * The target field of each returned entry contains the stored string description.
+     *
+     * @return a list of all audit entries with string-typed targets
+     */
+    List<AuditEntry<String>> findAll();
+
+    /**
+     * Removes all audit entries from the store while preserving the file and its header.
+     * Intended for development and testing use only; do not call in production workflows.
+     */
+    void clear();
+}

--- a/src/main/java/shelter/repository/csv/CsvAuditRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAuditRepository.java
@@ -1,0 +1,174 @@
+package shelter.repository.csv;
+
+import shelter.domain.Staff;
+import shelter.exception.DataPersistenceException;
+import shelter.repository.AuditRepository;
+import shelter.service.model.AuditEntry;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * CSV-backed implementation of {@link AuditRepository} that appends audit log entries
+ * to a flat file named {@code audit.csv}. Unlike other CSV repositories, this one never
+ * rewrites existing entries — each {@link #append} call adds a single line to the end of
+ * the file, preserving the original insertion order of the audit trail.
+ * The {@link #findAll()} method reads the file from disk each time to reflect any
+ * entries written by other invocations of the same command.
+ */
+public class CsvAuditRepository implements AuditRepository {
+
+    private static final String FILE_NAME = "audit.csv";
+    private static final String HEADER = "id,staffId,staffName,action,targetDescription,timestamp";
+    private static final DateTimeFormatter TIMESTAMP_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final Path filePath;
+
+    /**
+     * Constructs a new CsvAuditRepository that appends to a file in the given directory.
+     * If the directory or file does not yet exist, both are created with an appropriate header row.
+     *
+     * @param dataDir the path to the directory containing the CSV file; must not be null or blank
+     * @throws IllegalArgumentException if {@code dataDir} is null or blank
+     * @throws DataPersistenceException if the directory cannot be created or the file cannot be initialised
+     */
+    public CsvAuditRepository(String dataDir) {
+        if (dataDir == null || dataDir.isBlank()) {
+            throw new IllegalArgumentException("Data directory must not be null or blank.");
+        }
+        this.filePath = Paths.get(dataDir, FILE_NAME);
+        initFile();
+    }
+
+    /** Creates the directory and file if they do not already exist. */
+    private void initFile() {
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, HEADER + System.lineSeparator());
+            }
+        } catch (IOException e) {
+            throw new DataPersistenceException(
+                    "Failed to initialise CsvAuditRepository: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * Appends a single CSV row to the end of the audit file without rewriting previous entries.
+     *
+     * @throws IllegalArgumentException if any string argument is null or blank, or timestamp is null
+     * @throws DataPersistenceException if the row cannot be written to disk
+     */
+    @Override
+    public void append(String staffId, String staffName, String action,
+                       String targetDescription, LocalDateTime timestamp) {
+        // Guard: all fields are required for a meaningful audit entry
+        if (staffId == null || staffId.isBlank()) {
+            throw new IllegalArgumentException("Staff ID must not be null or blank.");
+        }
+        if (staffName == null || staffName.isBlank()) {
+            throw new IllegalArgumentException("Staff name must not be null or blank.");
+        }
+        if (action == null || action.isBlank()) {
+            throw new IllegalArgumentException("Action must not be null or blank.");
+        }
+        if (targetDescription == null || targetDescription.isBlank()) {
+            throw new IllegalArgumentException("Target description must not be null or blank.");
+        }
+        if (timestamp == null) {
+            throw new IllegalArgumentException("Timestamp must not be null.");
+        }
+
+        // Build and append the CSV row; generate a unique row ID for traceability
+        String id = java.util.UUID.randomUUID().toString();
+        String row = CsvUtils.escapeCsv(id) + ','
+                + CsvUtils.escapeCsv(staffId) + ','
+                + CsvUtils.escapeCsv(staffName) + ','
+                + CsvUtils.escapeCsv(action) + ','
+                + CsvUtils.escapeCsv(targetDescription) + ','
+                + timestamp.format(TIMESTAMP_FMT)
+                + System.lineSeparator();
+        try {
+            Files.writeString(filePath, row, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            throw new DataPersistenceException(
+                    "Failed to append audit entry to CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * Reads all rows from the audit file on each call to ensure entries from previous
+     * command invocations are included in the returned list.
+     *
+     * @throws DataPersistenceException if the file cannot be read
+     */
+    @Override
+    public List<AuditEntry<String>> findAll() {
+        try {
+            List<String> lines = Files.readAllLines(filePath);
+            List<AuditEntry<String>> result = new ArrayList<>();
+            // Skip header row; parse each subsequent non-blank line
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+                if (line.isEmpty()) continue;
+                try {
+                    result.add(parseLine(line));
+                } catch (Exception e) {
+                    System.err.println("Skipping malformed audit CSV row " + i + ": " + e.getMessage());
+                }
+            }
+            return Collections.unmodifiableList(result);
+        } catch (IOException e) {
+            throw new DataPersistenceException(
+                    "Failed to read audit entries from CSV: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * Overwrites the file with just the header row, effectively clearing all entries.
+     *
+     * @throws DataPersistenceException if the file cannot be written
+     */
+    @Override
+    public void clear() {
+        try {
+            Files.writeString(filePath, HEADER + System.lineSeparator());
+        } catch (IOException e) {
+            throw new DataPersistenceException(
+                    "Failed to clear audit log: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a single CSV row into an {@link AuditEntry} with a String-typed target.
+     * Fields are expected in order: id, staffId, staffName, action, targetDescription, timestamp.
+     * The staffId stored in the row is used only for traceability; the reconstructed Staff object
+     * carries the staffName so it can be displayed without looking up the staff repository.
+     *
+     * @param line a non-empty CSV row
+     * @return the reconstructed audit entry
+     */
+    private AuditEntry<String> parseLine(String line) {
+        String[] parts = CsvUtils.splitCsv(line);
+        String staffName = CsvUtils.unescapeCsv(parts[2]);
+        String action = CsvUtils.unescapeCsv(parts[3]);
+        String targetDescription = CsvUtils.unescapeCsv(parts[4]);
+        LocalDateTime timestamp = LocalDateTime.parse(parts[5].trim(), TIMESTAMP_FMT);
+
+        // Reconstruct a minimal Staff object for display; full Staff lookup is not required here
+        Staff staff = new Staff(staffName);
+        return new AuditEntry<>(staff, action, targetDescription, timestamp);
+    }
+}

--- a/src/main/java/shelter/service/impl/AdoptionServiceImpl.java
+++ b/src/main/java/shelter/service/impl/AdoptionServiceImpl.java
@@ -10,6 +10,7 @@ import shelter.repository.AdoptionRequestRepository;
 import shelter.repository.AnimalRepository;
 import shelter.exception.AnimalNotAvailableException;
 import shelter.service.AdoptionService;
+import shelter.service.AuditService;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -26,20 +27,24 @@ public class AdoptionServiceImpl implements AdoptionService {
     private final AdoptionRequestRepository requestRepository;
     private final AnimalRepository animalRepository;
     private final AdopterRepository adopterRepository;
+    private final AuditService<AdoptionRequest> auditService;
 
     /**
-     * Constructs a new {@code AdoptionServiceImpl} with the required repositories.
-     * All three repositories are needed for the full adoption lifecycle: the request
-     * must be persisted, and both the animal and adopter records updated on approval.
+     * Constructs a new {@code AdoptionServiceImpl} with the required repositories and audit service.
+     * All three repositories are needed for the full adoption lifecycle: the request must be
+     * persisted, and both the animal and adopter records updated on approval. The audit service
+     * records every state-changing operation for traceability.
      *
      * @param requestRepository the repository for adoption request persistence; must not be null
      * @param animalRepository  the repository for animal record persistence; must not be null
      * @param adopterRepository the repository for adopter record persistence; must not be null
-     * @throws IllegalArgumentException if any repository is null
+     * @param auditService      the service used to log adoption operations; must not be null
+     * @throws IllegalArgumentException if any argument is null
      */
     public AdoptionServiceImpl(AdoptionRequestRepository requestRepository,
                                AnimalRepository animalRepository,
-                               AdopterRepository adopterRepository) {
+                               AdopterRepository adopterRepository,
+                               AuditService<AdoptionRequest> auditService) {
         if (requestRepository == null) {
             throw new IllegalArgumentException("AdoptionRequestRepository must not be null.");
         }
@@ -49,9 +54,13 @@ public class AdoptionServiceImpl implements AdoptionService {
         if (adopterRepository == null) {
             throw new IllegalArgumentException("AdopterRepository must not be null.");
         }
+        if (auditService == null) {
+            throw new IllegalArgumentException("AuditService must not be null.");
+        }
         this.requestRepository = requestRepository;
         this.animalRepository = animalRepository;
         this.adopterRepository = adopterRepository;
+        this.auditService = auditService;
     }
 
     /**
@@ -73,6 +82,7 @@ public class AdoptionServiceImpl implements AdoptionService {
         }
         // Persist the new PENDING request
         requestRepository.save(request);
+        auditService.log("submitted adoption request", request);
     }
 
     /**
@@ -100,6 +110,7 @@ public class AdoptionServiceImpl implements AdoptionService {
         animalRepository.save(animal);
         adopterRepository.save(adopter);
         requestRepository.save(request);
+        auditService.log("approved adoption request", request);
     }
 
     /**
@@ -113,6 +124,7 @@ public class AdoptionServiceImpl implements AdoptionService {
         // Domain enforces PENDING; animal record needs no update on rejection
         request.reject();
         requestRepository.save(request);
+        auditService.log("rejected adoption request", request);
     }
 
     /**
@@ -126,6 +138,7 @@ public class AdoptionServiceImpl implements AdoptionService {
         // Same pattern as reject: only the request status changes
         request.cancel();
         requestRepository.save(request);
+        auditService.log("cancelled adoption request", request);
     }
 
     /**

--- a/src/main/java/shelter/service/impl/AuditServiceImpl.java
+++ b/src/main/java/shelter/service/impl/AuditServiceImpl.java
@@ -1,0 +1,113 @@
+package shelter.service.impl;
+
+import shelter.domain.Staff;
+import shelter.repository.AuditRepository;
+import shelter.service.AuditService;
+import shelter.service.model.AuditEntry;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Concrete implementation of {@link AuditService} that both prints a formatted log line
+ * to the console and persists each entry to the underlying {@link AuditRepository}.
+ * The in-memory list preserves type information (the generic {@code T}) for the duration
+ * of a single command execution; the repository stores the target as its string description
+ * so the audit trail survives across invocations.
+ *
+ * @param <T> the type of the target object being audited in this service context
+ */
+public class AuditServiceImpl<T> implements AuditService<T> {
+
+    private static final DateTimeFormatter DISPLAY_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final Staff staff;
+    private final AuditRepository auditRepository;
+    private final List<AuditEntry<T>> inMemoryLog;
+
+    /**
+     * Constructs a new {@code AuditServiceImpl} bound to the given staff member and repository.
+     * All entries logged through this instance will be attributed to {@code staff} and persisted
+     * via {@code auditRepository}.
+     *
+     * @param staff           the staff member performing the audited operations; must not be null
+     * @param auditRepository the repository used to persist audit entries; must not be null
+     * @throws IllegalArgumentException if either argument is null
+     */
+    public AuditServiceImpl(Staff staff, AuditRepository auditRepository) {
+        if (staff == null) {
+            throw new IllegalArgumentException("Staff must not be null.");
+        }
+        if (auditRepository == null) {
+            throw new IllegalArgumentException("AuditRepository must not be null.");
+        }
+        this.staff = staff;
+        this.auditRepository = auditRepository;
+        this.inMemoryLog = new ArrayList<>();
+    }
+
+    /**
+     * {@inheritDoc}
+     * Prints a formatted log line to the console, adds the entry to the in-memory list,
+     * and persists it to the audit repository. The console format is:
+     * {@code [INFO]  yyyy-MM-dd HH:mm:ss  staffName  →  action  |  target.toString()}.
+     *
+     * @throws IllegalArgumentException if {@code action} is null or blank, or {@code target} is null
+     */
+    @Override
+    public void log(String action, T target) {
+        // Guard: both fields are required to form a meaningful audit entry
+        if (action == null || action.isBlank()) {
+            throw new IllegalArgumentException("Action must not be null or blank.");
+        }
+        if (target == null) {
+            throw new IllegalArgumentException("Target must not be null.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Build the in-memory entry and add it to the session log
+        AuditEntry<T> entry = new AuditEntry<>(staff, action, target, now);
+        inMemoryLog.add(entry);
+
+        // Persist the entry to durable storage using the target's string representation
+        auditRepository.append(staff.getId(), staff.getName(), action,
+                target.toString(), now);
+
+        // Print a human-readable log line to the console for real-time operator feedback
+        System.out.println(formatLine(action, target.toString(), now));
+    }
+
+    /**
+     * {@inheritDoc}
+     * Returns entries accumulated during the current command execution only.
+     * Entries from previous executions are not included; use the repository's
+     * {@code findAll()} method to retrieve the full historical log.
+     *
+     * @return an unmodifiable view of the in-memory audit log for this session
+     */
+    @Override
+    public List<AuditEntry<T>> getLog() {
+        return Collections.unmodifiableList(inMemoryLog);
+    }
+
+    /**
+     * Formats an audit log line for console output.
+     * The format is: {@code [INFO]  timestamp  staffName  →  action  |  targetDescription}.
+     *
+     * @param action            the action description
+     * @param targetDescription the string representation of the target
+     * @param timestamp         the time the action occurred
+     * @return the formatted log line
+     */
+    private String formatLine(String action, String targetDescription, LocalDateTime timestamp) {
+        return "[INFO]  " + timestamp.format(DISPLAY_FMT)
+                + "  " + staff.getName()
+                + "  \u2192  " + action
+                + "  |  " + targetDescription;
+    }
+}

--- a/src/main/java/shelter/service/impl/RequestNotificationServiceImpl.java
+++ b/src/main/java/shelter/service/impl/RequestNotificationServiceImpl.java
@@ -1,0 +1,176 @@
+package shelter.service.impl;
+
+import shelter.domain.AdoptionRequest;
+import shelter.domain.Staff;
+import shelter.domain.TransferRequest;
+import shelter.repository.AuditRepository;
+import shelter.service.RequestNotificationService;
+import shelter.service.model.NotificationRecord;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Concrete implementation of {@link RequestNotificationService} that prints formatted
+ * notification messages to the console and maintains an in-memory record of all dispatched
+ * notifications for the duration of the current command execution.
+ * In this demo system, "sending a notification" means printing a {@code [NOTIFY]} line;
+ * no external messaging channel is involved.
+ */
+public class RequestNotificationServiceImpl implements RequestNotificationService {
+
+    private static final DateTimeFormatter DISPLAY_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final Staff staff;
+    private final AuditRepository auditRepository;
+    private final List<NotificationRecord> records;
+
+    /**
+     * Constructs a new {@code RequestNotificationServiceImpl} attributed to the given staff member.
+     * All notifications dispatched through this instance will be recorded under {@code staff}
+     * and persisted to the audit repository with a {@code [NOTIFICATION]} level prefix.
+     *
+     * @param staff           the staff member responsible for dispatching notifications; must not be null
+     * @param auditRepository the repository used to persist notification entries; must not be null
+     * @throws IllegalArgumentException if either argument is null
+     */
+    public RequestNotificationServiceImpl(Staff staff, AuditRepository auditRepository) {
+        if (staff == null) {
+            throw new IllegalArgumentException("Staff must not be null.");
+        }
+        if (auditRepository == null) {
+            throw new IllegalArgumentException("AuditRepository must not be null.");
+        }
+        this.staff = staff;
+        this.auditRepository = auditRepository;
+        this.records = new ArrayList<>();
+    }
+
+    /**
+     * {@inheritDoc}
+     * Prints a {@code [NOTIFY]} line to the console describing the adoption status change,
+     * then records the notification in the in-memory list.
+     *
+     * @throws IllegalArgumentException if {@code request} is null
+     */
+    @Override
+    public void notifyAdoptionStatusChange(AdoptionRequest request) {
+        // Guard: request must not be null
+        if (request == null) {
+            throw new IllegalArgumentException("AdoptionRequest must not be null.");
+        }
+
+        // Build the human-readable notification message
+        String message = "Adopter '" + request.getAdopter().getName()
+                + "' — adoption request " + request.getId()
+                + " for animal '" + request.getAnimal().getName()
+                + "' is now " + request.getStatus();
+
+        dispatchAndRecord(message, request.getId());
+    }
+
+    /**
+     * {@inheritDoc}
+     * Prints a {@code [NOTIFY]} line to the console describing the transfer status change,
+     * then records the notification in the in-memory list.
+     *
+     * @throws IllegalArgumentException if {@code request} is null
+     */
+    @Override
+    public void notifyTransferStatusChange(TransferRequest request) {
+        // Guard: request must not be null
+        if (request == null) {
+            throw new IllegalArgumentException("TransferRequest must not be null.");
+        }
+
+        // Build the human-readable notification message
+        String message = "Transfer request " + request.getId()
+                + " for animal '" + request.getAnimal().getName()
+                + "' (" + request.getFrom().getName()
+                + " \u2192 " + request.getTo().getName()
+                + ") is now " + request.getStatus();
+
+        dispatchAndRecord(message, request.getId());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<NotificationRecord> listAll() {
+        return Collections.unmodifiableList(records);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code staff} is null
+     */
+    @Override
+    public List<NotificationRecord> getByStaff(Staff staff) {
+        if (staff == null) {
+            throw new IllegalArgumentException("Staff must not be null.");
+        }
+        return records.stream()
+                .filter(r -> r.getStaff().equals(staff))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code targetId} is null or blank
+     */
+    @Override
+    public List<NotificationRecord> getByTarget(String targetId) {
+        if (targetId == null || targetId.isBlank()) {
+            throw new IllegalArgumentException("Target ID must not be null or blank.");
+        }
+        return records.stream()
+                .filter(r -> r.getTargetId().equals(targetId))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code keyword} is null or blank
+     */
+    @Override
+    public List<NotificationRecord> searchByAction(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            throw new IllegalArgumentException("Keyword must not be null or blank.");
+        }
+        return records.stream()
+                .filter(r -> r.getAction().contains(keyword))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Prints the notification to the console and adds a record to the in-memory list.
+     * This method centralises the two side effects shared by both notify methods.
+     *
+     * @param message  the human-readable notification text to print
+     * @param targetId the ID of the request that triggered the notification
+     */
+    private void dispatchAndRecord(String message, String targetId) {
+        LocalDateTime now = LocalDateTime.now();
+
+        // Print the notification line for real-time operator visibility
+        System.out.println("[NOTIFY]  " + now.format(DISPLAY_FMT)
+                + "  " + staff.getName()
+                + "  |  " + message);
+
+        // Persist to the shared audit log with NOTIFICATION level prefix for traceability
+        auditRepository.append(staff.getId(), staff.getName(),
+                "[NOTIFICATION] " + message, targetId, now);
+
+        // Keep an in-memory record for query within the current command execution
+        records.add(new NotificationRecord(staff, message, targetId, now));
+    }
+}

--- a/src/main/java/shelter/service/impl/TransferServiceImpl.java
+++ b/src/main/java/shelter/service/impl/TransferServiceImpl.java
@@ -9,6 +9,7 @@ import shelter.repository.ShelterRepository;
 import shelter.repository.TransferRequestRepository;
 import shelter.exception.AnimalNotInShelterException;
 import shelter.exception.ShelterAtCapacityException;
+import shelter.service.AuditService;
 import shelter.service.TransferService;
 
 import java.util.List;
@@ -24,20 +25,24 @@ public class TransferServiceImpl implements TransferService {
     private final TransferRequestRepository requestRepository;
     private final AnimalRepository animalRepository;
     private final ShelterRepository shelterRepository;
+    private final AuditService<TransferRequest> auditService;
 
     /**
-     * Constructs a new {@code TransferServiceImpl} with the required repositories.
-     * All three are needed: requests track workflow state, the animal carries the
+     * Constructs a new {@code TransferServiceImpl} with the required repositories and audit service.
+     * All three repositories are needed: requests track workflow state, the animal carries the
      * authoritative shelter reference, and both shelters maintain their in-memory animal lists.
+     * The audit service records every state-changing operation for traceability.
      *
      * @param requestRepository the repository for transfer request persistence; must not be null
      * @param animalRepository  the repository for animal record persistence; must not be null
      * @param shelterRepository the repository for shelter record persistence; must not be null
-     * @throws IllegalArgumentException if any repository is null
+     * @param auditService      the service used to log transfer operations; must not be null
+     * @throws IllegalArgumentException if any argument is null
      */
     public TransferServiceImpl(TransferRequestRepository requestRepository,
                                AnimalRepository animalRepository,
-                               ShelterRepository shelterRepository) {
+                               ShelterRepository shelterRepository,
+                               AuditService<TransferRequest> auditService) {
         if (requestRepository == null) {
             throw new IllegalArgumentException("TransferRequestRepository must not be null.");
         }
@@ -47,9 +52,13 @@ public class TransferServiceImpl implements TransferService {
         if (shelterRepository == null) {
             throw new IllegalArgumentException("ShelterRepository must not be null.");
         }
+        if (auditService == null) {
+            throw new IllegalArgumentException("AuditService must not be null.");
+        }
         this.requestRepository = requestRepository;
         this.animalRepository = animalRepository;
         this.shelterRepository = shelterRepository;
+        this.auditService = auditService;
     }
 
     /**
@@ -82,6 +91,7 @@ public class TransferServiceImpl implements TransferService {
         // Create and persist the PENDING request
         TransferRequest request = new TransferRequest(animal, from, to);
         requestRepository.save(request);
+        auditService.log("submitted transfer request", request);
         return request;
     }
 
@@ -113,6 +123,7 @@ public class TransferServiceImpl implements TransferService {
         shelterRepository.save(from);
         shelterRepository.save(to);
         requestRepository.save(request);
+        auditService.log("approved transfer request", request);
     }
 
     /**
@@ -126,6 +137,7 @@ public class TransferServiceImpl implements TransferService {
         // Animal does not move; only the request status changes
         request.reject();
         requestRepository.save(request);
+        auditService.log("rejected transfer request", request);
     }
 
     /**
@@ -140,6 +152,7 @@ public class TransferServiceImpl implements TransferService {
         // "dismiss" is the service-level term; "cancel" is the domain-level state name
         request.cancel();
         requestRepository.save(request);
+        auditService.log("dismissed transfer request", request);
     }
 
     /**

--- a/src/test/java/shelter/service/AdoptionServiceImplTest.java
+++ b/src/test/java/shelter/service/AdoptionServiceImplTest.java
@@ -16,7 +16,9 @@ import shelter.domain.Species;
 import shelter.repository.AdopterRepository;
 import shelter.repository.AdoptionRequestRepository;
 import shelter.repository.AnimalRepository;
+import shelter.service.AuditService;
 import shelter.service.impl.AdoptionServiceImpl;
+import shelter.service.model.AuditEntry;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -52,7 +54,7 @@ class AdoptionServiceImplTest {
         requestRepo = new StubAdoptionRequestRepository();
         animalRepo = new StubAnimalRepository();
         adopterRepo = new StubAdopterRepository();
-        service = new AdoptionServiceImpl(requestRepo, animalRepo, adopterRepo);
+        service = new AdoptionServiceImpl(requestRepo, animalRepo, adopterRepo, new NoOpAuditService<>());
 
         AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, null, 0, 10);
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
@@ -277,6 +279,66 @@ class AdoptionServiceImplTest {
         assertThrows(IllegalArgumentException.class, () -> service.getApprovedAfter(null));
     }
 
+    // ── audit logging ─────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that submit logs an audit entry with the expected action string.
+     */
+    @Test
+    void submit_logsAuditEntry() {
+        SpyAuditService<AdoptionRequest> spy = new SpyAuditService<>();
+        service = new AdoptionServiceImpl(requestRepo, animalRepo, adopterRepo, spy);
+
+        service.submit(new AdoptionRequest(adopter, dog));
+
+        assertTrue(spy.loggedActions.contains("submitted adoption request"));
+    }
+
+    /**
+     * Verifies that approve logs an audit entry with the expected action string.
+     */
+    @Test
+    void approve_logsAuditEntry() {
+        SpyAuditService<AdoptionRequest> spy = new SpyAuditService<>();
+        service = new AdoptionServiceImpl(requestRepo, animalRepo, adopterRepo, spy);
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        requestRepo.save(req);
+
+        service.approve(req);
+
+        assertTrue(spy.loggedActions.contains("approved adoption request"));
+    }
+
+    /**
+     * Verifies that reject logs an audit entry with the expected action string.
+     */
+    @Test
+    void reject_logsAuditEntry() {
+        SpyAuditService<AdoptionRequest> spy = new SpyAuditService<>();
+        service = new AdoptionServiceImpl(requestRepo, animalRepo, adopterRepo, spy);
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        requestRepo.save(req);
+
+        service.reject(req);
+
+        assertTrue(spy.loggedActions.contains("rejected adoption request"));
+    }
+
+    /**
+     * Verifies that cancel logs an audit entry with the expected action string.
+     */
+    @Test
+    void cancel_logsAuditEntry() {
+        SpyAuditService<AdoptionRequest> spy = new SpyAuditService<>();
+        service = new AdoptionServiceImpl(requestRepo, animalRepo, adopterRepo, spy);
+        AdoptionRequest req = new AdoptionRequest(adopter, dog);
+        requestRepo.save(req);
+
+        service.cancel(req);
+
+        assertTrue(spy.loggedActions.contains("cancelled adoption request"));
+    }
+
     // ── in-memory stubs ───────────────────────────────────────────────────────
 
     private static class StubAdoptionRequestRepository implements AdoptionRequestRepository {
@@ -329,5 +391,18 @@ class AdoptionServiceImplTest {
         @Override public Optional<Adopter> findById(String id) { return Optional.ofNullable(store.get(id)); }
         @Override public List<Adopter> findAll() { return new ArrayList<>(store.values()); }
         @Override public void delete(String id) { store.remove(id); }
+    }
+
+    /** No-op audit stub that silently discards all log calls during tests. */
+    private static class NoOpAuditService<T> implements AuditService<T> {
+        @Override public void log(String action, T target) { }
+        @Override public List<AuditEntry<T>> getLog() { return new ArrayList<>(); }
+    }
+
+    /** Spy audit stub that records action strings so tests can assert on them. */
+    private static class SpyAuditService<T> implements AuditService<T> {
+        final List<String> loggedActions = new ArrayList<>();
+        @Override public void log(String action, T target) { loggedActions.add(action); }
+        @Override public List<AuditEntry<T>> getLog() { return new ArrayList<>(); }
     }
 }

--- a/src/test/java/shelter/service/AuditServiceImplTest.java
+++ b/src/test/java/shelter/service/AuditServiceImplTest.java
@@ -1,0 +1,163 @@
+package shelter.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.Staff;
+import shelter.repository.AuditRepository;
+import shelter.repository.csv.CsvAuditRepository;
+import shelter.service.impl.AuditServiceImpl;
+import shelter.service.model.AuditEntry;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link AuditServiceImpl}, verifying that log entries are stored in memory,
+ * persisted to CSV, and printed to the console with the expected format.
+ */
+class AuditServiceImplTest {
+
+    @TempDir
+    Path tempDir;
+
+    private AuditRepository auditRepository;
+    private AuditServiceImpl<String> service;
+    private Staff staff;
+
+    private ByteArrayOutputStream outCapture;
+    private PrintStream originalOut;
+
+    /**
+     * Redirects stdout before each test so console output can be inspected.
+     * Constructs a real CsvAuditRepository backed by the JUnit temporary directory.
+     */
+    @BeforeEach
+    void setUp() {
+        // Redirect System.out so we can assert on printed lines
+        outCapture = new ByteArrayOutputStream();
+        originalOut = System.out;
+        System.setOut(new PrintStream(outCapture));
+
+        staff = new Staff("admin", "Manager");
+        auditRepository = new CsvAuditRepository(tempDir.toString());
+        service = new AuditServiceImpl<>(staff, auditRepository);
+    }
+
+    /**
+     * Restores the original stdout after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+    }
+
+    // ── in-memory log ─────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that log() adds an entry to the in-memory list returned by getLog().
+     */
+    @Test
+    void log_addsEntryToInMemoryLog() {
+        service.log("approved adoption", "AdoptionRequest#001");
+
+        List<AuditEntry<String>> log = service.getLog();
+        assertEquals(1, log.size());
+        assertEquals("approved adoption", log.get(0).getAction());
+        assertEquals("AdoptionRequest#001", log.get(0).getTarget());
+        assertEquals(staff.getName(), log.get(0).getStaff().getName());
+    }
+
+    /**
+     * Verifies that multiple log() calls accumulate all entries in order.
+     */
+    @Test
+    void log_multipleEntries_allStoredInOrder() {
+        service.log("submitted adoption", "req-1");
+        service.log("approved adoption", "req-1");
+
+        List<AuditEntry<String>> log = service.getLog();
+        assertEquals(2, log.size());
+        assertEquals("submitted adoption", log.get(0).getAction());
+        assertEquals("approved adoption", log.get(1).getAction());
+    }
+
+    // ── CSV persistence ───────────────────────────────────────────────────────
+
+    /**
+     * Verifies that log() appends a row to the CSV file so the entry survives across sessions.
+     */
+    @Test
+    void log_writesRowToCsvFile() throws Exception {
+        service.log("approved adoption", "AdoptionRequest#001");
+
+        Path csvFile = tempDir.resolve("audit.csv");
+        List<String> lines = Files.readAllLines(csvFile);
+
+        // Header plus one data row
+        assertEquals(2, lines.size());
+        assertTrue(lines.get(1).contains("approved adoption"));
+        assertTrue(lines.get(1).contains("admin"));
+    }
+
+    /**
+     * Verifies that each subsequent log() call appends a new row without overwriting previous ones.
+     */
+    @Test
+    void log_appendsWithoutOverwriting() throws Exception {
+        service.log("submitted adoption", "req-1");
+        service.log("approved adoption", "req-1");
+
+        Path csvFile = tempDir.resolve("audit.csv");
+        List<String> lines = Files.readAllLines(csvFile);
+
+        // Header plus two data rows
+        assertEquals(3, lines.size());
+    }
+
+    // ── console output ────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that log() prints a line starting with [INFO] to the console.
+     */
+    @Test
+    void log_printsInfoLineToConsole() {
+        service.log("approved adoption", "AdoptionRequest#001");
+
+        String output = outCapture.toString();
+        assertTrue(output.contains("[INFO]"), "Expected [INFO] prefix in console output");
+    }
+
+    /**
+     * Verifies that the console line contains the staff name, action, and target.
+     */
+    @Test
+    void log_consoleLineContainsAllFields() {
+        service.log("approved adoption", "AdoptionRequest#001");
+
+        String output = outCapture.toString();
+        assertTrue(output.contains("admin"),               "Expected staff name in output");
+        assertTrue(output.contains("approved adoption"),   "Expected action in output");
+        assertTrue(output.contains("AdoptionRequest#001"), "Expected target in output");
+    }
+
+    // ── null / blank guards ───────────────────────────────────────────────────
+
+    @Test void log_nullAction_throws() {
+        assertThrows(IllegalArgumentException.class, () -> service.log(null, "target"));
+    }
+
+    @Test void log_blankAction_throws() {
+        assertThrows(IllegalArgumentException.class, () -> service.log("  ", "target"));
+    }
+
+    @Test void log_nullTarget_throws() {
+        assertThrows(IllegalArgumentException.class, () -> service.log("action", null));
+    }
+}

--- a/src/test/java/shelter/service/RequestNotificationServiceImplTest.java
+++ b/src/test/java/shelter/service/RequestNotificationServiceImplTest.java
@@ -1,0 +1,238 @@
+package shelter.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Adopter;
+import shelter.domain.AdopterPreferences;
+import shelter.domain.AdoptionRequest;
+import shelter.domain.Animal;
+import shelter.domain.DailySchedule;
+import shelter.domain.Dog;
+import shelter.domain.LivingSpace;
+import shelter.domain.Shelter;
+import shelter.domain.Species;
+import shelter.domain.Staff;
+import shelter.domain.TransferRequest;
+import shelter.repository.AuditRepository;
+import shelter.service.impl.RequestNotificationServiceImpl;
+import shelter.service.model.AuditEntry;
+import shelter.service.model.NotificationRecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link RequestNotificationServiceImpl}, verifying that notifications are
+ * printed to the console, persisted via the audit repository, and queryable from the
+ * in-memory record list.
+ */
+class RequestNotificationServiceImplTest {
+
+    private SpyAuditRepository auditRepo;
+    private RequestNotificationServiceImpl service;
+    private Staff staff;
+
+    private Adopter adopter;
+    private Dog dog;
+    private AdoptionRequest adoptionRequest;
+
+    private Shelter shelterA;
+    private Shelter shelterB;
+    private TransferRequest transferRequest;
+
+    private ByteArrayOutputStream outCapture;
+    private PrintStream originalOut;
+
+    /**
+     * Redirects stdout and sets up a seeded adoption request and transfer request before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        // Redirect System.out so we can assert on printed lines
+        outCapture = new ByteArrayOutputStream();
+        originalOut = System.out;
+        System.setOut(new PrintStream(outCapture));
+
+        staff = new Staff("admin", "Manager");
+        auditRepo = new SpyAuditRepository();
+        service = new RequestNotificationServiceImpl(staff, auditRepo);
+
+        // Seed an adoption request
+        AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, null, 0, 10);
+        adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, null, prefs);
+        dog = new Dog("Rex", "Labrador", 3, ActivityLevel.HIGH, false, Dog.Size.LARGE, false);
+        adoptionRequest = new AdoptionRequest(adopter, dog);
+
+        // Seed a transfer request
+        shelterA = new Shelter("Shelter A", "Boston", 10);
+        shelterB = new Shelter("Shelter B", "Cambridge", 10);
+        dog.setShelterId(shelterA.getId());
+        shelterA.addAnimal(dog);
+        transferRequest = new TransferRequest(dog, shelterA, shelterB);
+    }
+
+    /**
+     * Restores the original stdout after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+    }
+
+    // ── notifyAdoptionStatusChange ────────────────────────────────────────────
+
+    /**
+     * Verifies that notifyAdoptionStatusChange prints a [NOTIFY] line to the console.
+     */
+    @Test
+    void notifyAdoption_printsNotifyLineToConsole() {
+        service.notifyAdoptionStatusChange(adoptionRequest);
+
+        String output = outCapture.toString();
+        assertTrue(output.contains("[NOTIFY]"), "Expected [NOTIFY] prefix in console output");
+    }
+
+    /**
+     * Verifies that the console line contains the adopter name, animal name, and request status.
+     */
+    @Test
+    void notifyAdoption_consoleLineContainsKeyFields() {
+        service.notifyAdoptionStatusChange(adoptionRequest);
+
+        String output = outCapture.toString();
+        assertTrue(output.contains("Alice"),   "Expected adopter name in output");
+        assertTrue(output.contains("Rex"),     "Expected animal name in output");
+        assertTrue(output.contains("PENDING"), "Expected request status in output");
+    }
+
+    /**
+     * Verifies that notifyAdoptionStatusChange adds a record retrievable via listAll().
+     */
+    @Test
+    void notifyAdoption_addsRecordToList() {
+        service.notifyAdoptionStatusChange(adoptionRequest);
+
+        assertEquals(1, service.listAll().size());
+    }
+
+    /**
+     * Verifies that notifyAdoptionStatusChange calls auditRepository.append().
+     */
+    @Test
+    void notifyAdoption_callsAuditRepositoryAppend() {
+        service.notifyAdoptionStatusChange(adoptionRequest);
+
+        assertEquals(1, auditRepo.appendCallCount);
+        assertTrue(auditRepo.lastAction.contains("[NOTIFICATION]"));
+    }
+
+    /**
+     * Verifies that notifyAdoptionStatusChange rejects a null request.
+     */
+    @Test
+    void notifyAdoption_null_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.notifyAdoptionStatusChange(null));
+    }
+
+    // ── notifyTransferStatusChange ────────────────────────────────────────────
+
+    /**
+     * Verifies that notifyTransferStatusChange prints a [NOTIFY] line to the console.
+     */
+    @Test
+    void notifyTransfer_printsNotifyLineToConsole() {
+        service.notifyTransferStatusChange(transferRequest);
+
+        String output = outCapture.toString();
+        assertTrue(output.contains("[NOTIFY]"), "Expected [NOTIFY] prefix in console output");
+    }
+
+    /**
+     * Verifies that the console line contains both shelter names and the animal name.
+     */
+    @Test
+    void notifyTransfer_consoleLineContainsKeyFields() {
+        service.notifyTransferStatusChange(transferRequest);
+
+        String output = outCapture.toString();
+        assertTrue(output.contains("Rex"),       "Expected animal name in output");
+        assertTrue(output.contains("Shelter A"), "Expected source shelter in output");
+        assertTrue(output.contains("Shelter B"), "Expected destination shelter in output");
+    }
+
+    /**
+     * Verifies that notifyTransferStatusChange rejects a null request.
+     */
+    @Test
+    void notifyTransfer_null_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.notifyTransferStatusChange(null));
+    }
+
+    // ── query methods ─────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that getByTarget returns only records matching the given request ID.
+     */
+    @Test
+    void getByTarget_returnsMatchingRecords() {
+        service.notifyAdoptionStatusChange(adoptionRequest);
+
+        List<NotificationRecord> result = service.getByTarget(adoptionRequest.getId());
+        assertEquals(1, result.size());
+        assertEquals(adoptionRequest.getId(), result.get(0).getTargetId());
+    }
+
+    /**
+     * Verifies that searchByAction returns records whose action contains the keyword.
+     */
+    @Test
+    void searchByAction_returnsMatchingRecords() {
+        service.notifyAdoptionStatusChange(adoptionRequest);
+        service.notifyTransferStatusChange(transferRequest);
+
+        List<NotificationRecord> result = service.searchByAction("adoption");
+        assertEquals(1, result.size());
+    }
+
+    /**
+     * Verifies that listAll returns all dispatched notifications.
+     */
+    @Test
+    void listAll_returnsAllRecords() {
+        service.notifyAdoptionStatusChange(adoptionRequest);
+        service.notifyTransferStatusChange(transferRequest);
+
+        assertEquals(2, service.listAll().size());
+    }
+
+    // ── in-memory stubs ───────────────────────────────────────────────────────
+
+    /** Spy repository that counts append() calls and records the last action string. */
+    private static class SpyAuditRepository implements AuditRepository {
+        int appendCallCount = 0;
+        String lastAction = null;
+
+        @Override
+        public void append(String staffId, String staffName, String action,
+                           String targetDescription, LocalDateTime timestamp) {
+            appendCallCount++;
+            lastAction = action;
+        }
+
+        @Override
+        public List<AuditEntry<String>> findAll() { return new ArrayList<>(); }
+
+        @Override
+        public void clear() { appendCallCount = 0; lastAction = null; }
+    }
+}

--- a/src/test/java/shelter/service/TransferServiceImplTest.java
+++ b/src/test/java/shelter/service/TransferServiceImplTest.java
@@ -11,7 +11,9 @@ import shelter.domain.TransferRequest;
 import shelter.repository.AnimalRepository;
 import shelter.repository.ShelterRepository;
 import shelter.repository.TransferRequestRepository;
+import shelter.service.AuditService;
 import shelter.service.impl.TransferServiceImpl;
+import shelter.service.model.AuditEntry;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -46,7 +48,7 @@ class TransferServiceImplTest {
         requestRepo = new StubTransferRequestRepository();
         animalRepo = new StubAnimalRepository();
         shelterRepo = new StubShelterRepository();
-        service = new TransferServiceImpl(requestRepo, animalRepo, shelterRepo);
+        service = new TransferServiceImpl(requestRepo, animalRepo, shelterRepo, new NoOpAuditService<>());
 
         shelterA = new Shelter("Shelter A", "Boston", 10);
         shelterB = new Shelter("Shelter B", "Cambridge", 10);
@@ -224,6 +226,63 @@ class TransferServiceImplTest {
         assertThrows(IllegalArgumentException.class, () -> service.getPendingRequests(null));
     }
 
+    // ── audit logging ─────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that requestTransfer logs an audit entry with the expected action string.
+     */
+    @Test
+    void requestTransfer_logsAuditEntry() {
+        SpyAuditService<TransferRequest> spy = new SpyAuditService<>();
+        service = new TransferServiceImpl(requestRepo, animalRepo, shelterRepo, spy);
+
+        service.requestTransfer(dog, shelterA, shelterB);
+
+        assertTrue(spy.loggedActions.contains("submitted transfer request"));
+    }
+
+    /**
+     * Verifies that approve logs an audit entry with the expected action string.
+     */
+    @Test
+    void approve_logsAuditEntry() {
+        SpyAuditService<TransferRequest> spy = new SpyAuditService<>();
+        service = new TransferServiceImpl(requestRepo, animalRepo, shelterRepo, spy);
+        TransferRequest req = service.requestTransfer(dog, shelterA, shelterB);
+
+        service.approve(req);
+
+        assertTrue(spy.loggedActions.contains("approved transfer request"));
+    }
+
+    /**
+     * Verifies that reject logs an audit entry with the expected action string.
+     */
+    @Test
+    void reject_logsAuditEntry() {
+        SpyAuditService<TransferRequest> spy = new SpyAuditService<>();
+        service = new TransferServiceImpl(requestRepo, animalRepo, shelterRepo, spy);
+        TransferRequest req = service.requestTransfer(dog, shelterA, shelterB);
+
+        service.reject(req);
+
+        assertTrue(spy.loggedActions.contains("rejected transfer request"));
+    }
+
+    /**
+     * Verifies that dismiss logs an audit entry with the expected action string.
+     */
+    @Test
+    void dismiss_logsAuditEntry() {
+        SpyAuditService<TransferRequest> spy = new SpyAuditService<>();
+        service = new TransferServiceImpl(requestRepo, animalRepo, shelterRepo, spy);
+        TransferRequest req = service.requestTransfer(dog, shelterA, shelterB);
+
+        service.dismiss(req);
+
+        assertTrue(spy.loggedActions.contains("dismissed transfer request"));
+    }
+
     // ── in-memory stubs ───────────────────────────────────────────────────────
 
     private static class StubTransferRequestRepository implements TransferRequestRepository {
@@ -277,5 +336,18 @@ class TransferServiceImplTest {
         @Override public Optional<Shelter> findById(String id) { return Optional.ofNullable(store.get(id)); }
         @Override public List<Shelter> findAll() { return new ArrayList<>(store.values()); }
         @Override public void delete(String id) { store.remove(id); }
+    }
+
+    /** No-op audit stub that silently discards all log calls during tests. */
+    private static class NoOpAuditService<T> implements AuditService<T> {
+        @Override public void log(String action, T target) { }
+        @Override public List<AuditEntry<T>> getLog() { return new ArrayList<>(); }
+    }
+
+    /** Spy audit stub that records action strings so tests can assert on them. */
+    private static class SpyAuditService<T> implements AuditService<T> {
+        final List<String> loggedActions = new ArrayList<>();
+        @Override public void log(String action, T target) { loggedActions.add(action); }
+        @Override public List<AuditEntry<T>> getLog() { return new ArrayList<>(); }
     }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive audit logging system for adoption-related operations. It adds a generic audit service that records actions both in memory and in a durable CSV-backed repository, and integrates this service into the adoption workflow. The main changes are grouped below:

**Audit Logging Infrastructure:**

* Added a new `AuditRepository` interface to define persistence operations for audit log entries, supporting appending, reading, and clearing audit records. (`src/main/java/shelter/repository/AuditRepository.java`)
* Implemented `CsvAuditRepository`, a CSV-backed repository that appends audit entries to `audit.csv` and supports reading all entries and clearing the log. (`src/main/java/shelter/repository/csv/CsvAuditRepository.java`)
* Introduced `AuditServiceImpl<T>`, a generic audit service that logs actions to the console, maintains an in-memory session log, and persists entries via `AuditRepository`. (`src/main/java/shelter/service/impl/AuditServiceImpl.java`)

**Adoption Workflow Integration:**

* Updated `AdoptionServiceImpl` to require and use an `AuditService<AdoptionRequest>`, ensuring that all state-changing adoption operations (submit, approve, reject, cancel) are logged via the audit service. (`src/main/java/shelter/service/impl/AdoptionServiceImpl.java`) [[1]](diffhunk://#diff-8ce0f28035ebcae8262d20b506292eb2500fcc919f5cd7a995af94e579ca9b09R13) [[2]](diffhunk://#diff-8ce0f28035ebcae8262d20b506292eb2500fcc919f5cd7a995af94e579ca9b09R30-R47) [[3]](diffhunk://#diff-8ce0f28035ebcae8262d20b506292eb2500fcc919f5cd7a995af94e579ca9b09R57-R63) [[4]](diffhunk://#diff-8ce0f28035ebcae8262d20b506292eb2500fcc919f5cd7a995af94e579ca9b09R85) [[5]](diffhunk://#diff-8ce0f28035ebcae8262d20b506292eb2500fcc919f5cd7a995af94e579ca9b09R113) [[6]](diffhunk://#diff-8ce0f28035ebcae8262d20b506292eb2500fcc919f5cd7a995af94e579ca9b09R127) [[7]](diffhunk://#diff-8ce0f28035ebcae8262d20b506292eb2500fcc919f5cd7a995af94e579ca9b09R141)