### PR TITLE
feat(cli): full Picocli CLI covering all 8 use cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'application'
 }
 
 group = 'shelter'
@@ -10,9 +11,26 @@ repositories {
 }
 
 dependencies {
+    implementation 'info.picocli:picocli:4.7.5'
+    annotationProcessor 'info.picocli:picocli-codegen:4.7.5'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+application {
+    mainClass = 'shelter.cli.Main'
+    applicationName = 'shelter'
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'shelter.cli.Main'
+    }
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 test {

--- a/src/main/java/shelter/cli/AdoptCmd.java
+++ b/src/main/java/shelter/cli/AdoptCmd.java
@@ -1,0 +1,163 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import shelter.domain.AdoptionRequest;
+
+/**
+ * Top-level CLI command group for the adoption request lifecycle.
+ * Provides subcommands to submit, approve, reject, and cancel adoption requests.
+ * All operations are delegated to {@link AppContext#adoptionApp()}.
+ */
+@Command(
+        name = "adopt",
+        description = "Manage adoption requests",
+        subcommands = {
+                AdoptCmd.SubmitCmd.class,
+                AdoptCmd.ApproveCmd.class,
+                AdoptCmd.RejectCmd.class,
+                AdoptCmd.CancelCmd.class
+        },
+        mixinStandardHelpOptions = true
+)
+public class AdoptCmd implements Runnable {
+
+    /**
+     * Prints usage help when the subcommand group is invoked without a subcommand.
+     * This method is called by Picocli when no subcommand is specified.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter adopt <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // submit
+    // -------------------------------------------------------------------------
+
+    /**
+     * Submits a new adoption request on behalf of an adopter for a specific animal.
+     * The animal must be available (not yet adopted).
+     */
+    @Command(name = "submit", description = "Submit an adoption request",
+             mixinStandardHelpOptions = true)
+    static class SubmitCmd implements Runnable {
+
+        /** The ID of the adopter submitting the request; required. */
+        @Option(names = "--adopter", required = true, description = "Adopter ID")
+        private String adopterId;
+
+        /** The ID of the animal being requested; required. */
+        @Option(names = "--animal", required = true, description = "Animal ID")
+        private String animalId;
+
+        /**
+         * Executes the submission and prints the new request's ID.
+         * Prints an error message if the adopter or animal is not found, or the animal is not available.
+         */
+        @Override
+        public void run() {
+            try {
+                AdoptionRequest r = AppContext.get().adoptionApp()
+                        .submitRequest(adopterId, animalId);
+                System.out.printf("Submitted adoption request: id=%s (adopter=%s, animal=%s)%n",
+                        r.getId(), adopterId, animalId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // approve
+    // -------------------------------------------------------------------------
+
+    /**
+     * Approves a pending adoption request, marking the animal as adopted.
+     * Updates both the animal's adopter reference and the adopter's adopted animal list.
+     */
+    @Command(name = "approve", description = "Approve an adoption request",
+             mixinStandardHelpOptions = true)
+    static class ApproveCmd implements Runnable {
+
+        /** The ID of the adoption request to approve; required. */
+        @Option(names = "--request", required = true, description = "Adoption request ID")
+        private String requestId;
+
+        /**
+         * Executes the approval and prints a confirmation message.
+         * Prints an error message if the request is not found or is not in a pending state.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().adoptionApp().approveRequest(requestId);
+                System.out.println("Approved adoption request: " + requestId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // reject
+    // -------------------------------------------------------------------------
+
+    /**
+     * Rejects a pending adoption request, leaving the animal available for other requests.
+     * The adopter is notified of the rejection.
+     */
+    @Command(name = "reject", description = "Reject an adoption request",
+             mixinStandardHelpOptions = true)
+    static class RejectCmd implements Runnable {
+
+        /** The ID of the adoption request to reject; required. */
+        @Option(names = "--request", required = true, description = "Adoption request ID")
+        private String requestId;
+
+        /**
+         * Executes the rejection and prints a confirmation message.
+         * Prints an error message if the request is not found or is not in a pending state.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().adoptionApp().rejectRequest(requestId);
+                System.out.println("Rejected adoption request: " + requestId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // cancel
+    // -------------------------------------------------------------------------
+
+    /**
+     * Cancels a pending adoption request before it is reviewed.
+     * The animal remains available for other requests after cancellation.
+     */
+    @Command(name = "cancel", description = "Cancel an adoption request",
+             mixinStandardHelpOptions = true)
+    static class CancelCmd implements Runnable {
+
+        /** The ID of the adoption request to cancel; required. */
+        @Option(names = "--request", required = true, description = "Adoption request ID")
+        private String requestId;
+
+        /**
+         * Executes the cancellation and prints a confirmation message.
+         * Prints an error message if the request is not found or is not in a pending state.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().adoptionApp().cancelRequest(requestId);
+                System.out.println("Cancelled adoption request: " + requestId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/shelter/cli/AdopterCmd.java
+++ b/src/main/java/shelter/cli/AdopterCmd.java
@@ -1,0 +1,233 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Adopter;
+import shelter.domain.DailySchedule;
+import shelter.domain.LivingSpace;
+import shelter.domain.Species;
+
+import java.util.List;
+
+/**
+ * Top-level CLI command group for adopter management operations.
+ * Provides subcommands to register, list, update, and remove adopters.
+ * All operations are delegated to {@link AppContext#adopterApp()}.
+ */
+@Command(
+        name = "adopter",
+        description = "Manage adopters",
+        subcommands = {
+                AdopterCmd.ListCmd.class,
+                AdopterCmd.RegisterCmd.class,
+                AdopterCmd.UpdateCmd.class,
+                AdopterCmd.RemoveCmd.class
+        },
+        mixinStandardHelpOptions = true
+)
+public class AdopterCmd implements Runnable {
+
+    /**
+     * Prints usage help when the subcommand group is invoked without a subcommand.
+     * This method is called by Picocli when no subcommand is specified.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter adopter <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // list
+    // -------------------------------------------------------------------------
+
+    /**
+     * Lists all registered adopters with their IDs, names, living spaces, and schedules.
+     * Prints a message if no adopters have been registered.
+     */
+    @Command(name = "list", description = "List all adopters", mixinStandardHelpOptions = true)
+    static class ListCmd implements Runnable {
+
+        /**
+         * Executes the list operation and prints each adopter's summary to stdout.
+         * Prints a message if no adopters are found.
+         */
+        @Override
+        public void run() {
+            List<Adopter> adopters = AppContext.get().adopterApp().listAdopters();
+            if (adopters.isEmpty()) {
+                System.out.println("No adopters registered.");
+                return;
+            }
+            System.out.printf("%-36s  %-15s  %-18s  %-22s%n",
+                    "ID", "Name", "Living Space", "Schedule");
+            System.out.println("-".repeat(100));
+            for (Adopter a : adopters) {
+                System.out.printf("%-36s  %-15s  %-18s  %-22s%n",
+                        a.getId(), a.getName(), a.getLivingSpace(), a.getDailySchedule());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // register
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers a new adopter with personal details and optional preferences.
+     * Preference fields default to null (no preference) when omitted.
+     */
+    @Command(name = "register", description = "Register a new adopter",
+             mixinStandardHelpOptions = true)
+    static class RegisterCmd implements Runnable {
+
+        /** The adopter's name; required. */
+        @Option(names = "--name", required = true, description = "Adopter name")
+        private String name;
+
+        /** The adopter's living space type; required. */
+        @Option(names = "--space", required = true,
+                description = "Living space: APARTMENT, HOUSE_NO_YARD, HOUSE_WITH_YARD")
+        private LivingSpace livingSpace;
+
+        /** The adopter's daily schedule; required. */
+        @Option(names = "--schedule", required = true,
+                description = "Schedule: HOME_MOST_OF_DAY, AWAY_PART_OF_DAY, AWAY_MOST_OF_DAY")
+        private DailySchedule dailySchedule;
+
+        /** Preferred species; omit for no preference. */
+        @Option(names = "--species", description = "Preferred species (omit for no preference)")
+        private Species preferredSpecies;
+
+        /** Preferred breed; omit for no preference. */
+        @Option(names = "--breed", description = "Preferred breed (omit for no preference)")
+        private String preferredBreed;
+
+        /** Preferred activity level; omit for no preference. */
+        @Option(names = "--activity",
+                description = "Preferred activity level (omit for no preference)")
+        private ActivityLevel preferredActivityLevel;
+
+        /** Minimum preferred animal age; defaults to 0. */
+        @Option(names = "--min-age", description = "Minimum preferred animal age (default 0)")
+        private int minAge = 0;
+
+        /** Maximum preferred animal age; defaults to 20. */
+        @Option(names = "--max-age", description = "Maximum preferred animal age (default 20)")
+        private int maxAge = 20;
+
+        /**
+         * Executes the registration and prints the new adopter's ID and name.
+         * Prints an error message if registration fails.
+         */
+        @Override
+        public void run() {
+            try {
+                Adopter a = AppContext.get().adopterApp().registerAdopter(
+                        name, livingSpace, dailySchedule,
+                        preferredSpecies, preferredBreed, preferredActivityLevel,
+                        minAge, maxAge);
+                System.out.printf("Registered adopter: %s (id=%s)%n", a.getName(), a.getId());
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // update
+    // -------------------------------------------------------------------------
+
+    /**
+     * Updates an existing adopter's personal details or preferences.
+     * Only the fields provided are changed; omitted fields retain their current values.
+     */
+    @Command(name = "update", description = "Update an adopter's details",
+             mixinStandardHelpOptions = true)
+    static class UpdateCmd implements Runnable {
+
+        /** The ID of the adopter to update; required. */
+        @Option(names = "--id", required = true, description = "Adopter ID")
+        private String id;
+
+        /** New name; omit to keep current value. */
+        @Option(names = "--name", description = "New name (omit to keep current)")
+        private String name;
+
+        /** New living space; omit to keep current value. */
+        @Option(names = "--space", description = "New living space (omit to keep current)")
+        private LivingSpace livingSpace;
+
+        /** New daily schedule; omit to keep current value. */
+        @Option(names = "--schedule", description = "New schedule (omit to keep current)")
+        private DailySchedule dailySchedule;
+
+        /** New preferred species; omit to keep current value. */
+        @Option(names = "--species", description = "New preferred species (omit to keep current)")
+        private Species preferredSpecies;
+
+        /** New preferred breed; omit to keep current value. */
+        @Option(names = "--breed", description = "New preferred breed (omit to keep current)")
+        private String preferredBreed;
+
+        /** New preferred activity level; omit to keep current value. */
+        @Option(names = "--activity",
+                description = "New preferred activity level (omit to keep current)")
+        private ActivityLevel preferredActivityLevel;
+
+        /** New minimum preferred age; omit to keep current value. */
+        @Option(names = "--min-age", description = "New minimum preferred age (omit to keep current)")
+        private Integer minAge;
+
+        /** New maximum preferred age; omit to keep current value. */
+        @Option(names = "--max-age", description = "New maximum preferred age (omit to keep current)")
+        private Integer maxAge;
+
+        /**
+         * Executes the update and prints a confirmation message.
+         * Prints an error message if the adopter is not found.
+         */
+        @Override
+        public void run() {
+            try {
+                Adopter a = AppContext.get().adopterApp().updateAdopter(
+                        id, name, livingSpace, dailySchedule,
+                        preferredSpecies, preferredBreed, preferredActivityLevel,
+                        minAge, maxAge);
+                System.out.printf("Updated adopter: %s (id=%s)%n", a.getName(), a.getId());
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // remove
+    // -------------------------------------------------------------------------
+
+    /**
+     * Removes an adopter from the system by ID.
+     * The adopter must not have a pending adoption request.
+     */
+    @Command(name = "remove", description = "Remove an adopter", mixinStandardHelpOptions = true)
+    static class RemoveCmd implements Runnable {
+
+        /** The ID of the adopter to remove; required. */
+        @Option(names = "--id", required = true, description = "Adopter ID")
+        private String id;
+
+        /**
+         * Executes the removal and prints a confirmation message.
+         * Prints an error message if the adopter is not found or removal is blocked.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().adopterApp().removeAdopter(id);
+                System.out.println("Removed adopter: " + id);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/shelter/cli/AnimalCmd.java
+++ b/src/main/java/shelter/cli/AnimalCmd.java
@@ -1,0 +1,262 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Animal;
+import shelter.domain.Dog;
+import shelter.domain.Rabbit;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Top-level CLI command group for animal management operations.
+ * Provides subcommands to admit, list, update, and remove animals.
+ * All operations are delegated to {@link AppContext#animalApp()}.
+ */
+@Command(
+        name = "animal",
+        description = "Manage animals",
+        subcommands = {
+                AnimalCmd.ListCmd.class,
+                AnimalCmd.AdmitCmd.class,
+                AnimalCmd.UpdateCmd.class,
+                AnimalCmd.RemoveCmd.class
+        },
+        mixinStandardHelpOptions = true
+)
+public class AnimalCmd implements Runnable {
+
+    /**
+     * Prints usage help when the subcommand group is invoked without a subcommand.
+     * This method is called by Picocli when no subcommand is specified.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter animal <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // list
+    // -------------------------------------------------------------------------
+
+    /**
+     * Lists animals in the system, optionally filtered to a specific shelter.
+     * Without {@code --shelter}, all animals system-wide are returned.
+     */
+    @Command(name = "list", description = "List animals (optionally by shelter)",
+             mixinStandardHelpOptions = true)
+    static class ListCmd implements Runnable {
+
+        /** Shelter ID filter; omit to list all animals across all shelters. */
+        @Option(names = "--shelter", description = "Shelter ID (omit for all shelters)")
+        private String shelterId;
+
+        /**
+         * Executes the list operation and prints each animal's details to stdout.
+         * Prints a message if no animals are found.
+         */
+        @Override
+        public void run() {
+            try {
+                List<Animal> animals = AppContext.get().animalApp().listAnimals(shelterId);
+                if (animals.isEmpty()) {
+                    System.out.println("No animals found.");
+                    return;
+                }
+                System.out.printf("%-36s  %-10s  %-12s  %-20s  %-4s  %-8s  %s%n",
+                        "ID", "Species", "Name", "Breed", "Age", "Activity", "Status");
+                System.out.println("-".repeat(110));
+                for (Animal a : animals) {
+                    String status = a.isAvailable() ? "available" : "adopted";
+                    System.out.printf("%-36s  %-10s  %-12s  %-20s  %-4d  %-8s  %s%n",
+                            a.getId(), a.getSpecies(), a.getName(), a.getBreed(),
+                            a.getAge(), a.getActivityLevel(), status);
+                }
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // admit
+    // -------------------------------------------------------------------------
+
+    /**
+     * Admits a new animal into a shelter.
+     * The species is specified with {@code --species} and routes to the appropriate admit method.
+     * Species-specific flags (size, fur, indoor, etc.) are optional with sensible defaults.
+     * Either {@code --birthday} or {@code --age} must be provided to indicate the animal's age.
+     */
+    @Command(name = "admit", description = "Admit a new animal into a shelter",
+             mixinStandardHelpOptions = true)
+    static class AdmitCmd implements Runnable {
+
+        /** The species of the animal; required. Valid values: dog, cat, rabbit, other. */
+        @Option(names = "--species", required = true,
+                description = "Species: dog, cat, rabbit, other")
+        private String species;
+
+        /** The animal's name; required. */
+        @Option(names = "--name", required = true, description = "Animal name")
+        private String name;
+
+        /** The animal's breed or description; required. */
+        @Option(names = "--breed", required = true, description = "Breed or description")
+        private String breed;
+
+        /** The animal's date of birth in ISO format (yyyy-MM-dd); takes priority over --age. */
+        @Option(names = "--birthday", description = "Date of birth (yyyy-MM-dd)")
+        private LocalDate birthday;
+
+        /** The animal's approximate age in years; converted to a birthday if --birthday is absent. */
+        @Option(names = "--age", description = "Age in years (alternative to --birthday)")
+        private Integer age;
+
+        /** The animal's activity level; required. Valid values: LOW, MEDIUM, HIGH. */
+        @Option(names = "--activity", required = true,
+                description = "Activity level: LOW, MEDIUM, HIGH")
+        private ActivityLevel activityLevel;
+
+        /** The ID of the shelter to admit the animal into; required. */
+        @Option(names = "--shelter", required = true, description = "Shelter ID")
+        private String shelterId;
+
+        /** Dog size; used only when species is dog. Defaults to MEDIUM. */
+        @Option(names = "--size", description = "Dog size: SMALL, MEDIUM, LARGE (dogs only)")
+        private Dog.Size size = Dog.Size.MEDIUM;
+
+        /** Whether the dog or cat is neutered; used for dogs and cats. */
+        @Option(names = "--neutered", description = "Whether the animal is neutered (dogs/cats)")
+        private boolean neutered;
+
+        /** Whether the cat lives indoors; used only when species is cat. */
+        @Option(names = "--indoor", description = "Whether the cat is indoor (cats only)")
+        private boolean indoor;
+
+        /** Rabbit fur length; used only when species is rabbit. Defaults to SHORT. */
+        @Option(names = "--fur", description = "Rabbit fur length: SHORT, LONG (rabbits only)")
+        private Rabbit.FurLength furLength = Rabbit.FurLength.SHORT;
+
+        /** Free-form species name for unclassified animals; used only when species is other. */
+        @Option(names = "--species-name",
+                description = "Species description for 'other' (e.g. fish)")
+        private String speciesName = "unknown";
+
+        /**
+         * Executes the admit operation by routing to the appropriate typed admit method.
+         * Prints the new animal's ID and details upon success.
+         * Prints an error message if the shelter is not found, is at capacity, or input is invalid.
+         */
+        @Override
+        public void run() {
+            // Resolve birthday: prefer --birthday; fall back to converting --age to an approximate date
+            LocalDate resolvedBirthday = birthday;
+            if (resolvedBirthday == null) {
+                if (age == null || age < 0) {
+                    System.err.println("Error: provide --birthday (yyyy-MM-dd) or --age <years>.");
+                    return;
+                }
+                resolvedBirthday = LocalDate.now().minusYears(age);
+            }
+
+            try {
+                Animal animal;
+                switch (species.toLowerCase()) {
+                    case "dog" -> animal = AppContext.get().animalApp()
+                            .admitDog(name, breed, resolvedBirthday, activityLevel,
+                                      shelterId, size, neutered);
+                    case "cat" -> animal = AppContext.get().animalApp()
+                            .admitCat(name, breed, resolvedBirthday, activityLevel,
+                                      shelterId, indoor, neutered);
+                    case "rabbit" -> animal = AppContext.get().animalApp()
+                            .admitRabbit(name, breed, resolvedBirthday, activityLevel,
+                                         shelterId, furLength);
+                    case "other" -> animal = AppContext.get().animalApp()
+                            .admitOther(name, breed, resolvedBirthday, activityLevel,
+                                        shelterId, speciesName);
+                    default -> {
+                        System.err.println("Error: unknown species '" + species
+                                + "'. Valid values: dog, cat, rabbit, other.");
+                        return;
+                    }
+                }
+                System.out.printf("Admitted %s: %s (id=%s, shelter=%s)%n",
+                        animal.getSpecies(), animal.getName(), animal.getId(), shelterId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // update
+    // -------------------------------------------------------------------------
+
+    /**
+     * Updates an existing animal's mutable fields.
+     * Breed and birthday are immutable; only name and activity level can be changed.
+     */
+    @Command(name = "update", description = "Update an animal's mutable details",
+             mixinStandardHelpOptions = true)
+    static class UpdateCmd implements Runnable {
+
+        /** The ID of the animal to update; required. */
+        @Option(names = "--id", required = true, description = "Animal ID")
+        private String id;
+
+        /** The new name; omit to keep current value. */
+        @Option(names = "--name", description = "New name (omit to keep current)")
+        private String name;
+
+        /** The new activity level; omit to keep current value. */
+        @Option(names = "--activity", description = "New activity level (omit to keep current)")
+        private ActivityLevel activityLevel;
+
+        /**
+         * Executes the update and prints a confirmation message with the updated values.
+         * Prints an error message if the animal is not found.
+         */
+        @Override
+        public void run() {
+            try {
+                Animal a = AppContext.get().animalApp().updateAnimal(id, name, activityLevel);
+                System.out.printf("Updated animal: %s (id=%s)%n", a.getName(), a.getId());
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // remove
+    // -------------------------------------------------------------------------
+
+    /**
+     * Removes an animal from the system by ID.
+     * The animal must not have a pending adoption request.
+     */
+    @Command(name = "remove", description = "Remove an animal", mixinStandardHelpOptions = true)
+    static class RemoveCmd implements Runnable {
+
+        /** The ID of the animal to remove; required. */
+        @Option(names = "--id", required = true, description = "Animal ID")
+        private String id;
+
+        /**
+         * Executes the removal and prints a confirmation message.
+         * Prints an error message if the animal is not found or removal is blocked.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().animalApp().removeAnimal(id);
+                System.out.println("Removed animal: " + id);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/shelter/cli/AppContext.java
+++ b/src/main/java/shelter/cli/AppContext.java
@@ -1,0 +1,248 @@
+package shelter.cli;
+
+import shelter.application.AdopterApplicationService;
+import shelter.application.AdoptionApplicationService;
+import shelter.application.AnimalApplicationService;
+import shelter.application.AuditApplicationService;
+import shelter.application.MatchingApplicationService;
+import shelter.application.ShelterApplicationService;
+import shelter.application.TransferApplicationService;
+import shelter.application.VaccinationApplicationService;
+import shelter.application.impl.AdopterApplicationServiceImpl;
+import shelter.application.impl.AdoptionApplicationServiceImpl;
+import shelter.application.impl.AnimalApplicationServiceImpl;
+import shelter.application.impl.AuditApplicationServiceImpl;
+import shelter.application.impl.MatchingApplicationServiceImpl;
+import shelter.application.impl.ShelterApplicationServiceImpl;
+import shelter.application.impl.TransferApplicationServiceImpl;
+import shelter.application.impl.VaccinationApplicationServiceImpl;
+import shelter.domain.AdoptionRequest;
+import shelter.domain.Animal;
+import shelter.domain.Adopter;
+import shelter.domain.Shelter;
+import shelter.domain.Staff;
+import shelter.domain.TransferRequest;
+import shelter.domain.VaccinationRecord;
+import shelter.repository.csv.CsvAdopterRepository;
+import shelter.repository.csv.CsvAdoptionRequestRepository;
+import shelter.repository.csv.CsvAnimalRepository;
+import shelter.repository.csv.CsvAuditRepository;
+import shelter.repository.csv.CsvShelterRepository;
+import shelter.repository.csv.CsvTransferRequestRepository;
+import shelter.repository.csv.CsvVaccinationRecordRepository;
+import shelter.repository.csv.CsvVaccineTypeRepository;
+import shelter.service.AdopterBasedMatchingService;
+import shelter.service.AnimalBasedMatchingService;
+import shelter.service.ExplanationService;
+import shelter.service.impl.AdopterBasedMatchingServiceImpl;
+import shelter.service.impl.AdopterServiceImpl;
+import shelter.service.impl.AdoptionServiceImpl;
+import shelter.service.impl.AnimalBasedMatchingServiceImpl;
+import shelter.service.impl.AnimalServiceImpl;
+import shelter.service.impl.AuditServiceImpl;
+import shelter.service.impl.MockExplanationService;
+import shelter.service.impl.RequestNotificationServiceImpl;
+import shelter.service.impl.ShelterServiceImpl;
+import shelter.service.impl.TransferServiceImpl;
+import shelter.service.impl.VaccinationServiceImpl;
+import shelter.service.impl.VaccineTypeCatalogServiceImpl;
+import shelter.strategy.ActivityLevelStrategy;
+import shelter.strategy.AgePreferenceStrategy;
+import shelter.strategy.BreedPreferenceStrategy;
+import shelter.strategy.IMatchingStrategy;
+import shelter.strategy.LifestyleCompatibilityStrategy;
+import shelter.strategy.SpeciesPreferenceStrategy;
+import shelter.strategy.VaccinationPreferenceStrategy;
+
+import java.util.List;
+
+/**
+ * Singleton dependency-injection container that wires together all repositories, services,
+ * and application-layer objects for a single CLI command execution.
+ * Repositories are initialized from the given data directory; a hardcoded admin staff member
+ * is used as the current session operator.
+ */
+public class AppContext {
+
+    /** The data directory path used for all CSV repositories. */
+    public static final String DATA_DIR =
+            System.getProperty("user.home") + "/shelter/data";
+
+    private static AppContext instance;
+
+    private final AnimalApplicationService animalAppService;
+    private final AdopterApplicationService adopterAppService;
+    private final ShelterApplicationService shelterAppService;
+    private final AdoptionApplicationService adoptionAppService;
+    private final TransferApplicationService transferAppService;
+    private final MatchingApplicationService matchingAppService;
+    private final VaccinationApplicationService vaccinationAppService;
+    private final AuditApplicationService auditAppService;
+    private final ExplanationService explanationService;
+
+    /**
+     * Returns the singleton AppContext, initializing it on first call.
+     * Subsequent calls return the same instance without re-loading data.
+     *
+     * @return the shared AppContext instance
+     */
+    public static AppContext get() {
+        if (instance == null) {
+            instance = new AppContext(DATA_DIR);
+        }
+        return instance;
+    }
+
+    /**
+     * Constructs an AppContext by wiring all repositories, services, and application services.
+     * Uses the given data directory for all CSV-backed repositories and a hardcoded admin staff.
+     *
+     * @param dataDir the path to the directory where CSV data files are stored
+     */
+    private AppContext(String dataDir) {
+        // Hardcoded admin staff for the demo session
+        Staff admin = new Staff("Admin", "Manager");
+
+        // --- Repositories ---
+        CsvShelterRepository shelterRepo         = new CsvShelterRepository(dataDir);
+        CsvAnimalRepository animalRepo           = new CsvAnimalRepository(dataDir);
+        CsvAdopterRepository adopterRepo         = new CsvAdopterRepository(dataDir);
+        CsvAdoptionRequestRepository adoptionRepo =
+                new CsvAdoptionRequestRepository(dataDir, animalRepo, adopterRepo);
+        CsvTransferRequestRepository transferRepo =
+                new CsvTransferRequestRepository(dataDir, animalRepo, shelterRepo);
+        CsvVaccineTypeRepository vaccTypeRepo    = new CsvVaccineTypeRepository(dataDir);
+        CsvVaccinationRecordRepository vacRepo   =
+                new CsvVaccinationRecordRepository(dataDir, animalRepo);
+        CsvAuditRepository auditRepo             = new CsvAuditRepository(dataDir);
+
+        // --- Typed audit services (one per domain type) ---
+        AuditServiceImpl<Shelter>           shelterAudit    = new AuditServiceImpl<>(admin, auditRepo);
+        AuditServiceImpl<Animal>            animalAudit     = new AuditServiceImpl<>(admin, auditRepo);
+        AuditServiceImpl<Adopter>           adopterAudit    = new AuditServiceImpl<>(admin, auditRepo);
+        AuditServiceImpl<AdoptionRequest>   adoptionAudit   = new AuditServiceImpl<>(admin, auditRepo);
+        AuditServiceImpl<TransferRequest>   transferAudit   = new AuditServiceImpl<>(admin, auditRepo);
+        AuditServiceImpl<VaccinationRecord> vacAudit        = new AuditServiceImpl<>(admin, auditRepo);
+        AuditServiceImpl<Object>            vaccTypeAudit   = new AuditServiceImpl<>(admin, auditRepo);
+
+        // --- Core services ---
+        ShelterServiceImpl shelterService    = new ShelterServiceImpl(shelterRepo);
+        AnimalServiceImpl animalService      = new AnimalServiceImpl(animalRepo);
+        AdopterServiceImpl adopterService    = new AdopterServiceImpl(adopterRepo);
+        AdoptionServiceImpl adoptionService  =
+                new AdoptionServiceImpl(adoptionRepo, animalRepo, adopterRepo, adoptionAudit);
+        TransferServiceImpl transferService  =
+                new TransferServiceImpl(transferRepo, animalRepo, shelterRepo, transferAudit);
+        VaccineTypeCatalogServiceImpl vaccTypeCatalogService =
+                new VaccineTypeCatalogServiceImpl(vaccTypeRepo);
+        VaccinationServiceImpl vaccinationService =
+                new VaccinationServiceImpl(vacRepo, vaccTypeRepo, vacAudit);
+        RequestNotificationServiceImpl notificationService =
+                new RequestNotificationServiceImpl(admin, auditRepo);
+
+        // --- Matching strategies (all active for the demo) ---
+        List<IMatchingStrategy> strategies = List.of(
+                new SpeciesPreferenceStrategy(),
+                new BreedPreferenceStrategy(),
+                new ActivityLevelStrategy(),
+                new AgePreferenceStrategy(),
+                new LifestyleCompatibilityStrategy(),
+                new VaccinationPreferenceStrategy()
+        );
+        AdopterBasedMatchingService adopterMatchingService =
+                new AdopterBasedMatchingServiceImpl(strategies);
+        AnimalBasedMatchingService animalMatchingService =
+                new AnimalBasedMatchingServiceImpl(strategies);
+
+        // --- Application services ---
+        shelterAppService    = new ShelterApplicationServiceImpl(shelterService, shelterAudit);
+        animalAppService     = new AnimalApplicationServiceImpl(animalService, shelterService, animalAudit);
+        adopterAppService    = new AdopterApplicationServiceImpl(adopterService, adopterAudit);
+        adoptionAppService   = new AdoptionApplicationServiceImpl(
+                adoptionService, animalService, adopterService, notificationService, adoptionAudit);
+        transferAppService   = new TransferApplicationServiceImpl(
+                transferService, animalService, shelterService, notificationService, transferAudit);
+        matchingAppService   = new MatchingApplicationServiceImpl(
+                adopterMatchingService, animalMatchingService,
+                animalService, adopterService, shelterService,
+                new MockExplanationService());
+        explanationService = new MockExplanationService();
+        vaccinationAppService = new VaccinationApplicationServiceImpl(
+                vaccinationService, vaccTypeCatalogService, animalService, vaccTypeAudit);
+
+        // Audit log delegates to the persistent repository to show the full history across sessions
+        auditAppService = new AuditApplicationServiceImpl(new shelter.service.AuditService<String>() {
+            @Override
+            public void log(String action, String target) { /* no-op: only used for reading */ }
+
+            @Override
+            public java.util.List<shelter.service.model.AuditEntry<String>> getLog() {
+                return auditRepo.findAll();
+            }
+        });
+    }
+
+    /**
+     * Returns the application service for animal management operations.
+     *
+     * @return the {@link AnimalApplicationService} instance
+     */
+    public AnimalApplicationService animalApp()      { return animalAppService; }
+
+    /**
+     * Returns the application service for adopter management operations.
+     *
+     * @return the {@link AdopterApplicationService} instance
+     */
+    public AdopterApplicationService adopterApp()    { return adopterAppService; }
+
+    /**
+     * Returns the application service for shelter management operations.
+     *
+     * @return the {@link ShelterApplicationService} instance
+     */
+    public ShelterApplicationService shelterApp()    { return shelterAppService; }
+
+    /**
+     * Returns the application service for the adoption request lifecycle.
+     *
+     * @return the {@link AdoptionApplicationService} instance
+     */
+    public AdoptionApplicationService adoptionApp()  { return adoptionAppService; }
+
+    /**
+     * Returns the application service for the transfer request lifecycle.
+     *
+     * @return the {@link TransferApplicationService} instance
+     */
+    public TransferApplicationService transferApp()  { return transferAppService; }
+
+    /**
+     * Returns the application service for animal-adopter matching.
+     *
+     * @return the {@link MatchingApplicationService} instance
+     */
+    public MatchingApplicationService matchingApp()  { return matchingAppService; }
+
+    /**
+     * Returns the application service for vaccination and vaccine type management.
+     *
+     * @return the {@link VaccinationApplicationService} instance
+     */
+    public VaccinationApplicationService vaccinationApp() { return vaccinationAppService; }
+
+    /**
+     * Returns the application service for retrieving the session audit log.
+     *
+     * @return the {@link AuditApplicationService} instance
+     */
+    public AuditApplicationService auditApp()        { return auditAppService; }
+
+    /**
+     * Returns the explanation service used to generate natural-language match summaries.
+     * The CLI calls this directly to display structured explanation output when {@code --explain} is set.
+     *
+     * @return the {@link ExplanationService} instance
+     */
+    public ExplanationService explanationService()   { return explanationService; }
+}

--- a/src/main/java/shelter/cli/AuditCmd.java
+++ b/src/main/java/shelter/cli/AuditCmd.java
@@ -1,0 +1,69 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import shelter.service.model.AuditEntry;
+
+import java.util.List;
+
+/**
+ * Top-level CLI command group for audit log operations.
+ * Provides a subcommand to view the full persistent audit trail of staff actions.
+ * All operations are delegated to {@link AppContext#auditApp()}.
+ */
+@Command(
+        name = "audit",
+        description = "View the system audit log",
+        subcommands = {AuditCmd.LogCmd.class},
+        mixinStandardHelpOptions = true
+)
+public class AuditCmd implements Runnable {
+
+    /**
+     * Prints usage help when the subcommand group is invoked without a subcommand.
+     * This method is called by Picocli when no subcommand is specified.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter audit log");
+    }
+
+    // -------------------------------------------------------------------------
+    // log
+    // -------------------------------------------------------------------------
+
+    /**
+     * Displays the full persistent audit log of all staff actions.
+     * Reads from the CSV-backed audit repository so the history survives across command executions.
+     */
+    @Command(name = "log", description = "Display the full audit log",
+             mixinStandardHelpOptions = true)
+    static class LogCmd implements Runnable {
+
+        /**
+         * Executes the log retrieval and prints each entry with timestamp, staff, and action.
+         * Prints a message if the audit log is empty.
+         */
+        @Override
+        @SuppressWarnings("rawtypes")
+        public void run() {
+            List<AuditEntry<?>> entries = AppContext.get().auditApp().getLog();
+            if (entries.isEmpty()) {
+                System.out.println("Audit log is empty.");
+                return;
+            }
+            System.out.printf("%-20s  %-12s  %-30s  %s%n",
+                    "Timestamp", "Staff", "Action", "Target");
+            System.out.println("-".repeat(90));
+            for (AuditEntry<?> e : entries) {
+                String staffName = e.getStaff() != null ? e.getStaff().getName() : "unknown";
+                String target    = e.getTarget() != null ? e.getTarget().toString() : "";
+                // Truncate long target strings for readability
+                if (target.length() > 35) {
+                    target = target.substring(0, 32) + "...";
+                }
+                System.out.printf("%-20s  %-12s  %-30s  %s%n",
+                        e.getTimestamp(), staffName, e.getAction(), target);
+            }
+        }
+    }
+}

--- a/src/main/java/shelter/cli/Main.java
+++ b/src/main/java/shelter/cli/Main.java
@@ -1,0 +1,51 @@
+package shelter.cli;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/**
+ * Entry point for the {@code shelter} CLI tool.
+ * Registers all top-level subcommand groups and delegates execution to Picocli.
+ * On first invocation, {@link AppContext#get()} initializes all repositories and services
+ * from {@code ~/shelter/data/}; subsequent calls reuse the same wired instance.
+ */
+@Command(
+        name = "shelter",
+        description = "Multi-shelter animal adoption management system",
+        subcommands = {
+                ShelterCmd.class,
+                AnimalCmd.class,
+                AdopterCmd.class,
+                AdoptCmd.class,
+                TransferCmd.class,
+                MatchCmd.class,
+                VaccineCmd.class,
+                AuditCmd.class,
+                CommandLine.HelpCommand.class
+        },
+        mixinStandardHelpOptions = true,
+        version = "1.0"
+)
+public class Main implements Runnable {
+
+    /**
+     * Prints a brief usage hint when the CLI is invoked with no subcommand.
+     * This method is called by Picocli when the user types {@code shelter} with no arguments.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter <subcommand> --help");
+        System.out.println("Subcommands: shelter, animal, adopter, adopt, transfer, match, vaccine, audit");
+    }
+
+    /**
+     * Application entry point. Initializes Picocli and exits with the command's return code.
+     * Errors thrown during command execution are handled within each command's {@code run()} method.
+     *
+     * @param args the CLI arguments passed from the operating system
+     */
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new Main()).execute(args);
+        System.exit(exitCode);
+    }
+}

--- a/src/main/java/shelter/cli/MatchCmd.java
+++ b/src/main/java/shelter/cli/MatchCmd.java
@@ -1,0 +1,158 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import shelter.service.model.ExplanationResult;
+import shelter.service.model.MatchResult;
+
+import java.util.List;
+
+/**
+ * Top-level CLI command group for animal-adopter matching operations.
+ * Provides subcommands to match animals for an adopter or adopters for an animal.
+ * All operations are delegated to {@link AppContext#matchingApp()}.
+ */
+@Command(
+        name = "match",
+        description = "Run animal-adopter matching",
+        subcommands = {
+                MatchCmd.AnimalCmd.class,
+                MatchCmd.AdopterCmd.class
+        },
+        mixinStandardHelpOptions = true
+)
+public class MatchCmd implements Runnable {
+
+    /**
+     * Prints usage help when the subcommand group is invoked without a subcommand.
+     * This method is called by Picocli when no subcommand is specified.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter match <animal|adopter> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // match animal  (find animals for an adopter)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Finds and ranks available animals in a shelter for a given adopter.
+     * Only available (unadopted) matchable animals are scored and returned.
+     * Results are printed in descending score order; an optional AI explanation follows.
+     */
+    @Command(name = "animal",
+             description = "Find best-matching animals for an adopter",
+             mixinStandardHelpOptions = true)
+    static class AnimalCmd implements Runnable {
+
+        /** The adopter ID to match for; required. */
+        @Option(names = "--adopter", required = true, description = "Adopter ID")
+        private String adopterId;
+
+        /** The shelter ID to search in; required. */
+        @Option(names = "--shelter", required = true, description = "Shelter ID")
+        private String shelterId;
+
+        /** Whether to include a structured AI-generated explanation after the ranked list. */
+        @Option(names = "--explain", description = "Include AI match explanation")
+        private boolean explain;
+
+        /**
+         * Executes the matching, prints ranked results, and optionally prints the AI explanation.
+         * Prints a message if no available animals are found in the shelter.
+         */
+        @Override
+        public void run() {
+            try {
+                List<MatchResult> results = AppContext.get().matchingApp()
+                        .matchAnimalsForAdopter(adopterId, shelterId, false);
+                if (results.isEmpty()) {
+                    System.out.println("No available animals found in shelter " + shelterId + ".");
+                    return;
+                }
+                // Print ranked match results table
+                System.out.printf("%-4s  %-36s  %-15s  %s%n",
+                        "Rank", "Animal ID", "Name", "Score");
+                System.out.println("-".repeat(70));
+                int rank = 1;
+                for (MatchResult r : results) {
+                    System.out.printf("%-4d  %-36s  %-15s  %d%n",
+                            rank++, r.getAnimal().getId(), r.getAnimal().getName(), r.getScore());
+                }
+                // Optionally print structured explanation from the explanation service
+                if (explain) {
+                    ExplanationResult exp =
+                            AppContext.get().explanationService().explain(results);
+                    System.out.println();
+                    System.out.println("=== Match Explanation ===");
+                    System.out.println("Rationale   : " + exp.getMatchRationale());
+                    System.out.println("Confidence  : " + exp.getConfidenceAssessment());
+                    System.out.println("Advice      : " + exp.getPersonalizedAdvice());
+                }
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // match adopter  (find adopters for an animal)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Finds and ranks all registered adopters by compatibility with a given available animal.
+     * The animal must not have been adopted. Results are printed in descending score order.
+     */
+    @Command(name = "adopter",
+             description = "Find best-matching adopters for an animal",
+             mixinStandardHelpOptions = true)
+    static class AdopterCmd implements Runnable {
+
+        /** The animal ID to match for; required. */
+        @Option(names = "--animal", required = true, description = "Animal ID")
+        private String animalId;
+
+        /** Whether to include a structured AI-generated explanation after the ranked list. */
+        @Option(names = "--explain", description = "Include AI match explanation")
+        private boolean explain;
+
+        /**
+         * Executes the matching, prints ranked results, and optionally prints the AI explanation.
+         * Prints an error if the animal is not found, is already adopted, or is not matchable.
+         */
+        @Override
+        public void run() {
+            try {
+                List<MatchResult> results = AppContext.get().matchingApp()
+                        .matchAdoptersForAnimal(animalId, false);
+                if (results.isEmpty()) {
+                    System.out.println("No adopters registered.");
+                    return;
+                }
+                // Print ranked match results table
+                System.out.printf("%-4s  %-36s  %-15s  %s%n",
+                        "Rank", "Adopter ID", "Name", "Score");
+                System.out.println("-".repeat(70));
+                int rank = 1;
+                for (MatchResult r : results) {
+                    System.out.printf("%-4d  %-36s  %-15s  %d%n",
+                            rank++, r.getAdopter().getId(), r.getAdopter().getName(),
+                            r.getScore());
+                }
+                // Optionally print structured explanation from the explanation service
+                if (explain) {
+                    ExplanationResult exp =
+                            AppContext.get().explanationService().explain(results);
+                    System.out.println();
+                    System.out.println("=== Match Explanation ===");
+                    System.out.println("Rationale   : " + exp.getMatchRationale());
+                    System.out.println("Confidence  : " + exp.getConfidenceAssessment());
+                    System.out.println("Advice      : " + exp.getPersonalizedAdvice());
+                }
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/shelter/cli/ShelterCmd.java
+++ b/src/main/java/shelter/cli/ShelterCmd.java
@@ -1,0 +1,182 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import shelter.domain.Shelter;
+
+import java.util.List;
+
+/**
+ * Top-level CLI command group for shelter management operations.
+ * Provides subcommands to register, list, update, and remove shelters.
+ * All operations are delegated to {@link AppContext#shelterApp()}.
+ */
+@Command(
+        name = "shelter",
+        description = "Manage shelters",
+        subcommands = {
+                ShelterCmd.ListCmd.class,
+                ShelterCmd.RegisterCmd.class,
+                ShelterCmd.UpdateCmd.class,
+                ShelterCmd.RemoveCmd.class
+        },
+        mixinStandardHelpOptions = true
+)
+public class ShelterCmd implements Runnable {
+
+    /**
+     * Prints usage help when the subcommand group is invoked without a subcommand.
+     * This method is called by Picocli when no subcommand is specified.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter shelter <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // list
+    // -------------------------------------------------------------------------
+
+    /**
+     * Lists all registered shelters with their IDs, names, locations, and capacity usage.
+     * Prints a message if no shelters have been registered.
+     */
+    @Command(name = "list", description = "List all shelters", mixinStandardHelpOptions = true)
+    static class ListCmd implements Runnable {
+
+        /**
+         * Executes the list operation and prints each shelter's details to stdout.
+         * Prints a message if the system contains no shelters.
+         */
+        @Override
+        public void run() {
+            List<Shelter> shelters = AppContext.get().shelterApp().listShelters();
+            if (shelters.isEmpty()) {
+                System.out.println("No shelters registered.");
+                return;
+            }
+            System.out.printf("%-36s  %-20s  %-20s  %s%n",
+                    "ID", "Name", "Location", "Capacity");
+            System.out.println("-".repeat(90));
+            for (Shelter s : shelters) {
+                System.out.printf("%-36s  %-20s  %-20s  %d/%d%n",
+                        s.getId(), s.getName(), s.getLocation(),
+                        s.getCurrentCount(), s.getCapacity());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // register
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers a new shelter with the specified name, location, and capacity.
+     * Prints the new shelter's ID and details upon success.
+     */
+    @Command(name = "register", description = "Register a new shelter",
+             mixinStandardHelpOptions = true)
+    static class RegisterCmd implements Runnable {
+
+        /** The shelter name; required. */
+        @Option(names = "--name", required = true, description = "Shelter name")
+        private String name;
+
+        /** The shelter location; required. */
+        @Option(names = "--location", required = true, description = "Shelter location")
+        private String location;
+
+        /** The maximum animal capacity; required. */
+        @Option(names = "--capacity", required = true, description = "Maximum capacity")
+        private int capacity;
+
+        /**
+         * Executes the registration and prints the new shelter's ID and details.
+         * Prints an error message if registration fails (e.g., duplicate name/location).
+         */
+        @Override
+        public void run() {
+            try {
+                Shelter s = AppContext.get().shelterApp()
+                        .registerShelter(name, location, capacity);
+                System.out.printf("Registered shelter: %s (id=%s)%n", s.getName(), s.getId());
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // update
+    // -------------------------------------------------------------------------
+
+    /**
+     * Updates an existing shelter's name, location, or capacity.
+     * Only the fields provided are changed; omitted fields retain their current values.
+     */
+    @Command(name = "update", description = "Update a shelter's details",
+             mixinStandardHelpOptions = true)
+    static class UpdateCmd implements Runnable {
+
+        /** The ID of the shelter to update; required. */
+        @Option(names = "--id", required = true, description = "Shelter ID")
+        private String id;
+
+        /** The new name; omit to keep current value. */
+        @Option(names = "--name", description = "New name (omit to keep current)")
+        private String name;
+
+        /** The new location; omit to keep current value. */
+        @Option(names = "--location", description = "New location (omit to keep current)")
+        private String location;
+
+        /** The new capacity; omit to keep current value. */
+        @Option(names = "--capacity", description = "New capacity (omit to keep current)")
+        private Integer capacity;
+
+        /**
+         * Executes the update and prints a confirmation with the updated field values.
+         * Prints an error message if the shelter is not found.
+         */
+        @Override
+        public void run() {
+            try {
+                Shelter s = AppContext.get().shelterApp()
+                        .updateShelter(id, name, location, capacity);
+                System.out.printf("Updated shelter: %s (id=%s)%n", s.getName(), s.getId());
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // remove
+    // -------------------------------------------------------------------------
+
+    /**
+     * Removes a shelter from the system by ID.
+     * The shelter must have no animals and no pending transfer requests.
+     */
+    @Command(name = "remove", description = "Remove a shelter", mixinStandardHelpOptions = true)
+    static class RemoveCmd implements Runnable {
+
+        /** The ID of the shelter to remove; required. */
+        @Option(names = "--id", required = true, description = "Shelter ID")
+        private String id;
+
+        /**
+         * Executes the removal and prints a confirmation message.
+         * Prints an error message if the shelter is not found or removal is blocked.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().shelterApp().removeShelter(id);
+                System.out.println("Removed shelter: " + id);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/shelter/cli/TransferCmd.java
+++ b/src/main/java/shelter/cli/TransferCmd.java
@@ -1,0 +1,168 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import shelter.domain.TransferRequest;
+
+/**
+ * Top-level CLI command group for the inter-shelter transfer request lifecycle.
+ * Provides subcommands to request, approve, reject, and cancel transfer requests.
+ * All operations are delegated to {@link AppContext#transferApp()}.
+ */
+@Command(
+        name = "transfer",
+        description = "Manage inter-shelter transfer requests",
+        subcommands = {
+                TransferCmd.RequestCmd.class,
+                TransferCmd.ApproveCmd.class,
+                TransferCmd.RejectCmd.class,
+                TransferCmd.CancelCmd.class
+        },
+        mixinStandardHelpOptions = true
+)
+public class TransferCmd implements Runnable {
+
+    /**
+     * Prints usage help when the subcommand group is invoked without a subcommand.
+     * This method is called by Picocli when no subcommand is specified.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter transfer <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // request
+    // -------------------------------------------------------------------------
+
+    /**
+     * Initiates a transfer request to move an available animal from one shelter to another.
+     * The animal must be available and the destination shelter must not be at capacity.
+     */
+    @Command(name = "request", description = "Initiate a transfer request",
+             mixinStandardHelpOptions = true)
+    static class RequestCmd implements Runnable {
+
+        /** The ID of the animal to transfer; required. */
+        @Option(names = "--animal", required = true, description = "Animal ID")
+        private String animalId;
+
+        /** The ID of the source shelter; required. */
+        @Option(names = "--from", required = true, description = "Source shelter ID")
+        private String fromShelterId;
+
+        /** The ID of the destination shelter; required. */
+        @Option(names = "--to", required = true, description = "Destination shelter ID")
+        private String toShelterId;
+
+        /**
+         * Executes the transfer request and prints the new request's ID.
+         * Prints an error message if the animal is not found, not available, or the destination
+         * shelter is at capacity.
+         */
+        @Override
+        public void run() {
+            try {
+                TransferRequest r = AppContext.get().transferApp()
+                        .requestTransfer(animalId, fromShelterId, toShelterId);
+                System.out.printf("Transfer request created: id=%s (animal=%s, %s → %s)%n",
+                        r.getId(), animalId, fromShelterId, toShelterId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // approve
+    // -------------------------------------------------------------------------
+
+    /**
+     * Approves a pending transfer request and moves the animal to the destination shelter.
+     * Updates the animal's shelter assignment in the persistent store.
+     */
+    @Command(name = "approve", description = "Approve a transfer request",
+             mixinStandardHelpOptions = true)
+    static class ApproveCmd implements Runnable {
+
+        /** The ID of the transfer request to approve; required. */
+        @Option(names = "--request", required = true, description = "Transfer request ID")
+        private String requestId;
+
+        /**
+         * Executes the approval and prints a confirmation message.
+         * Prints an error message if the request is not found or is not in a pending state.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().transferApp().approveTransfer(requestId);
+                System.out.println("Approved transfer request: " + requestId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // reject
+    // -------------------------------------------------------------------------
+
+    /**
+     * Rejects a pending transfer request, leaving the animal in the source shelter.
+     * The destination shelter remains unaffected.
+     */
+    @Command(name = "reject", description = "Reject a transfer request",
+             mixinStandardHelpOptions = true)
+    static class RejectCmd implements Runnable {
+
+        /** The ID of the transfer request to reject; required. */
+        @Option(names = "--request", required = true, description = "Transfer request ID")
+        private String requestId;
+
+        /**
+         * Executes the rejection and prints a confirmation message.
+         * Prints an error message if the request is not found or is not in a pending state.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().transferApp().rejectTransfer(requestId);
+                System.out.println("Rejected transfer request: " + requestId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // cancel
+    // -------------------------------------------------------------------------
+
+    /**
+     * Cancels a pending transfer request that has not yet been reviewed.
+     * The animal remains in the source shelter after cancellation.
+     */
+    @Command(name = "cancel", description = "Cancel a transfer request",
+             mixinStandardHelpOptions = true)
+    static class CancelCmd implements Runnable {
+
+        /** The ID of the transfer request to cancel; required. */
+        @Option(names = "--request", required = true, description = "Transfer request ID")
+        private String requestId;
+
+        /**
+         * Executes the cancellation and prints a confirmation message.
+         * Prints an error message if the request is not found or is not in a pending state.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().transferApp().cancelTransfer(requestId);
+                System.out.println("Cancelled transfer request: " + requestId);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/shelter/cli/VaccineCmd.java
+++ b/src/main/java/shelter/cli/VaccineCmd.java
@@ -1,0 +1,285 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import shelter.domain.Species;
+import shelter.domain.VaccineType;
+import shelter.service.model.OverdueVaccination;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Top-level CLI command group for vaccination management operations.
+ * Provides subcommands to record vaccinations, check overdue status, and manage vaccine types.
+ * All operations are delegated to {@link AppContext#vaccinationApp()}.
+ */
+@Command(
+        name = "vaccine",
+        description = "Manage vaccinations and vaccine types",
+        subcommands = {
+                VaccineCmd.RecordCmd.class,
+                VaccineCmd.OverdueCmd.class,
+                VaccineCmd.TypeCmd.class
+        },
+        mixinStandardHelpOptions = true
+)
+public class VaccineCmd implements Runnable {
+
+    /**
+     * Prints usage help when the subcommand group is invoked without a subcommand.
+     * This method is called by Picocli when no subcommand is specified.
+     */
+    @Override
+    public void run() {
+        System.out.println("Usage: shelter vaccine <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // record
+    // -------------------------------------------------------------------------
+
+    /**
+     * Records that an animal received a specific vaccine on a given date.
+     * The vaccine type must exist in the catalog and apply to the animal's species.
+     */
+    @Command(name = "record", description = "Record a vaccination for an animal",
+             mixinStandardHelpOptions = true)
+    static class RecordCmd implements Runnable {
+
+        /** The ID of the animal that was vaccinated; required. */
+        @Option(names = "--animal", required = true, description = "Animal ID")
+        private String animalId;
+
+        /** The name of the vaccine type administered; required. */
+        @Option(names = "--type", required = true, description = "Vaccine type name")
+        private String vaccineTypeName;
+
+        /** The date the vaccine was administered (yyyy-MM-dd); required. */
+        @Option(names = "--date", required = true, description = "Date administered (yyyy-MM-dd)")
+        private LocalDate date;
+
+        /**
+         * Executes the vaccination record and prints a confirmation message.
+         * Prints an error if the animal is not found, vaccine type is unknown, or species mismatch.
+         */
+        @Override
+        public void run() {
+            try {
+                AppContext.get().vaccinationApp()
+                        .recordVaccination(animalId, vaccineTypeName, date);
+                System.out.printf("Recorded vaccination: animal=%s, type=%s, date=%s%n",
+                        animalId, vaccineTypeName, date);
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // overdue
+    // -------------------------------------------------------------------------
+
+    /**
+     * Checks which vaccinations are overdue for a given animal.
+     * An overdue vaccination is one that is either missing or past its validity period.
+     */
+    @Command(name = "overdue",
+             description = "List overdue vaccinations for an animal",
+             mixinStandardHelpOptions = true)
+    static class OverdueCmd implements Runnable {
+
+        /** The ID of the animal to check; required. */
+        @Option(names = "--animal", required = true, description = "Animal ID")
+        private String animalId;
+
+        /**
+         * Executes the overdue check and prints each overdue vaccination.
+         * Prints a confirmation message if all vaccinations are current.
+         */
+        @Override
+        public void run() {
+            try {
+                List<OverdueVaccination> overdueList = AppContext.get().vaccinationApp()
+                        .getOverdueVaccinations(animalId);
+                if (overdueList.isEmpty()) {
+                    System.out.println("All vaccinations are current for animal: " + animalId);
+                    return;
+                }
+                System.out.printf("%-25s  %-12s%n", "Vaccine Type", "Due Date");
+                System.out.println("-".repeat(40));
+                for (OverdueVaccination ov : overdueList) {
+                    System.out.printf("%-25s  %-12s%n",
+                            ov.getVaccineType().getName(), ov.getDueDate());
+                }
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // type (sub-group: list / add / update / remove)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Subcommand group for vaccine type catalog management.
+     * Provides add, update, remove, and list operations for vaccine types.
+     */
+    @Command(
+            name = "type",
+            description = "Manage vaccine types",
+            subcommands = {
+                    TypeCmd.ListCmd.class,
+                    TypeCmd.AddCmd.class,
+                    TypeCmd.UpdateCmd.class,
+                    TypeCmd.RemoveCmd.class
+            },
+            mixinStandardHelpOptions = true
+    )
+    static class TypeCmd implements Runnable {
+
+        /**
+         * Prints usage help when invoked without a subcommand.
+         * This method is called by Picocli when no nested subcommand is specified.
+         */
+        @Override
+        public void run() {
+            System.out.println("Usage: shelter vaccine type <subcommand> --help");
+        }
+
+        /**
+         * Lists all vaccine types in the catalog with their IDs, names, species, and validity periods.
+         * Prints a message if the catalog is empty.
+         */
+        @Command(name = "list", description = "List all vaccine types",
+                 mixinStandardHelpOptions = true)
+        static class ListCmd implements Runnable {
+
+            /**
+             * Executes the list and prints each vaccine type's details.
+             * Prints a message if no vaccine types have been added.
+             */
+            @Override
+            public void run() {
+                List<VaccineType> types = AppContext.get().vaccinationApp().listVaccineTypes();
+                if (types.isEmpty()) {
+                    System.out.println("No vaccine types in catalog.");
+                    return;
+                }
+                System.out.printf("%-36s  %-20s  %-10s  %s%n",
+                        "ID", "Name", "Species", "Validity (days)");
+                System.out.println("-".repeat(80));
+                for (VaccineType t : types) {
+                    System.out.printf("%-36s  %-20s  %-10s  %d%n",
+                            t.getId(), t.getName(), t.getApplicableSpecies(), t.getValidityDays());
+                }
+            }
+        }
+
+        /**
+         * Adds a new vaccine type to the catalog with a name, applicable species, and validity period.
+         * Throws an error if a vaccine type with the same name already exists.
+         */
+        @Command(name = "add", description = "Add a new vaccine type to the catalog",
+                 mixinStandardHelpOptions = true)
+        static class AddCmd implements Runnable {
+
+            /** The vaccine type name; required. */
+            @Option(names = "--name", required = true, description = "Vaccine type name")
+            private String name;
+
+            /** The applicable species; required. */
+            @Option(names = "--species", required = true,
+                    description = "Applicable species: DOG, CAT, RABBIT, OTHER")
+            private Species species;
+
+            /** The validity period in days; required. */
+            @Option(names = "--days", required = true, description = "Validity period in days")
+            private int days;
+
+            /**
+             * Executes the add operation and prints the new vaccine type's ID and name.
+             * Prints an error if a duplicate name exists.
+             */
+            @Override
+            public void run() {
+                try {
+                    VaccineType t = AppContext.get().vaccinationApp()
+                            .addVaccineType(name, species, days);
+                    System.out.printf("Added vaccine type: %s (id=%s, species=%s, validity=%d days)%n",
+                            t.getName(), t.getId(), t.getApplicableSpecies(), t.getValidityDays());
+                } catch (Exception e) {
+                    System.err.println("Error: " + e.getMessage());
+                }
+            }
+        }
+
+        /**
+         * Updates an existing vaccine type's name, species, or validity period by ID.
+         * Only provided fields are changed; omitted fields retain their current values.
+         */
+        @Command(name = "update", description = "Update a vaccine type",
+                 mixinStandardHelpOptions = true)
+        static class UpdateCmd implements Runnable {
+
+            /** The ID of the vaccine type to update; required. */
+            @Option(names = "--id", required = true, description = "Vaccine type ID")
+            private String id;
+
+            /** New name; omit to keep current value. */
+            @Option(names = "--name", description = "New name (omit to keep current)")
+            private String name;
+
+            /** New applicable species; omit to keep current value. */
+            @Option(names = "--species", description = "New species (omit to keep current)")
+            private Species species;
+
+            /** New validity period; omit to keep current value. */
+            @Option(names = "--days", description = "New validity days (omit to keep current)")
+            private Integer days;
+
+            /**
+             * Executes the update and prints a confirmation message.
+             * Prints an error if the vaccine type is not found or the new name conflicts.
+             */
+            @Override
+            public void run() {
+                try {
+                    VaccineType t = AppContext.get().vaccinationApp()
+                            .updateVaccineType(id, name, species, days);
+                    System.out.printf("Updated vaccine type: %s (id=%s)%n", t.getName(), t.getId());
+                } catch (Exception e) {
+                    System.err.println("Error: " + e.getMessage());
+                }
+            }
+        }
+
+        /**
+         * Removes a vaccine type from the catalog by ID.
+         * Throws an error if the vaccine type is not found.
+         */
+        @Command(name = "remove", description = "Remove a vaccine type from the catalog",
+                 mixinStandardHelpOptions = true)
+        static class RemoveCmd implements Runnable {
+
+            /** The ID of the vaccine type to remove; required. */
+            @Option(names = "--id", required = true, description = "Vaccine type ID")
+            private String id;
+
+            /**
+             * Executes the removal and prints a confirmation message.
+             * Prints an error if the vaccine type is not found.
+             */
+            @Override
+            public void run() {
+                try {
+                    AppContext.get().vaccinationApp().removeVaccineType(id);
+                    System.out.println("Removed vaccine type: " + id);
+                } catch (Exception e) {
+                    System.err.println("Error: " + e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/shelter/service/impl/MockExplanationService.java
+++ b/src/main/java/shelter/service/impl/MockExplanationService.java
@@ -7,26 +7,27 @@ import shelter.service.model.MatchResult;
 import java.util.List;
 
 /**
- * A deterministic, non-AI implementation of {@link ExplanationService} for use in unit tests.
- * Returns fixed, predictable explanation components that do not depend on any external AI service,
- * ensuring tests remain fast, isolated, and reproducible regardless of network or API availability.
+ * A deterministic, non-AI implementation of {@link ExplanationService} used as the default
+ * placeholder until {@code AIExplanationService} is integrated.
+ * Returns a fixed "not connected" message for every field instead of an AI-generated explanation,
+ * making it clear to demo viewers that no real AI output is being produced.
  */
 public class MockExplanationService implements ExplanationService {
 
+    /** Placeholder message shown in every explanation field when no AI service is connected. */
+    private static final String NOT_CONNECTED_MESSAGE =
+            "AI explanation service is not connected — no explanation available.";
+
     /**
-     * Returns a fixed ExplanationResult containing placeholder values for each explanation component.
-     * The result is derived purely from the size of the input list so tests can assert on stable output
-     * without any AI call or random behavior.
+     * Returns an ExplanationResult whose every field is the fixed "not connected" placeholder.
+     * This method ignores the input {@code results} entirely and never calls any external service,
+     * keeping tests deterministic and making the absence of a real AI explanation obvious in demo output.
      *
      * @param results the ranked list of match results to explain; may be empty but must not be null
-     * @return a deterministic ExplanationResult with fixed placeholder strings
+     * @return an ExplanationResult with the "not connected" placeholder in every field
      */
     @Override
     public ExplanationResult explain(List<MatchResult> results) {
-        // Build a stable rationale that mentions the number of results for minimal test assertability
-        String rationale = "Mock rationale: " + results.size() + " match(es) evaluated.";
-        String confidence = "Mock confidence: scores are deterministic in test mode.";
-        String advice = "Mock advice: review all candidates before deciding.";
-        return new ExplanationResult(rationale, confidence, advice);
+        return new ExplanationResult(NOT_CONNECTED_MESSAGE, NOT_CONNECTED_MESSAGE, NOT_CONNECTED_MESSAGE);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `shelter` CLI tool as presentation layer, every UC-01 to UC-08 reachable as a subcommand
- CLI delegates to application layer — no business logic in `shelter.cli` package
- `AppContext` wires all repositories, services, and application services (temporary — will be replaced by `SystemStartupImpl` in #20)
- `MockExplanationService` now returns a clear "not connected" placeholder so demo output makes it obvious when real AI isn't integrated (#22)

## What's implemented
- `Main.java` — Picocli entry point registering all top-level subcommand groups
- `AppContext.java` — singleton DI container, includes inline read-only `AuditService` that reads `CsvAuditRepository.findAll()` for cross-session audit history
- 8 command groups: `ShelterCmd`, `AnimalCmd`, `AdopterCmd`, `AdoptCmd`, `TransferCmd`, `MatchCmd`, `VaccineCmd`, `AuditCmd`
- `build.gradle` — Picocli 4.7.5, `application` plugin, fat JAR config, `applicationName = 'shelter'`

Full command reference, demo setup notes, and known limitations are documented in #41. Closes #21.

## Test plan
- [x] `./gradlew test` — all 357 existing tests pass
- [x] `./gradlew installDist` — produces `build/install/shelter/bin/shelter`
- [x] `shelter --help` lists every top-level subcommand
- [x] End-to-end smoke test: register shelter → admit dog → register adopter → run `match animal` → verify match result → check `audit log` shows all actions
- [x] `shelter match animal --explain` now prints the "not connected" placeholder instead of the old fake mock text