### PR TITLE
feat(service): add VaccinationServiceImpl with tests

### DIFF
--- a/src/main/java/shelter/service/impl/VaccinationServiceImpl.java
+++ b/src/main/java/shelter/service/impl/VaccinationServiceImpl.java
@@ -1,0 +1,194 @@
+package shelter.service.impl;
+
+import shelter.domain.Animal;
+import shelter.domain.VaccinationRecord;
+import shelter.domain.VaccineType;
+import shelter.exception.EntityNotFoundException;
+import shelter.exception.SpeciesMismatchException;
+import shelter.repository.VaccinationRecordRepository;
+import shelter.repository.VaccineTypeRepository;
+import shelter.service.AuditService;
+import shelter.service.VaccinationService;
+import shelter.service.model.OverdueVaccination;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Concrete implementation of {@link VaccinationService} that records vaccination events,
+ * checks overdue status against each vaccine type's validity period, and queries vaccination
+ * history by animal. All significant operations are forwarded to the {@link AuditService}
+ * for traceability.
+ */
+public class VaccinationServiceImpl implements VaccinationService {
+
+    private final VaccinationRecordRepository recordRepository;
+    private final VaccineTypeRepository vaccineTypeRepository;
+    private final AuditService<VaccinationRecord> auditService;
+
+    /**
+     * Constructs a new {@code VaccinationServiceImpl} with the required repositories and audit service.
+     * The vaccine type repository is used to determine which vaccines are applicable to a given species
+     * when evaluating overdue status.
+     *
+     * @param recordRepository    the repository for vaccination record persistence; must not be null
+     * @param vaccineTypeRepository the repository for vaccine type catalog lookups; must not be null
+     * @param auditService        the service used to log vaccination events; must not be null
+     * @throws IllegalArgumentException if any argument is null
+     */
+    public VaccinationServiceImpl(VaccinationRecordRepository recordRepository,
+                                  VaccineTypeRepository vaccineTypeRepository,
+                                  AuditService<VaccinationRecord> auditService) {
+        if (recordRepository == null) {
+            throw new IllegalArgumentException("VaccinationRecordRepository must not be null.");
+        }
+        if (vaccineTypeRepository == null) {
+            throw new IllegalArgumentException("VaccineTypeRepository must not be null.");
+        }
+        if (auditService == null) {
+            throw new IllegalArgumentException("AuditService must not be null.");
+        }
+        this.recordRepository = recordRepository;
+        this.vaccineTypeRepository = vaccineTypeRepository;
+        this.auditService = auditService;
+    }
+
+    /**
+     * {@inheritDoc}
+     * Validates that the vaccine type is applicable to the animal's species before creating the record.
+     * The vaccination is persisted and an audit entry is logged on success.
+     *
+     * @throws IllegalArgumentException if any argument is null
+     * @throws SpeciesMismatchException if the vaccine type does not apply to the animal's species
+     */
+    @Override
+    public void recordVaccination(Animal animal, VaccineType vaccineType, LocalDate date) {
+        // Guard: all three arguments are required
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+        if (vaccineType == null) {
+            throw new IllegalArgumentException("VaccineType must not be null.");
+        }
+        if (date == null) {
+            throw new IllegalArgumentException("Date must not be null.");
+        }
+
+        // Business rule: the vaccine must be approved for this animal's species
+        if (vaccineType.getApplicableSpecies() != animal.getSpecies()) {
+            throw new SpeciesMismatchException(
+                    "Vaccine '" + vaccineType.getName() + "' is not applicable to species "
+                            + animal.getSpecies() + ".");
+        }
+
+        // Create and persist the vaccination record
+        VaccinationRecord record = new VaccinationRecord(
+                animal.getId(), vaccineType.getId(), date);
+        recordRepository.save(record);
+
+        // Log the operation for audit trail
+        auditService.log("recorded vaccination: " + vaccineType.getName()
+                + " for animal " + animal.getName(), record);
+    }
+
+    /**
+     * {@inheritDoc}
+     * For each vaccine type applicable to the animal's species, finds the most recent
+     * vaccination date and compares it against the vaccine's validity period.
+     * A vaccine is overdue if it has never been given or if today is on or after the due date.
+     * Results are sorted by due date ascending so the most overdue entries appear first.
+     *
+     * @throws IllegalArgumentException if {@code animal} is null
+     */
+    @Override
+    public List<OverdueVaccination> getOverdueVaccinations(Animal animal) {
+        // Guard: animal is required
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        // Retrieve all vaccine types applicable to this animal's species
+        List<VaccineType> applicableTypes =
+                vaccineTypeRepository.findByApplicableSpecies(animal.getSpecies());
+
+        // Build the full vaccination history for this animal once, to avoid repeated queries
+        List<VaccinationRecord> history = recordRepository.findByAnimalId(animal.getId());
+
+        LocalDate today = LocalDate.now();
+        List<OverdueVaccination> overdue = new ArrayList<>();
+
+        for (VaccineType vt : applicableTypes) {
+            // Find the most recent administration date for this vaccine type
+            LocalDate lastAdministered = findMostRecentDate(history, vt.getId());
+
+            // Calculate the due date: validity window from last dose, or today if never given
+            LocalDate dueDate = (lastAdministered != null)
+                    ? lastAdministered.plusDays(vt.getValidityDays())
+                    : today;
+
+            // A vaccine is overdue if today is on or after the due date
+            if (!today.isBefore(dueDate)) {
+                overdue.add(new OverdueVaccination(vt, lastAdministered, dueDate));
+            }
+        }
+
+        Collections.sort(overdue);
+        return Collections.unmodifiableList(overdue);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if {@code animal} is null
+     */
+    @Override
+    public List<VaccinationRecord> getVaccinationHistory(Animal animal) {
+        // Guard: animal is required
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+        return recordRepository.findByAnimalId(animal.getId());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException  if {@code id} is null or blank
+     * @throws EntityNotFoundException   if no vaccination record with the given ID exists
+     */
+    @Override
+    public VaccinationRecord findById(String id) {
+        // Guard: ID is required for lookup
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Vaccination record ID must not be null or blank.");
+        }
+        Optional<VaccinationRecord> found = recordRepository.findById(id);
+        if (found.isEmpty()) {
+            throw new EntityNotFoundException("VaccinationRecord not found: " + id);
+        }
+        return found.get();
+    }
+
+    /**
+     * Scans the given vaccination history and returns the most recent administration date
+     * for the specified vaccine type ID. Returns null if no matching record is found.
+     *
+     * @param history       the list of vaccination records to search
+     * @param vaccineTypeId the vaccine type ID to filter by
+     * @return the most recent date, or null if never administered
+     */
+    private LocalDate findMostRecentDate(List<VaccinationRecord> history, String vaccineTypeId) {
+        LocalDate latest = null;
+        for (VaccinationRecord rec : history) {
+            if (vaccineTypeId.equals(rec.getVaccineTypeId())) {
+                if (latest == null || rec.getDateAdministered().isAfter(latest)) {
+                    latest = rec.getDateAdministered();
+                }
+            }
+        }
+        return latest;
+    }
+}

--- a/src/test/java/shelter/service/VaccinationServiceImplTest.java
+++ b/src/test/java/shelter/service/VaccinationServiceImplTest.java
@@ -1,0 +1,294 @@
+package shelter.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Dog;
+import shelter.domain.Species;
+import shelter.domain.VaccinationRecord;
+import shelter.domain.VaccineType;
+import shelter.exception.EntityNotFoundException;
+import shelter.exception.SpeciesMismatchException;
+import shelter.repository.VaccinationRecordRepository;
+import shelter.repository.VaccineTypeRepository;
+import shelter.service.impl.VaccinationServiceImpl;
+import shelter.service.model.AuditEntry;
+import shelter.service.model.OverdueVaccination;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link VaccinationServiceImpl}, covering vaccination recording,
+ * overdue detection, history queries, and null guards. Repositories are replaced
+ * with in-memory stubs to isolate service logic from persistence concerns.
+ */
+class VaccinationServiceImplTest {
+
+    private StubVaccinationRecordRepository recordRepo;
+    private StubVaccineTypeRepository typeRepo;
+    private VaccinationServiceImpl service;
+
+    private Dog dog;
+    private VaccineType rabies;   // valid 365 days, for DOG
+    private VaccineType bordetella; // valid 180 days, for DOG
+
+    /**
+     * Sets up fresh stubs and a dog with two applicable vaccine types before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        recordRepo = new StubVaccinationRecordRepository();
+        typeRepo = new StubVaccineTypeRepository();
+        service = new VaccinationServiceImpl(recordRepo, typeRepo, new NoOpAuditService<>());
+
+        dog = new Dog("Rex", "Labrador", 3, ActivityLevel.HIGH, false, Dog.Size.LARGE, false);
+        dog.setShelterId("shelter-1");
+
+        rabies = new VaccineType("Rabies", Species.DOG, 365);
+        bordetella = new VaccineType("Bordetella", Species.DOG, 180);
+        typeRepo.save(rabies);
+        typeRepo.save(bordetella);
+    }
+
+    // ── recordVaccination ─────────────────────────────────────────────────────
+
+    /**
+     * Verifies that a valid vaccination is persisted to the repository.
+     */
+    @Test
+    void recordVaccination_valid_savesRecord() {
+        service.recordVaccination(dog, rabies, LocalDate.now());
+
+        assertEquals(1, recordRepo.findAll().size());
+        assertEquals(dog.getId(), recordRepo.findAll().get(0).getAnimalId());
+        assertEquals(rabies.getId(), recordRepo.findAll().get(0).getVaccineTypeId());
+    }
+
+    /**
+     * Verifies that vaccinating a dog with a cat-specific vaccine throws SpeciesMismatchException.
+     */
+    @Test
+    void recordVaccination_speciesMismatch_throws() {
+        VaccineType catVaccine = new VaccineType("FVRCP", Species.CAT, 365);
+        assertThrows(SpeciesMismatchException.class,
+                () -> service.recordVaccination(dog, catVaccine, LocalDate.now()));
+    }
+
+    /**
+     * Verifies that recordVaccination rejects null inputs.
+     */
+    @Test void recordVaccination_nullAnimal_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.recordVaccination(null, rabies, LocalDate.now()));
+    }
+
+    @Test void recordVaccination_nullVaccineType_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.recordVaccination(dog, null, LocalDate.now()));
+    }
+
+    @Test void recordVaccination_nullDate_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.recordVaccination(dog, rabies, null));
+    }
+
+    // ── getOverdueVaccinations ────────────────────────────────────────────────
+
+    /**
+     * Verifies that a vaccine never given is reported as overdue.
+     */
+    @Test
+    void getOverdueVaccinations_neverGiven_allOverdue() {
+        List<OverdueVaccination> overdue = service.getOverdueVaccinations(dog);
+
+        // Both rabies and bordetella have never been given
+        assertEquals(2, overdue.size());
+    }
+
+    /**
+     * Verifies that a recently given vaccine within its validity window is not overdue.
+     */
+    @Test
+    void getOverdueVaccinations_recentVaccine_notOverdue() {
+        // Rabies given today — valid for 365 days, not overdue
+        recordRepo.save(new VaccinationRecord(dog.getId(), rabies.getId(), LocalDate.now()));
+
+        List<OverdueVaccination> overdue = service.getOverdueVaccinations(dog);
+
+        // Only bordetella should be overdue
+        assertEquals(1, overdue.size());
+        assertEquals(bordetella.getId(), overdue.get(0).getVaccineType().getId());
+    }
+
+    /**
+     * Verifies that a vaccine given beyond its validity period is reported as overdue.
+     */
+    @Test
+    void getOverdueVaccinations_expiredVaccine_isOverdue() {
+        // Rabies given 400 days ago — validity is 365 days, so overdue
+        LocalDate longAgo = LocalDate.now().minusDays(400);
+        recordRepo.save(new VaccinationRecord(dog.getId(), rabies.getId(), longAgo));
+
+        List<OverdueVaccination> overdue = service.getOverdueVaccinations(dog);
+        boolean rabiesOverdue = overdue.stream()
+                .anyMatch(o -> o.getVaccineType().getId().equals(rabies.getId()));
+
+        assertTrue(rabiesOverdue);
+    }
+
+    /**
+     * Verifies that only the most recent dose is used when checking overdue status.
+     */
+    @Test
+    void getOverdueVaccinations_usesLatestDose() {
+        // Old dose 400 days ago, new dose today — should NOT be overdue
+        LocalDate longAgo = LocalDate.now().minusDays(400);
+        recordRepo.save(new VaccinationRecord(dog.getId(), rabies.getId(), longAgo));
+        recordRepo.save(new VaccinationRecord(dog.getId(), rabies.getId(), LocalDate.now()));
+
+        List<OverdueVaccination> overdue = service.getOverdueVaccinations(dog);
+        boolean rabiesOverdue = overdue.stream()
+                .anyMatch(o -> o.getVaccineType().getId().equals(rabies.getId()));
+
+        assertFalse(rabiesOverdue);
+    }
+
+    /**
+     * Verifies that getOverdueVaccinations rejects a null animal.
+     */
+    @Test
+    void getOverdueVaccinations_null_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.getOverdueVaccinations(null));
+    }
+
+    // ── getVaccinationHistory ─────────────────────────────────────────────────
+
+    /**
+     * Verifies that getVaccinationHistory returns all records for the given animal.
+     */
+    @Test
+    void getVaccinationHistory_returnsAllRecords() {
+        recordRepo.save(new VaccinationRecord(dog.getId(), rabies.getId(), LocalDate.now()));
+        recordRepo.save(new VaccinationRecord(dog.getId(), bordetella.getId(), LocalDate.now()));
+
+        assertEquals(2, service.getVaccinationHistory(dog).size());
+    }
+
+    /**
+     * Verifies that getVaccinationHistory returns empty list when no records exist.
+     */
+    @Test
+    void getVaccinationHistory_noRecords_returnsEmpty() {
+        assertTrue(service.getVaccinationHistory(dog).isEmpty());
+    }
+
+    /**
+     * Verifies that getVaccinationHistory rejects a null animal.
+     */
+    @Test
+    void getVaccinationHistory_null_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.getVaccinationHistory(null));
+    }
+
+    // ── findById ─────────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that findById returns the correct record when it exists.
+     */
+    @Test
+    void findById_existing_returnsRecord() {
+        VaccinationRecord record = new VaccinationRecord(dog.getId(), rabies.getId(), LocalDate.now());
+        recordRepo.save(record);
+
+        VaccinationRecord found = service.findById(record.getId());
+        assertEquals(record.getId(), found.getId());
+    }
+
+    /**
+     * Verifies that findById throws EntityNotFoundException when the ID does not exist.
+     */
+    @Test
+    void findById_notFound_throws() {
+        assertThrows(EntityNotFoundException.class, () -> service.findById("nonexistent"));
+    }
+
+    /**
+     * Verifies that findById rejects null and blank IDs.
+     */
+    @Test void findById_null_throws() {
+        assertThrows(IllegalArgumentException.class, () -> service.findById(null));
+    }
+
+    @Test void findById_blank_throws() {
+        assertThrows(IllegalArgumentException.class, () -> service.findById("  "));
+    }
+
+    // ── audit logging ─────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that recordVaccination calls auditService.log().
+     */
+    @Test
+    void recordVaccination_logsAuditEntry() {
+        SpyAuditService<VaccinationRecord> spy = new SpyAuditService<>();
+        service = new VaccinationServiceImpl(recordRepo, typeRepo, spy);
+
+        service.recordVaccination(dog, rabies, LocalDate.now());
+
+        assertEquals(1, spy.loggedActions.size());
+        assertTrue(spy.loggedActions.get(0).contains("Rabies"));
+    }
+
+    // ── in-memory stubs ───────────────────────────────────────────────────────
+
+    private static class StubVaccinationRecordRepository implements VaccinationRecordRepository {
+        private final Map<String, VaccinationRecord> store = new LinkedHashMap<>();
+
+        @Override public void save(VaccinationRecord r) { store.put(r.getId(), r); }
+        @Override public Optional<VaccinationRecord> findById(String id) { return Optional.ofNullable(store.get(id)); }
+        @Override public List<VaccinationRecord> findAll() { return new ArrayList<>(store.values()); }
+        @Override public void delete(String id) { store.remove(id); }
+        @Override public List<VaccinationRecord> findByAnimalId(String id) {
+            return store.values().stream().filter(r -> id.equals(r.getAnimalId())).collect(Collectors.toList());
+        }
+        @Override public List<VaccinationRecord> findByShelterId(String id) { return new ArrayList<>(); }
+    }
+
+    private static class StubVaccineTypeRepository implements VaccineTypeRepository {
+        private final Map<String, VaccineType> store = new LinkedHashMap<>();
+
+        @Override public void save(VaccineType v) { store.put(v.getId(), v); }
+        @Override public Optional<VaccineType> findById(String id) { return Optional.ofNullable(store.get(id)); }
+        @Override public List<VaccineType> findAll() { return new ArrayList<>(store.values()); }
+        @Override public void delete(String id) { store.remove(id); }
+        @Override public Optional<VaccineType> findByName(String name) {
+            return store.values().stream().filter(v -> v.getName().equalsIgnoreCase(name)).findFirst();
+        }
+        @Override public List<VaccineType> findByApplicableSpecies(Species species) {
+            return store.values().stream().filter(v -> v.getApplicableSpecies() == species).collect(Collectors.toList());
+        }
+    }
+
+    /** No-op audit stub. */
+    private static class NoOpAuditService<T> implements AuditService<T> {
+        @Override public void log(String action, T target) { }
+        @Override public List<AuditEntry<T>> getLog() { return new ArrayList<>(); }
+    }
+
+    /** Spy audit stub that records action strings. */
+    private static class SpyAuditService<T> implements AuditService<T> {
+        final List<String> loggedActions = new ArrayList<>();
+        @Override public void log(String action, T target) { loggedActions.add(action); }
+        @Override public List<AuditEntry<T>> getLog() { return new ArrayList<>(); }
+    }
+}


### PR DESCRIPTION
- Records vaccinations with species mismatch validation
- Detects overdue vaccinations using each vaccine type's validity window
- Uses most recent dose date when multiple records exist for same vaccine type
- Queries vaccination history by animal; findById throws EntityNotFoundException
- Injects AuditService for operation logging
- Tests cover normal paths, overdue edge cases, and null guards

Closes #18