### PR TITLE
Feat/strategy layer-Implement Strategy Layer Matching and Tests

### DIFF
--- a/src/main/java/shelter/application/AdopterApplicationService.java
+++ b/src/main/java/shelter/application/AdopterApplicationService.java
@@ -26,13 +26,16 @@ public interface AdopterApplicationService {
      * @param preferredSpecies       the preferred species, or {@code null} for no preference
      * @param preferredBreed         the preferred breed, or {@code null} for no preference
      * @param preferredActivityLevel the preferred activity level, or {@code null} for no preference
+     * @param requiresVaccinated     {@code true} if vaccinated animals are required,
+     *                               or {@code null} for no vaccination preference
      * @param minAge                 the minimum preferred animal age; must be non-negative
      * @param maxAge                 the maximum preferred animal age; must be &gt;= {@code minAge}
      * @return the newly created {@link Adopter}
      */
     Adopter registerAdopter(String name, LivingSpace livingSpace, DailySchedule dailySchedule,
                              Species preferredSpecies, String preferredBreed,
-                             ActivityLevel preferredActivityLevel, int minAge, int maxAge);
+                             ActivityLevel preferredActivityLevel, Boolean requiresVaccinated,
+                             int minAge, int maxAge);
 
     /**
      * Returns a list of all registered adopters in the system.
@@ -54,6 +57,7 @@ public interface AdopterApplicationService {
      * @param preferredSpecies       the new preferred species, or {@code null} to keep the current value
      * @param preferredBreed         the new preferred breed, or {@code null} to keep the current value
      * @param preferredActivityLevel the new preferred activity level, or {@code null} to keep the current value
+     * @param requiresVaccinated     the new vaccination requirement, or {@code null} to keep the current value
      * @param minAge                 the new minimum preferred age, or {@code null} to keep the current value
      * @param maxAge                 the new maximum preferred age, or {@code null} to keep the current value
      * @return the updated {@link Adopter}
@@ -61,7 +65,7 @@ public interface AdopterApplicationService {
     Adopter updateAdopter(String adopterId, String name, LivingSpace livingSpace,
                           DailySchedule dailySchedule, Species preferredSpecies,
                           String preferredBreed, ActivityLevel preferredActivityLevel,
-                          Integer minAge, Integer maxAge);
+                          Boolean requiresVaccinated, Integer minAge, Integer maxAge);
 
     /**
      * Removes an adopter from the system by ID.

--- a/src/main/java/shelter/application/impl/AdopterApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/AdopterApplicationServiceImpl.java
@@ -46,10 +46,12 @@ public class AdopterApplicationServiceImpl implements AdopterApplicationService 
     @Override
     public Adopter registerAdopter(String name, LivingSpace livingSpace, DailySchedule dailySchedule,
                                     Species preferredSpecies, String preferredBreed,
-                                    ActivityLevel preferredActivityLevel, int minAge, int maxAge) {
+                                    ActivityLevel preferredActivityLevel, Boolean requiresVaccinated,
+                                    int minAge, int maxAge) {
         // Build preferences object from individual fields
         AdopterPreferences preferences = new AdopterPreferences(
-                preferredSpecies, preferredBreed, preferredActivityLevel, minAge, maxAge);
+                preferredSpecies, preferredBreed, preferredActivityLevel,
+                requiresVaccinated, minAge, maxAge);
         Adopter adopter = new Adopter(name, livingSpace, dailySchedule, null, preferences);
         adopterService.register(adopter);
         auditService.log("registered adopter", adopter);
@@ -72,7 +74,7 @@ public class AdopterApplicationServiceImpl implements AdopterApplicationService 
     public Adopter updateAdopter(String adopterId, String name, LivingSpace livingSpace,
                                   DailySchedule dailySchedule, Species preferredSpecies,
                                   String preferredBreed, ActivityLevel preferredActivityLevel,
-                                  Integer minAge, Integer maxAge) {
+                                  Boolean requiresVaccinated, Integer minAge, Integer maxAge) {
         Adopter existing = adopterService.findById(adopterId);
 
         // Merge only provided (non-null) fields; fall back to current values
@@ -83,10 +85,13 @@ public class AdopterApplicationServiceImpl implements AdopterApplicationService 
         Species      newSpecies  = preferredSpecies       != null ? preferredSpecies       : oldPrefs.getPreferredSpecies();
         String       newBreed    = preferredBreed         != null ? preferredBreed         : oldPrefs.getPreferredBreed();
         ActivityLevel newActivity = preferredActivityLevel != null ? preferredActivityLevel : oldPrefs.getPreferredActivityLevel();
+        Boolean      newRequiresVaccinated =
+                requiresVaccinated != null ? requiresVaccinated : oldPrefs.getRequiresVaccinated();
         int          newMin      = minAge != null ? minAge : oldPrefs.getMinAge();
         int          newMax      = maxAge != null ? maxAge : oldPrefs.getMaxAge();
 
-        AdopterPreferences newPrefs = new AdopterPreferences(newSpecies, newBreed, newActivity, newMin, newMax);
+        AdopterPreferences newPrefs = new AdopterPreferences(
+                newSpecies, newBreed, newActivity, newRequiresVaccinated, newMin, newMax);
 
         // Reconstruct adopter with updated values, preserving ID and adopted animal list
         Adopter updated = new Adopter(existing.getId(), newName, newSpace, newSched,

--- a/src/main/java/shelter/cli/AdopterCmd.java
+++ b/src/main/java/shelter/cli/AdopterCmd.java
@@ -108,6 +108,11 @@ public class AdopterCmd implements Runnable {
                 description = "Preferred activity level (omit for no preference)")
         private ActivityLevel preferredActivityLevel;
 
+        /** Whether vaccinated animals are required; omit for no preference. */
+        @Option(names = "--requires-vaccinated",
+                description = "Whether vaccinated animals are required: true or false")
+        private Boolean requiresVaccinated;
+
         /** Minimum preferred animal age; defaults to 0. */
         @Option(names = "--min-age", description = "Minimum preferred animal age (default 0)")
         private int minAge = 0;
@@ -126,6 +131,7 @@ public class AdopterCmd implements Runnable {
                 Adopter a = AppContext.get().adopterApp().registerAdopter(
                         name, livingSpace, dailySchedule,
                         preferredSpecies, preferredBreed, preferredActivityLevel,
+                        requiresVaccinated,
                         minAge, maxAge);
                 System.out.printf("Registered adopter: %s (id=%s)%n", a.getName(), a.getId());
             } catch (Exception e) {
@@ -175,6 +181,11 @@ public class AdopterCmd implements Runnable {
                 description = "New preferred activity level (omit to keep current)")
         private ActivityLevel preferredActivityLevel;
 
+        /** New vaccination requirement; omit to keep current value. */
+        @Option(names = "--requires-vaccinated",
+                description = "New vaccination requirement: true or false (omit to keep current)")
+        private Boolean requiresVaccinated;
+
         /** New minimum preferred age; omit to keep current value. */
         @Option(names = "--min-age", description = "New minimum preferred age (omit to keep current)")
         private Integer minAge;
@@ -193,6 +204,7 @@ public class AdopterCmd implements Runnable {
                 Adopter a = AppContext.get().adopterApp().updateAdopter(
                         id, name, livingSpace, dailySchedule,
                         preferredSpecies, preferredBreed, preferredActivityLevel,
+                        requiresVaccinated,
                         minAge, maxAge);
                 System.out.printf("Updated adopter: %s (id=%s)%n", a.getName(), a.getId());
             } catch (Exception e) {

--- a/src/main/java/shelter/cli/AppContext.java
+++ b/src/main/java/shelter/cli/AppContext.java
@@ -147,7 +147,7 @@ public class AppContext {
                 new ActivityLevelStrategy(),
                 new AgePreferenceStrategy(),
                 new LifestyleCompatibilityStrategy(),
-                new VaccinationPreferenceStrategy()
+                new VaccinationPreferenceStrategy(vaccinationService)
         );
         AdopterBasedMatchingService adopterMatchingService =
                 new AdopterBasedMatchingServiceImpl(strategies);

--- a/src/main/java/shelter/domain/AdopterPreferences.java
+++ b/src/main/java/shelter/domain/AdopterPreferences.java
@@ -4,7 +4,8 @@ import java.util.Objects;
 
 /**
  * Represents the adoption preferences of a prospective adopter.
- * Preferences include desired species, breed, activity level, and age range;
+ * Preferences include desired species, breed, activity level, age range,
+ * and whether the adopter requires already-vaccinated animals;
  * these are consumed by matching strategies to score compatibility with available animals.
  * All fields except {@code minAge} and {@code maxAge} may be {@code null} to indicate no preference.
  */
@@ -13,6 +14,7 @@ public class AdopterPreferences {
     private final Species preferredSpecies;
     private final String preferredBreed;
     private final ActivityLevel preferredActivityLevel;
+    private final Boolean requiresVaccinated;
     private final int minAge;
     private final int maxAge;
 
@@ -24,12 +26,15 @@ public class AdopterPreferences {
      * @param preferredSpecies        the desired {@link Species}, or {@code null} for no preference
      * @param preferredBreed          the desired breed, or {@code null} for no preference
      * @param preferredActivityLevel  the desired activity level, or {@code null} for no preference
+     * @param requiresVaccinated      {@code true} if the adopter requires vaccinated animals,
+     *                                or {@code null} for no vaccination preference
      * @param minAge                  the minimum preferred age in years; must be non-negative
      * @param maxAge                  the maximum preferred age in years; must be &gt;= {@code minAge}
      * @throws IllegalArgumentException if {@code minAge} is negative or {@code maxAge} &lt; {@code minAge}
      */
     public AdopterPreferences(Species preferredSpecies, String preferredBreed,
-                               ActivityLevel preferredActivityLevel, int minAge, int maxAge) {
+                               ActivityLevel preferredActivityLevel, Boolean requiresVaccinated,
+                               int minAge, int maxAge) {
         if (minAge < 0) {
             throw new IllegalArgumentException("Minimum age must be non-negative.");
         }
@@ -40,6 +45,7 @@ public class AdopterPreferences {
         this.preferredSpecies = preferredSpecies;
         this.preferredBreed = preferredBreed;
         this.preferredActivityLevel = preferredActivityLevel;
+        this.requiresVaccinated = requiresVaccinated;
         this.minAge = minAge;
         this.maxAge = maxAge;
     }
@@ -72,6 +78,15 @@ public class AdopterPreferences {
     }
 
     /**
+     * Returns whether the adopter requires vaccinated animals.
+     *
+     * @return {@code true} if vaccinated animals are required, or {@code null} for no preference
+     */
+    public Boolean getRequiresVaccinated() {
+        return requiresVaccinated;
+    }
+
+    /**
      * Returns the minimum preferred age in years.
      *
      * @return the minimum preferred age, always non-negative
@@ -97,7 +112,7 @@ public class AdopterPreferences {
      */
     public AdopterPreferences(AdopterPreferences other) {
         this(other.preferredSpecies, other.preferredBreed, other.preferredActivityLevel,
-                other.minAge, other.maxAge);
+                other.requiresVaccinated, other.minAge, other.maxAge);
     }
 
     /**
@@ -116,6 +131,7 @@ public class AdopterPreferences {
                 && maxAge == other.maxAge
                 && preferredSpecies == other.preferredSpecies
                 && preferredActivityLevel == other.preferredActivityLevel
+                && Objects.equals(requiresVaccinated, other.requiresVaccinated)
                 && Objects.equals(preferredBreed, other.preferredBreed);
     }
 
@@ -127,7 +143,8 @@ public class AdopterPreferences {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(preferredSpecies, preferredBreed, preferredActivityLevel, minAge, maxAge);
+        return Objects.hash(preferredSpecies, preferredBreed, preferredActivityLevel,
+                requiresVaccinated, minAge, maxAge);
     }
 
     /**
@@ -139,6 +156,7 @@ public class AdopterPreferences {
     public String toString() {
         return "AdopterPreferences[species=" + preferredSpecies + ", breed=" + preferredBreed
                 + ", activity=" + preferredActivityLevel
+                + ", requiresVaccinated=" + requiresVaccinated
                 + ", age=" + minAge + "-" + maxAge + "]";
     }
 }

--- a/src/main/java/shelter/repository/csv/CsvAdopterRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAdopterRepository.java
@@ -31,7 +31,7 @@ public class CsvAdopterRepository implements AdopterRepository {
     private static final String HEADER =
             "id,name,livingSpace,dailySchedule,personalNotes,"
             + "preferredSpecies,preferredBreed,preferredActivityLevel,"
-            + "minAge,maxAge,adoptedAnimalIds";
+            + "requiresVaccinated,minAge,maxAge,adoptedAnimalIds";
 
     private final Path filePath;
     private final Map<String, Adopter> store;
@@ -91,7 +91,8 @@ public class CsvAdopterRepository implements AdopterRepository {
     /**
      * Parses a single CSV row into an Adopter using the reconstruction constructor.
      * Fields are in order: id, name, livingSpace, dailySchedule, personalNotes,
-     * preferredSpecies, preferredBreed, preferredActivityLevel, minAge, maxAge, adoptedAnimalIds.
+     * preferredSpecies, preferredBreed, preferredActivityLevel, requiresVaccinated,
+     * minAge, maxAge, adoptedAnimalIds.
      *
      * @param line a non-empty CSV row
      * @return the reconstructed {@link Adopter}
@@ -111,12 +112,19 @@ public class CsvAdopterRepository implements AdopterRepository {
         String actRaw          = parts[7].trim();
         ActivityLevel prefAct  = actRaw.isEmpty() ? null : ActivityLevel.valueOf(actRaw);
 
-        int minAge             = Integer.parseInt(parts[8].trim());
-        int maxAge             = Integer.parseInt(parts[9].trim());
+        String requiresVaccinatedRaw = parts[8].trim();
+        Boolean requiresVaccinated = requiresVaccinatedRaw.isEmpty()
+                ? null
+                : Boolean.valueOf(requiresVaccinatedRaw);
 
-        List<String> adoptedIds = CsvUtils.decodeList(CsvUtils.unescapeCsv(parts[10]));
+        int minAge             = Integer.parseInt(parts[9].trim());
+        int maxAge             = Integer.parseInt(parts[10].trim());
 
-        AdopterPreferences prefs = new AdopterPreferences(prefSpecies, prefBreed, prefAct, minAge, maxAge);
+        List<String> adoptedIds = CsvUtils.decodeList(
+                CsvUtils.unescapeCsv(parts[11]));
+
+        AdopterPreferences prefs = new AdopterPreferences(
+                prefSpecies, prefBreed, prefAct, requiresVaccinated, minAge, maxAge);
         return new Adopter(id, name, living, schedule, notes, prefs, adoptedIds);
     }
 
@@ -134,6 +142,7 @@ public class CsvAdopterRepository implements AdopterRepository {
                   .append(p.getPreferredSpecies() != null ? p.getPreferredSpecies().name() : "").append(',')
                   .append(CsvUtils.escapeCsv(p.getPreferredBreed())).append(',')
                   .append(p.getPreferredActivityLevel() != null ? p.getPreferredActivityLevel().name() : "").append(',')
+                  .append(p.getRequiresVaccinated() != null ? p.getRequiresVaccinated() : "").append(',')
                   .append(p.getMinAge()).append(',')
                   .append(p.getMaxAge()).append(',')
                   .append(CsvUtils.escapeCsv(CsvUtils.encodeList(a.getAdoptedAnimalIds())))

--- a/src/main/java/shelter/service/VaccinationInfoProvider.java
+++ b/src/main/java/shelter/service/VaccinationInfoProvider.java
@@ -1,0 +1,33 @@
+package shelter.service;
+
+import java.util.List;
+
+import shelter.domain.Animal;
+import shelter.domain.VaccineType;
+import shelter.service.model.OverdueVaccination;
+
+/**
+ * A narrow abstraction that exposes only the vaccination facts needed by
+ * matching strategies.
+ *
+ * <p>This keeps strategy classes from depending on the full vaccination service
+ * interface while still allowing richer vaccination-based matching logic.</p>
+ */
+public interface VaccinationInfoProvider {
+
+    /**
+     * Returns all vaccine types applicable to the given animal's species.
+     *
+     * @param animal the animal to query
+     * @return the list of vaccine types applicable to the animal
+     */
+    List<VaccineType> getApplicableVaccineTypes(Animal animal);
+
+    /**
+     * Returns the overdue vaccinations for the given animal.
+     *
+     * @param animal the animal to query
+     * @return the list of overdue vaccinations for the animal
+     */
+    List<OverdueVaccination> getOverdueVaccinations(Animal animal);
+}

--- a/src/main/java/shelter/service/impl/AdopterBasedMatchingServiceImpl.java
+++ b/src/main/java/shelter/service/impl/AdopterBasedMatchingServiceImpl.java
@@ -5,6 +5,8 @@ import shelter.domain.Animal;
 import shelter.service.AdopterBasedMatchingService;
 import shelter.service.model.MatchResult;
 import shelter.strategy.IMatchingStrategy;
+import shelter.strategy.MatchingPreferencesProfile;
+import shelter.strategy.MatchingScoreCalculator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,13 +15,13 @@ import java.util.List;
 /**
  * Default implementation of {@link AdopterBasedMatchingService} that aggregates scores
  * from a configurable list of matching strategies to rank animals for a given adopter.
- * Each strategy contributes a normalized score in [0.0, 1.0]; the total is scaled to an
- * integer out of 100 per strategy so results are comparable regardless of how many
- * strategies are active.
+ * Each applicable strategy contributes a normalized score in [0.0, 1.0]. A priority
+ * profile can give ranked criteria stronger influence, while unranked applicable
+ * criteria still count with normal influence. Criteria that are not applicable do not count.
  */
 public class AdopterBasedMatchingServiceImpl implements AdopterBasedMatchingService {
 
-    private final List<IMatchingStrategy> strategies;
+    private final MatchingScoreCalculator scoreCalculator;
 
     /**
      * Constructs an AdopterBasedMatchingServiceImpl with the given list of strategies.
@@ -29,16 +31,29 @@ public class AdopterBasedMatchingServiceImpl implements AdopterBasedMatchingServ
      * @throws IllegalArgumentException if {@code strategies} is null or empty
      */
     public AdopterBasedMatchingServiceImpl(List<IMatchingStrategy> strategies) {
+        this(strategies, null);
+    }
+
+    /**
+     * Constructs an AdopterBasedMatchingServiceImpl with strategies and a priority profile.
+     * The profile may be {@code null}; in that case every applicable strategy uses normal weight.
+     *
+     * @param strategies the matching strategies to apply; must not be null or empty
+     * @param profile the optional ranked preference profile
+     * @throws IllegalArgumentException if {@code strategies} is null or empty
+     */
+    public AdopterBasedMatchingServiceImpl(List<IMatchingStrategy> strategies,
+                                           MatchingPreferencesProfile profile) {
         if (strategies == null || strategies.isEmpty()) {
             throw new IllegalArgumentException("At least one matching strategy must be provided.");
         }
-        this.strategies = new ArrayList<>(strategies);
+        this.scoreCalculator = new MatchingScoreCalculator(strategies, profile);
     }
 
     /**
      * {@inheritDoc}
-     * Scores each animal by summing contributions from all strategies, then sorts results
-     * descending by score. Animals with a score of zero are included in the result.
+     * Scores each animal using applicable strategy contributions, then sorts results descending
+     * by score. Animals with a score of zero are included in the result.
      */
     @Override
     public List<MatchResult> match(Adopter adopter, List<Animal> animals) {
@@ -47,14 +62,7 @@ public class AdopterBasedMatchingServiceImpl implements AdopterBasedMatchingServ
 
         List<MatchResult> results = new ArrayList<>();
         for (Animal animal : animals) {
-            // Sum raw scores from all strategies, then scale to integer points
-            double rawScore = 0.0;
-            for (IMatchingStrategy strategy : strategies) {
-                // Polymorphism: strategy.score() dispatches to the concrete implementation at runtime
-                // (e.g. SpeciesPreferenceStrategy, ActivityLevelStrategy) without this class knowing which
-                rawScore += strategy.score(adopter, animal);
-            }
-            int score = (int) Math.round(rawScore * 100);
+            int score = scoreCalculator.calculateScore(adopter, animal);
             results.add(new MatchResult(animal, adopter, score));
         }
 

--- a/src/main/java/shelter/service/impl/AnimalBasedMatchingServiceImpl.java
+++ b/src/main/java/shelter/service/impl/AnimalBasedMatchingServiceImpl.java
@@ -5,6 +5,8 @@ import shelter.domain.Animal;
 import shelter.service.AnimalBasedMatchingService;
 import shelter.service.model.MatchResult;
 import shelter.strategy.IMatchingStrategy;
+import shelter.strategy.MatchingPreferencesProfile;
+import shelter.strategy.MatchingScoreCalculator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,13 +15,13 @@ import java.util.List;
 /**
  * Default implementation of {@link AnimalBasedMatchingService} that aggregates scores
  * from a configurable list of matching strategies to rank adopters for a given animal.
- * Each strategy contributes a normalized score in [0.0, 1.0]; the total is scaled to an
- * integer out of 100 per strategy so results are comparable regardless of how many
- * strategies are active.
+ * Each applicable strategy contributes a normalized score in [0.0, 1.0]. A priority
+ * profile can give ranked criteria stronger influence, while unranked applicable
+ * criteria still count with normal influence. Criteria that are not applicable do not count.
  */
 public class AnimalBasedMatchingServiceImpl implements AnimalBasedMatchingService {
 
-    private final List<IMatchingStrategy> strategies;
+    private final MatchingScoreCalculator scoreCalculator;
 
     /**
      * Constructs an AnimalBasedMatchingServiceImpl with the given list of strategies.
@@ -29,16 +31,29 @@ public class AnimalBasedMatchingServiceImpl implements AnimalBasedMatchingServic
      * @throws IllegalArgumentException if {@code strategies} is null or empty
      */
     public AnimalBasedMatchingServiceImpl(List<IMatchingStrategy> strategies) {
+        this(strategies, null);
+    }
+
+    /**
+     * Constructs an AnimalBasedMatchingServiceImpl with strategies and a priority profile.
+     * The profile may be {@code null}; in that case every applicable strategy uses normal weight.
+     *
+     * @param strategies the matching strategies to apply; must not be null or empty
+     * @param profile the optional ranked preference profile
+     * @throws IllegalArgumentException if {@code strategies} is null or empty
+     */
+    public AnimalBasedMatchingServiceImpl(List<IMatchingStrategy> strategies,
+                                          MatchingPreferencesProfile profile) {
         if (strategies == null || strategies.isEmpty()) {
             throw new IllegalArgumentException("At least one matching strategy must be provided.");
         }
-        this.strategies = new ArrayList<>(strategies);
+        this.scoreCalculator = new MatchingScoreCalculator(strategies, profile);
     }
 
     /**
      * {@inheritDoc}
-     * Scores each adopter by summing contributions from all strategies, then sorts results
-     * descending by score. Adopters with a score of zero are included in the result.
+     * Scores each adopter using applicable strategy contributions, then sorts results descending
+     * by score. Adopters with a score of zero are included in the result.
      */
     @Override
     public List<MatchResult> match(Animal animal, List<Adopter> adopters) {
@@ -47,14 +62,7 @@ public class AnimalBasedMatchingServiceImpl implements AnimalBasedMatchingServic
 
         List<MatchResult> results = new ArrayList<>();
         for (Adopter adopter : adopters) {
-            // Sum raw scores from all strategies, then scale to integer points
-            double rawScore = 0.0;
-            for (IMatchingStrategy strategy : strategies) {
-                // Polymorphism: strategy.score() dispatches to the concrete implementation at runtime
-                // (e.g. BreedPreferenceStrategy, LifestyleCompatibilityStrategy) without this class knowing which
-                rawScore += strategy.score(adopter, animal);
-            }
-            int score = (int) Math.round(rawScore * 100);
+            int score = scoreCalculator.calculateScore(adopter, animal);
             results.add(new MatchResult(animal, adopter, score));
         }
 

--- a/src/main/java/shelter/service/impl/VaccinationServiceImpl.java
+++ b/src/main/java/shelter/service/impl/VaccinationServiceImpl.java
@@ -8,6 +8,7 @@ import shelter.exception.SpeciesMismatchException;
 import shelter.repository.VaccinationRecordRepository;
 import shelter.repository.VaccineTypeRepository;
 import shelter.service.AuditService;
+import shelter.service.VaccinationInfoProvider;
 import shelter.service.VaccinationService;
 import shelter.service.model.OverdueVaccination;
 
@@ -23,7 +24,7 @@ import java.util.Optional;
  * history by animal. All significant operations are forwarded to the {@link AuditService}
  * for traceability.
  */
-public class VaccinationServiceImpl implements VaccinationService {
+public class VaccinationServiceImpl implements VaccinationService, VaccinationInfoProvider {
 
     private final VaccinationRecordRepository recordRepository;
     private final VaccineTypeRepository vaccineTypeRepository;
@@ -111,8 +112,7 @@ public class VaccinationServiceImpl implements VaccinationService {
         }
 
         // Retrieve all vaccine types applicable to this animal's species
-        List<VaccineType> applicableTypes =
-                vaccineTypeRepository.findByApplicableSpecies(animal.getSpecies());
+        List<VaccineType> applicableTypes = getApplicableVaccineTypes(animal);
 
         // Build the full vaccination history for this animal once, to avoid repeated queries
         List<VaccinationRecord> history = recordRepository.findByAnimalId(animal.getId());
@@ -137,6 +137,21 @@ public class VaccinationServiceImpl implements VaccinationService {
 
         Collections.sort(overdue);
         return Collections.unmodifiableList(overdue);
+    }
+
+    /**
+     * Returns all vaccine types applicable to the given animal's species.
+     *
+     * @param animal the animal to query
+     * @return the list of vaccine types applicable to the animal
+     * @throws IllegalArgumentException if {@code animal} is null
+     */
+    @Override
+    public List<VaccineType> getApplicableVaccineTypes(Animal animal) {
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+        return vaccineTypeRepository.findByApplicableSpecies(animal.getSpecies());
     }
 
     /**

--- a/src/main/java/shelter/strategy/AbstractBinaryMatchingStrategy.java
+++ b/src/main/java/shelter/strategy/AbstractBinaryMatchingStrategy.java
@@ -1,0 +1,33 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * Base class for binary match strategies that return either a full match
+ * or no match.
+ */
+public abstract class AbstractBinaryMatchingStrategy extends AbstractMatchingStrategy {
+
+    /**
+     * Returns {@code 1.0} for a binary match and {@code 0.0} otherwise.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return {@code 1.0} when the binary condition matches; {@code 0.0} otherwise
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        validateInputs(adopter, animal);
+        return isMatch(adopter, animal) ? 1.0 : 0.0;
+    }
+
+    /**
+     * Returns whether the adopter-animal pair is a binary match under this criterion.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return {@code true} if the pair matches under this criterion
+     */
+    protected abstract boolean isMatch(Adopter adopter, Animal animal);
+}

--- a/src/main/java/shelter/strategy/AbstractMatchingStrategy.java
+++ b/src/main/java/shelter/strategy/AbstractMatchingStrategy.java
@@ -1,0 +1,26 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * Shared base class for matching strategies that need common input validation.
+ */
+public abstract class AbstractMatchingStrategy implements IMatchingStrategy {
+
+    /**
+     * Validates that both inputs are present before a strategy performs any work.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @throws IllegalArgumentException if either argument is {@code null}
+     */
+    protected void validateInputs(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+    }
+}

--- a/src/main/java/shelter/strategy/AbstractOrdinalMatchingStrategy.java
+++ b/src/main/java/shelter/strategy/AbstractOrdinalMatchingStrategy.java
@@ -1,0 +1,40 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * Base class for ordinal strategies where closer values receive stronger scores.
+ */
+public abstract class AbstractOrdinalMatchingStrategy extends AbstractMatchingStrategy {
+
+    /**
+     * Scores the adopter-animal pair using the ordinal distance supplied by the subclass.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return a normalized score in the range {@code [0.0, 1.0]}
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        validateInputs(adopter, animal);
+
+        int distance = getOrdinalDistance(adopter, animal);
+        if (distance == 0) {
+            return 1.0;
+        }
+        if (distance == 1) {
+            return 0.5;
+        }
+        return 0.0;
+    }
+
+    /**
+     * Returns the ordinal distance between the adopter's preference and the animal's value.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the ordinal distance, where {@code 0} means exact match
+     */
+    protected abstract int getOrdinalDistance(Adopter adopter, Animal animal);
+}

--- a/src/main/java/shelter/strategy/AbstractRangeMatchingStrategy.java
+++ b/src/main/java/shelter/strategy/AbstractRangeMatchingStrategy.java
@@ -1,0 +1,45 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+/**
+ * Base class for strategies that score how close a value is to a preferred range.
+ */
+public abstract class AbstractRangeMatchingStrategy extends AbstractMatchingStrategy {
+
+    /**
+     * Scores the adopter-animal pair using the subclass-provided distance from the
+     * preferred range.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return a normalized score in the range {@code [0.0, 1.0]}
+     */
+    @Override
+    public double score(Adopter adopter, Animal animal) {
+        validateInputs(adopter, animal);
+
+        double distanceFromPreferredRange = getDistanceFromPreferredRange(adopter, animal);
+        if (distanceFromPreferredRange == 0.0) {
+            return 1.0;
+        }
+        if (distanceFromPreferredRange <= 0.5) {
+            return 0.8;
+        }
+        if (distanceFromPreferredRange <= 1.0) {
+            return 0.5;
+        }
+        return 0.0;
+    }
+
+    /**
+     * Returns the distance between the animal's value and the preferred range.
+     * A value inside the range should return {@code 0.0}.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the distance from the preferred range
+     */
+    protected abstract double getDistanceFromPreferredRange(Adopter adopter, Animal animal);
+}

--- a/src/main/java/shelter/strategy/ActivityLevelStrategy.java
+++ b/src/main/java/shelter/strategy/ActivityLevelStrategy.java
@@ -5,10 +5,13 @@ import shelter.domain.Adopter;
 import shelter.domain.Animal;
 
 /**
- * A concrete matching strategy that evaluates compatibility between the adopter's
- * preferred activity level and the animal's activity level.
+ * A concrete matching strategy that evaluates preference alignment between the
+ * adopter's desired activity level and the animal's activity level.
+ * This strategy answers the question: "Is this the kind of energy level the adopter wants?"
+ * It does not consider whether the adopter's daily life can realistically support that level;
+ * that practical fit is handled separately by {@link LifestyleCompatibilityStrategy}.
  */
-public class ActivityLevelStrategy implements IMatchingStrategy {
+public class ActivityLevelStrategy extends AbstractOrdinalMatchingStrategy {
 
     /**
      * Returns the matching criterion handled by this strategy.
@@ -21,42 +24,46 @@ public class ActivityLevelStrategy implements IMatchingStrategy {
     }
 
     /**
-     * Returns the score contributed by this strategy for the given adopter-animal pair.
-     * An exact activity match returns {@code 1.0}, a nearby match returns {@code 0.5},
-     * and a poor match returns {@code 0.0}.
+     * Returns whether the adopter has set an activity-level preference.
      *
      * @param adopter the adopter being evaluated
      * @param animal the animal being evaluated
-     * @return the compatibility score for activity level
+     * @return {@code true} if the adopter has an activity preference; {@code false} otherwise
      * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
      */
     @Override
-    public double score(Adopter adopter, Animal animal) {
-        if (adopter == null) {
-            throw new IllegalArgumentException("Adopter must not be null.");
-        }
-        if (animal == null) {
-            throw new IllegalArgumentException("Animal must not be null.");
-        }
+    public boolean isApplicable(Adopter adopter, Animal animal) {
+        validateInputs(adopter, animal);
 
+        return adopter.getPreferences().getPreferredActivityLevel() != null;
+    }
+
+    /**
+     * Returns the ordinal distance between the adopter's preferred activity level
+     * and the animal's actual activity level.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the ordinal distance, where {@code 0} means exact match
+     */
+    @Override
+    protected int getOrdinalDistance(Adopter adopter, Animal animal) {
         ActivityLevel preferredActivity = adopter.getPreferences().getPreferredActivityLevel();
         ActivityLevel animalActivity = animal.getActivityLevel();
 
-        if (preferredActivity == null) {
-            return 0.0;
-        }
+        return Math.abs(getLevelRank(preferredActivity) - getLevelRank(animalActivity));
+    }
 
-        if (preferredActivity == animalActivity) {
-            return 1.0;
+    /**
+     * Returns a simple ordinal rank for each activity level.
+     */
+    private int getLevelRank(ActivityLevel activityLevel) {
+        if (activityLevel == ActivityLevel.LOW) {
+            return 0;
         }
-
-        if ((preferredActivity == ActivityLevel.LOW && animalActivity == ActivityLevel.MEDIUM)
-                || (preferredActivity == ActivityLevel.MEDIUM && animalActivity == ActivityLevel.LOW)
-                || (preferredActivity == ActivityLevel.MEDIUM && animalActivity == ActivityLevel.HIGH)
-                || (preferredActivity == ActivityLevel.HIGH && animalActivity == ActivityLevel.MEDIUM)) {
-            return 0.5;
+        if (activityLevel == ActivityLevel.MEDIUM) {
+            return 1;
         }
-
-        return 0.0;
+        return 2;
     }
 }

--- a/src/main/java/shelter/strategy/AgePreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/AgePreferenceStrategy.java
@@ -1,13 +1,18 @@
 package shelter.strategy;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
 import shelter.domain.Adopter;
 import shelter.domain.Animal;
 
 /**
  * A concrete matching strategy that evaluates whether an animal's age
  * fits the adopter's preferred age range.
+ * The age is measured from {@code Animal.getBirthday()} so the strategy can use
+ * finer-grained age differences than whole years.
  */
-public class AgePreferenceStrategy implements IMatchingStrategy {
+public class AgePreferenceStrategy extends AbstractRangeMatchingStrategy {
 
     /**
      * Returns the matching criterion handled by this strategy.
@@ -20,36 +25,60 @@ public class AgePreferenceStrategy implements IMatchingStrategy {
     }
 
     /**
-     * Returns the score contributed by this strategy for the given adopter-animal pair.
-     * An animal within the preferred age range returns {@code 1.0}. An animal
-     * just outside the preferred range returns {@code 0.5}. Otherwise, the score is {@code 0.0}.
+     * Returns whether the adopter has expressed an age preference.
+     * In the current design, an age range of {@code 0..Integer.MAX_VALUE}
+     * is treated as "no age preference".
      *
      * @param adopter the adopter being evaluated
      * @param animal the animal being evaluated
-     * @return the compatibility score for age preference
+     * @return {@code true} if the age criterion should be counted; {@code false} otherwise
      * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
      */
     @Override
-    public double score(Adopter adopter, Animal animal) {
-        if (adopter == null) {
-            throw new IllegalArgumentException("Adopter must not be null.");
-        }
-        if (animal == null) {
-            throw new IllegalArgumentException("Animal must not be null.");
-        }
+    public boolean isApplicable(Adopter adopter, Animal animal) {
+        validateInputs(adopter, animal);
 
         int minAge = adopter.getPreferences().getMinAge();
         int maxAge = adopter.getPreferences().getMaxAge();
-        int animalAge = animal.getAge();
+        return !(minAge == 0 && maxAge == Integer.MAX_VALUE);
+    }
 
-        if (animalAge >= minAge && animalAge <= maxAge) {
-            return 1.0;
+    /**
+     * Returns how far the animal's age is from the adopter's preferred age range.
+     * A value inside the range returns {@code 0.0}.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the distance from the preferred age range
+     */
+    @Override
+    protected double getDistanceFromPreferredRange(Adopter adopter, Animal animal) {
+        int minAge = adopter.getPreferences().getMinAge();
+        int maxAge = adopter.getPreferences().getMaxAge();
+        double animalAge = calculatePreciseAgeInYears(animal.getBirthday());
+        return calculateDistanceFromRange(animalAge, minAge, maxAge);
+    }
+
+    /**
+     * Calculates the animal's age in years using whole months for more precision than
+     * {@code Animal.getAge()}, which returns only whole years.
+     */
+    private double calculatePreciseAgeInYears(LocalDate birthday) {
+        long ageInMonths = ChronoUnit.MONTHS.between(birthday, LocalDate.now());
+        return ageInMonths / 12.0;
+    }
+
+    /**
+     * Calculates how far an age is from the nearest edge of the preferred range.
+     * A value inside the range has distance {@code 0.0}.
+     */
+    private double calculateDistanceFromRange(double age, int minAge, int maxAge) {
+        if (age < minAge) {
+            return minAge - age;
         }
-
-        if (animalAge == minAge - 1 || animalAge == maxAge + 1) {
-            return 0.5;
+        if (age > maxAge) {
+            return age - maxAge;
         }
-
         return 0.0;
     }
 }

--- a/src/main/java/shelter/strategy/BreedPreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/BreedPreferenceStrategy.java
@@ -7,7 +7,7 @@ import shelter.domain.Animal;
  * A concrete matching strategy that evaluates whether an animal's breed
  * matches the adopter's preferred breed.
  */
-public class BreedPreferenceStrategy implements IMatchingStrategy {
+public class BreedPreferenceStrategy extends AbstractBinaryMatchingStrategy {
 
     /**
      * Returns the matching criterion handled by this strategy.
@@ -20,29 +20,31 @@ public class BreedPreferenceStrategy implements IMatchingStrategy {
     }
 
     /**
-     * Returns the score contributed by this strategy for the given adopter-animal pair.
-     * A full match returns {@code 1.0}; otherwise this strategy returns {@code 0.0}.
+     * Returns whether the adopter has set a breed preference.
      *
      * @param adopter the adopter being evaluated
      * @param animal the animal being evaluated
-     * @return {@code 1.0} if the breed matches the adopter's preference;
-     *         {@code 0.0} otherwise
+     * @return {@code true} if the adopter has a breed preference; {@code false} otherwise
      * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
      */
     @Override
-    public double score(Adopter adopter, Animal animal) {
-        if (adopter == null) {
-            throw new IllegalArgumentException("Adopter must not be null.");
-        }
-        if (animal == null) {
-            throw new IllegalArgumentException("Animal must not be null.");
-        }
+    public boolean isApplicable(Adopter adopter, Animal animal) {
+        validateInputs(adopter, animal);
 
         String preferredBreed = adopter.getPreferences().getPreferredBreed();
-        if (preferredBreed == null || preferredBreed.isBlank()) {
-            return 0.0;
-        }
+        return preferredBreed != null && !preferredBreed.isBlank();
+    }
 
-        return preferredBreed.equalsIgnoreCase(animal.getBreed()) ? 1.0 : 0.0;
+    /**
+     * Returns whether the animal's breed matches the adopter's preferred breed.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return {@code true} if the breed matches the adopter's preference
+     */
+    @Override
+    protected boolean isMatch(Adopter adopter, Animal animal) {
+        String preferredBreed = adopter.getPreferences().getPreferredBreed();
+        return preferredBreed.equalsIgnoreCase(animal.getBreed());
     }
 }

--- a/src/main/java/shelter/strategy/IMatchingStrategy.java
+++ b/src/main/java/shelter/strategy/IMatchingStrategy.java
@@ -17,9 +17,23 @@ public interface IMatchingStrategy {
     MatchingCriterion getCriterion();
 
     /**
+     * Returns whether this strategy should contribute to the current adopter-animal match.
+     * A strategy is not applicable when the adopter did not express a preference for the
+     * criterion, or when the current design does not yet support evaluating that criterion.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal  the animal being evaluated
+     * @return {@code true} if this criterion should be counted in the total score;
+     *         {@code false} otherwise
+     */
+    boolean isApplicable(Adopter adopter, Animal animal);
+
+    /**
      * Returns the score contributed by this strategy for the given adopter-animal pair.
      * Implementations should return a normalized value, where larger values
      * indicate stronger compatibility under this criterion.
+     * This method is expected to be called only when {@link #isApplicable(Adopter, Animal)}
+     * returns {@code true}.
      *
      * @param adopter the adopter being evaluated
      * @param animal  the animal being evaluated

--- a/src/main/java/shelter/strategy/LifestyleCompatibilityStrategy.java
+++ b/src/main/java/shelter/strategy/LifestyleCompatibilityStrategy.java
@@ -1,11 +1,3 @@
-/*
-Modificaition on Domain/ActivityLevel is Needed.
-Scoring rule need to be adjuted later. 
-How does this apply to rabbit? 
-Score 1 for rabbit since rabit neither required outdoor activity nor extra space. 
-*/
-
-
 package shelter.strategy;
 
 import shelter.domain.ActivityLevel;
@@ -19,6 +11,11 @@ import shelter.domain.LivingSpace;
 /**
  * A concrete matching strategy that evaluates whether an animal is a practical
  * fit for the adopter's living space and daily schedule.
+ * This strategy answers the question: "Can the adopter realistically support this animal
+ * in daily life?" It focuses on feasibility rather than stated preference.
+ * Unlike {@link ActivityLevelStrategy}, which checks what the adopter wants,
+ * this strategy checks whether the adopter's home environment and availability
+ * can support the animal's care needs.
  */
 public class LifestyleCompatibilityStrategy implements IMatchingStrategy {
 
@@ -33,12 +30,38 @@ public class LifestyleCompatibilityStrategy implements IMatchingStrategy {
     }
 
     /**
-     * Returns the score contributed by this strategy for the given adopter-animal pair.
-     * The score is based on a simple combination of living-space fit and schedule fit.
+     * Returns whether lifestyle compatibility can be evaluated for this adopter-animal pair.
+     * This strategy is based on the adopter's living space and schedule, so it is applicable
+     * whenever both inputs are present.
      *
      * @param adopter the adopter being evaluated
      * @param animal the animal being evaluated
-     * @return the compatibility score for lifestyle fit
+     * @return {@code true} if both inputs are non-null
+     * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
+     */
+    @Override
+    public boolean isApplicable(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the score contributed by this strategy for the given adopter-animal pair.
+     * The score is based on a simple combination of living-space fit and schedule fit.
+     * It reflects practical feasibility, not personal preference.
+     *
+     * <p>In other words, this strategy measures whether the adopter's current lifestyle
+     * can support the animal in practice.</p>
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the practical-fit score for lifestyle compatibility
      * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
      */
     @Override
@@ -57,10 +80,14 @@ public class LifestyleCompatibilityStrategy implements IMatchingStrategy {
         return (livingSpaceScore + scheduleScore) / 2.0;
     }
 
+    /**
+     * Estimates whether the adopter's home environment is suitable for the animal.
+     */
     private double calculateLivingSpaceScore(Adopter adopter, Animal animal) {
         LivingSpace livingSpace = adopter.getLivingSpace();
 
         if (animal instanceof Dog dog) {
+            // Living-space scoring focuses on whether the home can physically accommodate the animal.
             // Large dogs are the weakest fit for apartment living.
             if (livingSpace == LivingSpace.APARTMENT && dog.getSize() == Dog.Size.LARGE) {
                 return 0.0;
@@ -92,10 +119,15 @@ public class LifestyleCompatibilityStrategy implements IMatchingStrategy {
         return 0.8;
     }
 
+    /**
+     * Estimates whether the adopter's daily routine can support the animal's care demand.
+     */
     private double calculateScheduleScore(Adopter adopter, Animal animal) {
         DailySchedule dailySchedule = adopter.getDailySchedule();
         ActivityLevel activityLevel = animal.getActivityLevel();
 
+        // Schedule scoring uses activity level only as a proxy for care demand,
+        // not as an adopter preference. Higher-energy animals generally need more time and attention.
         // Being home most of the day gives the strongest schedule fit.
         if (dailySchedule == DailySchedule.HOME_MOST_OF_DAY) {
             return 1.0;

--- a/src/main/java/shelter/strategy/MatchingPreferencesProfile.java
+++ b/src/main/java/shelter/strategy/MatchingPreferencesProfile.java
@@ -2,12 +2,15 @@ package shelter.strategy;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Represents the full prioritized matching setup selected by a user.
- * The profile stores only the criteria the user chose to rank, allowing
- * unselected criteria to be ignored by the matching workflow.
+ * The profile stores the criteria the user chose to rank. Ranked criteria can
+ * receive stronger influence in the matching workflow, while unranked criteria
+ * may still be considered when their corresponding strategy is applicable.
  */
 public class MatchingPreferencesProfile {
 
@@ -23,6 +26,19 @@ public class MatchingPreferencesProfile {
         if (priorities == null) {
             throw new IllegalArgumentException("Matching priorities must not be null.");
         }
+        Set<MatchingCriterion> seenCriteria = new HashSet<>();
+        Set<Integer> seenRanks = new HashSet<>();
+        for (MatchingPreferencesPriority priority : priorities) {
+            if (priority == null) {
+                throw new IllegalArgumentException("Matching priority entries must not be null.");
+            }
+            if (!seenCriteria.add(priority.getCriterion())) {
+                throw new IllegalArgumentException("Each matching criterion can only be ranked once.");
+            }
+            if (!seenRanks.add(priority.getRank())) {
+                throw new IllegalArgumentException("Each priority rank can only be used once.");
+            }
+        }
         this.priorities = Collections.unmodifiableList(new ArrayList<>(priorities));
     }
 
@@ -34,5 +50,38 @@ public class MatchingPreferencesProfile {
      */
     public List<MatchingPreferencesPriority> getPriorities() {
         return priorities;
+    }
+
+    /**
+     * Returns the rank for a criterion, or {@code null} if the user did not rank that criterion.
+     *
+     * @param criterion the criterion to look up
+     * @return the rank for the criterion, or {@code null} when unranked
+     * @throws IllegalArgumentException if {@code criterion} is {@code null}
+     */
+    public Integer getRank(MatchingCriterion criterion) {
+        if (criterion == null) {
+            throw new IllegalArgumentException("Matching criterion must not be null.");
+        }
+        for (MatchingPreferencesPriority priority : priorities) {
+            if (priority.getCriterion() == criterion) {
+                return priority.getRank();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the largest rank number in the profile.
+     * This is used to translate rank order into weighted matching influence.
+     *
+     * @return the largest rank, or {@code 0} when the profile is empty
+     */
+    public int getLargestRank() {
+        int largestRank = 0;
+        for (MatchingPreferencesPriority priority : priorities) {
+            largestRank = Math.max(largestRank, priority.getRank());
+        }
+        return largestRank;
     }
 }

--- a/src/main/java/shelter/strategy/MatchingScoreCalculator.java
+++ b/src/main/java/shelter/strategy/MatchingScoreCalculator.java
@@ -1,0 +1,89 @@
+package shelter.strategy;
+
+import shelter.domain.Adopter;
+import shelter.domain.Animal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Calculates the final match score by combining applicable strategy scores.
+ * Ranked criteria receive stronger influence, while applicable but unranked
+ * criteria still contribute with a normal baseline weight.
+ */
+public class MatchingScoreCalculator {
+
+    private static final double DEFAULT_WEIGHT = 1.0;
+
+    private final List<IMatchingStrategy> strategies;
+    private final MatchingPreferencesProfile profile;
+
+    /**
+     * Constructs a calculator with strategies and an optional priority profile.
+     *
+     * @param strategies the strategies used to score each adopter-animal pair
+     * @param profile the optional ranked preference profile; may be {@code null}
+     * @throws IllegalArgumentException if {@code strategies} is {@code null}, empty,
+     *                                  or contains {@code null}
+     */
+    public MatchingScoreCalculator(List<IMatchingStrategy> strategies,
+                                   MatchingPreferencesProfile profile) {
+        if (strategies == null || strategies.isEmpty()) {
+            throw new IllegalArgumentException("At least one matching strategy must be provided.");
+        }
+        for (IMatchingStrategy strategy : strategies) {
+            if (strategy == null) {
+                throw new IllegalArgumentException("Matching strategies must not contain null entries.");
+            }
+        }
+        this.strategies = new ArrayList<>(strategies);
+        this.profile = profile;
+    }
+
+    /**
+     * Calculates an integer score from 0 to 100 for one adopter-animal pair.
+     * Only applicable strategies count toward the final score.
+     * If no strategy is applicable, the user has not expressed a scoring preference,
+     * so every animal-adopter pair is treated as an equally acceptable match.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return the weighted score scaled to 100
+     */
+    public int calculateScore(Adopter adopter, Animal animal) {
+        double weightedScoreTotal = 0.0;
+        double weightTotal = 0.0;
+
+        for (IMatchingStrategy strategy : strategies) {
+            if (strategy.isApplicable(adopter, animal)) {
+                double influence = getInfluenceForCriterion(strategy.getCriterion());
+                weightedScoreTotal += strategy.score(adopter, animal) * influence;
+                weightTotal += influence;
+            }
+        }
+
+        if (weightTotal == 0.0) {
+            return 100;
+        }
+
+        return (int) Math.round((weightedScoreTotal / weightTotal) * 100);
+    }
+
+    /**
+     * Converts a rank into matching influence without exposing a separate public weight method.
+     * Unranked applicable criteria use the default weight. Ranked criteria get higher
+     * influence, and rank 1 receives the strongest influence.
+     */
+    private double getInfluenceForCriterion(MatchingCriterion criterion) {
+        if (profile == null || profile.getPriorities().isEmpty()) {
+            return DEFAULT_WEIGHT;
+        }
+
+        Integer rank = profile.getRank(criterion);
+        if (rank == null) {
+            return DEFAULT_WEIGHT;
+        }
+
+        return profile.getLargestRank() - rank + 2.0;
+    }
+}

--- a/src/main/java/shelter/strategy/SpeciesPreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/SpeciesPreferenceStrategy.java
@@ -8,7 +8,7 @@ import shelter.domain.Species;
  * A concrete matching strategy that evaluates whether an animal's species
  * matches the adopter's preferred species.
  */
-public class SpeciesPreferenceStrategy implements IMatchingStrategy {
+public class SpeciesPreferenceStrategy extends AbstractBinaryMatchingStrategy {
 
     /**
      * Returns the matching criterion handled by this strategy.
@@ -21,30 +21,31 @@ public class SpeciesPreferenceStrategy implements IMatchingStrategy {
     }
 
     /**
-     * Returns the score contributed by this strategy for the given adopter-animal pair.
-     * A full match returns {@code 1.0}; otherwise this strategy returns {@code 0.0}.
+     * Returns whether the adopter has set a species preference.
      *
      * @param adopter the adopter being evaluated
      * @param animal the animal being evaluated
-     * @return {@code 1.0} if the species matches the adopter's preference;
-     *         {@code 0.0} otherwise
+     * @return {@code true} if the adopter has a species preference; {@code false} otherwise
      * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
      */
     @Override
-    public double score(Adopter adopter, Animal animal) {
-        if (adopter == null) {
-            throw new IllegalArgumentException("Adopter must not be null.");
-        }
-        if (animal == null) {
-            throw new IllegalArgumentException("Animal must not be null.");
-        }
+    public boolean isApplicable(Adopter adopter, Animal animal) {
+        validateInputs(adopter, animal);
 
+        return adopter.getPreferences().getPreferredSpecies() != null;
+    }
+
+    /**
+     * Returns whether the animal's species matches the adopter's preferred species.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return {@code true} if the species matches the adopter's preference
+     */
+    @Override
+    protected boolean isMatch(Adopter adopter, Animal animal) {
         Species preferredSpecies = adopter.getPreferences().getPreferredSpecies();
-        if (preferredSpecies == null) {
-            return 0.0;
-        }
-
-        return preferredSpecies == animal.getSpecies() ? 1.0 : 0.0;
+        return preferredSpecies == animal.getSpecies();
     }
 
 }

--- a/src/main/java/shelter/strategy/VaccinationPreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/VaccinationPreferenceStrategy.java
@@ -1,16 +1,37 @@
 package shelter.strategy;
 
+import java.util.List;
+
 import shelter.domain.Adopter;
 import shelter.domain.Animal;
+import shelter.domain.VaccineType;
+import shelter.service.VaccinationInfoProvider;
+import shelter.service.model.OverdueVaccination;
 
 /**
  * A concrete matching strategy related to vaccination status.
- * At this stage, the adopter-side vaccination requirement has not been modeled yet,
- * so this strategy provisionally rewards animals that are already vaccinated.
- * TODO: revise this strategy after the team decides where vaccination preference
- * should be stored in the adopter-side matching data.
+ * This strategy only participates when the adopter explicitly requires
+ * vaccinated animals. It uses a {@link VaccinationInfoProvider} to compare
+ * the animal's vaccination records against the vaccine types that apply to
+ * that animal's species.
  */
 public class VaccinationPreferenceStrategy implements IMatchingStrategy {
+
+    private final VaccinationInfoProvider vaccinationInfoProvider;
+
+    /**
+     * Constructs the strategy with a provider that supplies vaccination facts
+     * needed for scoring.
+     *
+     * @param vaccinationInfoProvider the provider used to query vaccination facts
+     * @throws IllegalArgumentException if {@code vaccinationInfoProvider} is {@code null}
+     */
+    public VaccinationPreferenceStrategy(VaccinationInfoProvider vaccinationInfoProvider) {
+        if (vaccinationInfoProvider == null) {
+            throw new IllegalArgumentException("VaccinationInfoProvider must not be null.");
+        }
+        this.vaccinationInfoProvider = vaccinationInfoProvider;
+    }
 
     /**
      * Returns the matching criterion handled by this strategy.
@@ -23,10 +44,33 @@ public class VaccinationPreferenceStrategy implements IMatchingStrategy {
     }
 
     /**
+     * Returns whether vaccination should be counted in the total score.
+     * This criterion is only applicable when the adopter explicitly requires
+     * vaccinated animals as part of their preferences.
+     *
+     * @param adopter the adopter being evaluated
+     * @param animal the animal being evaluated
+     * @return {@code true} only when vaccinated animals are required
+     * @throws IllegalArgumentException if {@code adopter} or {@code animal} is {@code null}
+     */
+    @Override
+    public boolean isApplicable(Adopter adopter, Animal animal) {
+        if (adopter == null) {
+            throw new IllegalArgumentException("Adopter must not be null.");
+        }
+        if (animal == null) {
+            throw new IllegalArgumentException("Animal must not be null.");
+        }
+
+        return Boolean.TRUE.equals(adopter.getPreferences().getRequiresVaccinated());
+    }
+
+    /**
      * Returns the score contributed by this strategy for the given adopter-animal pair.
-     * Currently, vaccinated animals receive {@code 1.0} and unvaccinated animals
-     * receive {@code 0.0}. This scoring rule can be revised later when a user-side
-     * vaccination preference is added to the design.
+     * With a {@link VaccinationInfoProvider}, scoring is based on applicable vaccine types:
+     * valid vaccine types contribute {@code 1.0}, overdue vaccine types contribute
+     * {@code 0.5}, and missing vaccine types contribute {@code 0.0}. If there are no
+     * applicable vaccine types, the score is {@code 1.0}.
      *
      * @param adopter the adopter being evaluated
      * @param animal the animal being evaluated
@@ -42,7 +86,26 @@ public class VaccinationPreferenceStrategy implements IMatchingStrategy {
             throw new IllegalArgumentException("Animal must not be null.");
         }
 
-        // For the current first-stage design, vaccinated animals are treated as the stronger match.
-        return animal.isVaccinated() ? 1.0 : 0.0;
+        List<VaccineType> applicableTypes = vaccinationInfoProvider.getApplicableVaccineTypes(animal);
+        if (applicableTypes.isEmpty()) {
+            return 1.0;
+        }
+
+        List<OverdueVaccination> overdueVaccinations =
+                vaccinationInfoProvider.getOverdueVaccinations(animal);
+
+        int overdueCount = 0;
+        int missingCount = 0;
+        for (OverdueVaccination overdueVaccination : overdueVaccinations) {
+            if (overdueVaccination.getLastAdministered() == null) {
+                missingCount++;
+            } else {
+                overdueCount++;
+            }
+        }
+
+        int validCount = applicableTypes.size() - overdueCount - missingCount;
+        double weightedScore = validCount + (overdueCount * 0.5);
+        return weightedScore / applicableTypes.size();
     }
 }

--- a/src/test/java/shelter/application/AdopterApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AdopterApplicationServiceImplTest.java
@@ -42,7 +42,8 @@ class AdopterApplicationServiceImplTest {
     @Test
     void registerAdopter_createsAndPersists() {
         Adopter result = service.registerAdopter("Alice", LivingSpace.HOUSE_WITH_YARD,
-                DailySchedule.HOME_MOST_OF_DAY, Species.DOG, null, ActivityLevel.MEDIUM, 0, 10);
+                DailySchedule.HOME_MOST_OF_DAY, Species.DOG, null, ActivityLevel.MEDIUM,
+                null, 0, 10);
 
         assertNotNull(result);
         assertEquals("Alice", result.getName());
@@ -53,7 +54,7 @@ class AdopterApplicationServiceImplTest {
     @Test
     void listAdopters_returnsAll() {
         service.registerAdopter("Alice", LivingSpace.HOUSE_WITH_YARD,
-                DailySchedule.HOME_MOST_OF_DAY, null, null, null, 0, 20);
+                DailySchedule.HOME_MOST_OF_DAY, null, null, null, null, 0, 20);
 
         assertEquals(1, service.listAdopters().size());
     }
@@ -62,11 +63,11 @@ class AdopterApplicationServiceImplTest {
     void updateAdopter_mergesNameOnly() {
         Adopter adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null,
-                new AdopterPreferences(null, null, null, 0, 20));
+                new AdopterPreferences(null, null, null, null, 0, 20));
         adopterService.store.put(adopter.getId(), adopter);
 
         Adopter updated = service.updateAdopter(adopter.getId(), "Bob", null, null,
-                null, null, null, null, null);
+                null, null, null, null, null, null);
 
         assertEquals("Bob", updated.getName());
         assertEquals(LivingSpace.HOUSE_WITH_YARD, updated.getLivingSpace()); // unchanged
@@ -78,14 +79,14 @@ class AdopterApplicationServiceImplTest {
     void updateAdopter_notFound_throws() {
         assertThrows(EntityNotFoundException.class,
                 () -> service.updateAdopter("missing", "Bob", null, null,
-                        null, null, null, null, null));
+                        null, null, null, null, null, null));
     }
 
     @Test
     void removeAdopter_delegatesAndLogs() {
         Adopter adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null,
-                new AdopterPreferences(null, null, null, 0, 20));
+                new AdopterPreferences(null, null, null, null, 0, 20));
         adopterService.store.put(adopter.getId(), adopter);
 
         service.removeAdopter(adopter.getId());

--- a/src/test/java/shelter/application/AdoptionApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AdoptionApplicationServiceImplTest.java
@@ -45,7 +45,7 @@ class AdoptionApplicationServiceImplTest {
                 adoptionService, animalService, adopterService, notificationService, auditService);
 
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
-                null, new AdopterPreferences(null, null, null, 0, 20));
+                null, new AdopterPreferences(null, null, null, null, 0, 20));
         dog = new Dog("Rex", "Lab", LocalDate.now().minusYears(3), ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
 
         adopterService.store.put(adopter.getId(), adopter);

--- a/src/test/java/shelter/application/MatchingApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/MatchingApplicationServiceImplTest.java
@@ -48,7 +48,7 @@ class MatchingApplicationServiceImplTest {
                 animalService, adopterService, shelterService, explanationService);
 
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
-                null, new AdopterPreferences(null, null, null, 0, 20));
+                null, new AdopterPreferences(null, null, null, null, 0, 20));
         shelter = new Shelter("Test Shelter", "Boston", 20);
         dog     = new Dog("Rex", "Lab", LocalDate.now().minusYears(3), ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
         dog.setShelterId(shelter.getId());

--- a/src/test/java/shelter/domain/AdopterTest.java
+++ b/src/test/java/shelter/domain/AdopterTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AdopterTest {
 
     private AdopterPreferences defaultPrefs() {
-        return new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, 1, 5);
+        return new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, null, 1, 5);
     }
 
     // -------------------------------------------------------------------------
@@ -95,25 +95,27 @@ class AdopterTest {
     @Test
     void adopterPreferences_storesAllFields() {
         AdopterPreferences prefs = new AdopterPreferences(Species.CAT, "Persian",
-                ActivityLevel.LOW, 0, 8);
+                ActivityLevel.LOW, true, 0, 8);
         assertEquals(Species.CAT, prefs.getPreferredSpecies());
         assertEquals("Persian", prefs.getPreferredBreed());
         assertEquals(ActivityLevel.LOW, prefs.getPreferredActivityLevel());
+        assertEquals(true, prefs.getRequiresVaccinated());
         assertEquals(0, prefs.getMinAge());
         assertEquals(8, prefs.getMaxAge());
     }
 
     @Test
     void adopterPreferences_allowsNullSpeciesBreedAndActivity() {
-        AdopterPreferences prefs = new AdopterPreferences(null, null, null, 0, 10);
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, null, 0, 10);
         assertNull(prefs.getPreferredSpecies());
         assertNull(prefs.getPreferredBreed());
         assertNull(prefs.getPreferredActivityLevel());
+        assertNull(prefs.getRequiresVaccinated());
     }
 
     @Test
     void adopterPreferences_minEqualToMaxAgeIsValid() {
-        AdopterPreferences prefs = new AdopterPreferences(null, null, null, 3, 3);
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, null, 3, 3);
         assertEquals(3, prefs.getMinAge());
         assertEquals(3, prefs.getMaxAge());
     }
@@ -125,12 +127,12 @@ class AdopterTest {
     @Test
     void adopterPreferences_throwsIllegalArgumentException_whenMinAgeIsNegative() {
         assertThrows(IllegalArgumentException.class, () ->
-                new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, -1, 5));
+                new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, null, -1, 5));
     }
 
     @Test
     void adopterPreferences_throwsIllegalArgumentException_whenMaxAgeLessThanMinAge() {
         assertThrows(IllegalArgumentException.class, () ->
-                new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, 5, 3));
+                new AdopterPreferences(Species.DOG, "Labrador", ActivityLevel.HIGH, null, 5, 3));
     }
 }

--- a/src/test/java/shelter/domain/AdoptionRequestTest.java
+++ b/src/test/java/shelter/domain/AdoptionRequestTest.java
@@ -19,7 +19,8 @@ class AdoptionRequestTest {
 
     @BeforeEach
     void setUp() {
-        AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, ActivityLevel.HIGH, 0, 10);
+        AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, ActivityLevel.HIGH,
+                null, 0, 10);
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null, prefs);
         animal = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3), ActivityLevel.HIGH, true, Dog.Size.LARGE, false);

--- a/src/test/java/shelter/repository/csv/CsvAdopterRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvAdopterRepositoryTest.java
@@ -38,7 +38,7 @@ class CsvAdopterRepositoryTest {
 
     /** Builds a simple Adopter with no species/breed/activity preference and age range 0–10. */
     private Adopter buildAdopter(String name) {
-        AdopterPreferences prefs = new AdopterPreferences(null, null, null, 0, 10);
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, null, 0, 10);
         return new Adopter(name, LivingSpace.APARTMENT, DailySchedule.HOME_MOST_OF_DAY, null, prefs);
     }
 
@@ -48,7 +48,7 @@ class CsvAdopterRepositoryTest {
     @Test
     void saveAndFindById_returnsCorrectAdopter() {
         AdopterPreferences prefs = new AdopterPreferences(
-                Species.DOG, "Labrador", ActivityLevel.HIGH, 1, 5);
+                Species.DOG, "Labrador", ActivityLevel.HIGH, null, 1, 5);
         Adopter a = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, "Loves dogs", prefs);
         repo.save(a);
@@ -107,7 +107,7 @@ class CsvAdopterRepositoryTest {
      */
     @Test
     void nullPreferences_roundTrip() {
-        AdopterPreferences prefs = new AdopterPreferences(null, null, null, 0, 15);
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, null, 0, 15);
         Adopter a = new Adopter("NoPrefs", LivingSpace.APARTMENT,
                 DailySchedule.AWAY_MOST_OF_DAY, null, prefs);
         repo.save(a);
@@ -171,7 +171,7 @@ class CsvAdopterRepositoryTest {
         Adopter updated = new Adopter(
                 a.getId(), "Updated", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.AWAY_PART_OF_DAY, "updated notes",
-                new AdopterPreferences(Species.CAT, null, null, 0, 10),
+                new AdopterPreferences(Species.CAT, null, null, null, 0, 10),
                 List.of());
         repo.save(updated);
 

--- a/src/test/java/shelter/repository/csv/CsvAdoptionRequestRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvAdoptionRequestRepositoryTest.java
@@ -48,7 +48,7 @@ class CsvAdoptionRequestRepositoryTest {
         adopterRepo = new CsvAdopterRepository(tempDir.toString());
         repo        = new CsvAdoptionRequestRepository(tempDir.toString(), animalRepo, adopterRepo);
 
-        AdopterPreferences prefs = new AdopterPreferences(null, null, null, 0, 20);
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, null, 0, 20);
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null, prefs);
         adopterRepo.save(adopter);

--- a/src/test/java/shelter/service/AdopterServiceImplTest.java
+++ b/src/test/java/shelter/service/AdopterServiceImplTest.java
@@ -36,7 +36,7 @@ class AdopterServiceImplTest {
         repo = new StubAdopterRepository();
         service = new AdopterServiceImpl(repo);
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
-                null, new AdopterPreferences(null, null, null, 0, 20));
+                null, new AdopterPreferences(null, null, null, null, 0, 20));
     }
 
     @Test
@@ -100,7 +100,7 @@ class AdopterServiceImplTest {
     void listAll_returnsAllAdopters() {
         repo.save(adopter);
         Adopter b = new Adopter("Bob", LivingSpace.APARTMENT, DailySchedule.AWAY_PART_OF_DAY,
-                null, new AdopterPreferences(null, null, null, 0, 10));
+                null, new AdopterPreferences(null, null, null, null, 0, 10));
         repo.save(b);
         assertEquals(2, service.listAll().size());
     }
@@ -120,7 +120,7 @@ class AdopterServiceImplTest {
         adopter.addAdoptedAnimalId("animal-001");
         repo.save(adopter);
         Adopter noAdoptions = new Adopter("Carol", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
-                null, new AdopterPreferences(null, null, null, 0, 10));
+                null, new AdopterPreferences(null, null, null, null, 0, 10));
         repo.save(noAdoptions);
         List<Adopter> result = service.adoptedAfter(LocalDate.now().minusDays(1));
         assertEquals(1, result.size());

--- a/src/test/java/shelter/service/AdoptionServiceImplTest.java
+++ b/src/test/java/shelter/service/AdoptionServiceImplTest.java
@@ -56,7 +56,7 @@ class AdoptionServiceImplTest {
         adopterRepo = new StubAdopterRepository();
         service = new AdoptionServiceImpl(requestRepo, animalRepo, adopterRepo, new NoOpAuditService<>());
 
-        AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, null, 0, 10);
+        AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, null, null, 0, 10);
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null, prefs);
         dog = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3), ActivityLevel.HIGH, false, Dog.Size.LARGE, false);

--- a/src/test/java/shelter/service/AnimalServiceImplTest.java
+++ b/src/test/java/shelter/service/AnimalServiceImplTest.java
@@ -121,7 +121,7 @@ class AnimalServiceImplTest {
     @Test
     void adoptedBy_returnsAnimalsWithMatchingAdopterId() {
         Adopter adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
-                null, new AdopterPreferences(null, null, null, 0, 20));
+                null, new AdopterPreferences(null, null, null, null, 0, 20));
         dog.setAdopterId(adopter.getId());
         repo.save(dog);
         List<Animal> result = service.adoptedBy(adopter);

--- a/src/test/java/shelter/service/MatchingServiceImplTest.java
+++ b/src/test/java/shelter/service/MatchingServiceImplTest.java
@@ -8,6 +8,8 @@ import shelter.service.impl.AnimalBasedMatchingServiceImpl;
 import shelter.service.model.MatchResult;
 import shelter.strategy.IMatchingStrategy;
 import shelter.strategy.MatchingCriterion;
+import shelter.strategy.MatchingPreferencesPriority;
+import shelter.strategy.MatchingPreferencesProfile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -25,21 +27,46 @@ class MatchingServiceImplTest {
     /** Always returns 1.0 — represents a perfect match on any criterion. */
     private static class AlwaysOneStrategy implements IMatchingStrategy {
         @Override public MatchingCriterion getCriterion() { return MatchingCriterion.SPECIES; }
+        @Override public boolean isApplicable(Adopter adopter, Animal animal) { return true; }
         @Override public double score(Adopter adopter, Animal animal) { return 1.0; }
     }
 
     /** Always returns 0.0 — represents no match on any criterion. */
     private static class AlwaysZeroStrategy implements IMatchingStrategy {
         @Override public MatchingCriterion getCriterion() { return MatchingCriterion.SPECIES; }
+        @Override public boolean isApplicable(Adopter adopter, Animal animal) { return true; }
         @Override public double score(Adopter adopter, Animal animal) { return 0.0; }
     }
 
     /** Returns 1.0 only if animal name equals "Rex", otherwise 0.0. */
     private static class FavorRexStrategy implements IMatchingStrategy {
         @Override public MatchingCriterion getCriterion() { return MatchingCriterion.BREED; }
+        @Override public boolean isApplicable(Adopter adopter, Animal animal) { return true; }
         @Override public double score(Adopter adopter, Animal animal) {
             return "Rex".equals(animal.getName()) ? 1.0 : 0.0;
         }
+    }
+
+    /** Returns a fixed score for one criterion. */
+    private static class FixedScoreStrategy implements IMatchingStrategy {
+        private final MatchingCriterion criterion;
+        private final double score;
+
+        private FixedScoreStrategy(MatchingCriterion criterion, double score) {
+            this.criterion = criterion;
+            this.score = score;
+        }
+
+        @Override public MatchingCriterion getCriterion() { return criterion; }
+        @Override public boolean isApplicable(Adopter adopter, Animal animal) { return true; }
+        @Override public double score(Adopter adopter, Animal animal) { return score; }
+    }
+
+    /** Never applies to the current match. */
+    private static class NeverApplicableStrategy implements IMatchingStrategy {
+        @Override public MatchingCriterion getCriterion() { return MatchingCriterion.SPECIES; }
+        @Override public boolean isApplicable(Adopter adopter, Animal animal) { return false; }
+        @Override public double score(Adopter adopter, Animal animal) { return 0.0; }
     }
 
     private Adopter adopter;
@@ -49,7 +76,7 @@ class MatchingServiceImplTest {
     @BeforeEach
     void setUp() {
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
-                null, new AdopterPreferences(Species.DOG, null, ActivityLevel.MEDIUM, 0, 10));
+                null, new AdopterPreferences(Species.DOG, null, ActivityLevel.MEDIUM, null, 0, 10));
         rex   = new Dog("Rex",   "Labrador", LocalDate.now().minusYears(3), ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
         buddy = new Dog("Buddy", "Poodle",   LocalDate.now().minusYears(2), ActivityLevel.LOW,    false, Dog.Size.SMALL, false);
     }
@@ -90,6 +117,33 @@ class MatchingServiceImplTest {
     }
 
     @Test
+    void adopterBased_noApplicableStrategies_scoresEveryAnimalAsBestMatch() {
+        AdopterBasedMatchingServiceImpl service =
+                new AdopterBasedMatchingServiceImpl(List.of(new NeverApplicableStrategy()));
+        List<MatchResult> results = service.match(adopter, List.of(rex, buddy));
+        assertEquals(100, results.get(0).getScore());
+        assertEquals(100, results.get(1).getScore());
+    }
+
+    @Test
+    void adopterBased_rankedProfile_changesWeightedScore() {
+        MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.BREED, 1)
+        ));
+        AdopterBasedMatchingServiceImpl service = new AdopterBasedMatchingServiceImpl(
+                List.of(
+                        new FixedScoreStrategy(MatchingCriterion.SPECIES, 1.0),
+                        new FixedScoreStrategy(MatchingCriterion.BREED, 0.0)
+                ),
+                profile);
+
+        List<MatchResult> results = service.match(adopter, List.of(rex));
+
+        // BREED is ranked, so its zero score has stronger influence than the unranked SPECIES score.
+        assertEquals(33, results.get(0).getScore());
+    }
+
+    @Test
     void adopterBased_nullAdopter_throws() {
         AdopterBasedMatchingServiceImpl service =
                 new AdopterBasedMatchingServiceImpl(List.of(new AlwaysOneStrategy()));
@@ -122,12 +176,13 @@ class MatchingServiceImplTest {
         // Strategy that always returns 1.0 for alice, 0.0 for bob — by checking adopter name
         IMatchingStrategy favorAlice = new IMatchingStrategy() {
             @Override public MatchingCriterion getCriterion() { return MatchingCriterion.SPECIES; }
+            @Override public boolean isApplicable(Adopter adopter, Animal animal) { return true; }
             @Override public double score(Adopter a, Animal animal) {
                 return "Alice".equals(a.getName()) ? 1.0 : 0.0;
             }
         };
         Adopter bob = new Adopter("Bob", LivingSpace.APARTMENT, DailySchedule.AWAY_MOST_OF_DAY,
-                null, new AdopterPreferences(null, null, null, 0, 5));
+                null, new AdopterPreferences(null, null, null, null, 0, 5));
         AnimalBasedMatchingServiceImpl service =
                 new AnimalBasedMatchingServiceImpl(List.of(favorAlice));
         List<MatchResult> results = service.match(rex, List.of(bob, adopter));
@@ -143,11 +198,11 @@ class MatchingServiceImplTest {
 
     @Test
     void animalBased_multipleStrategies_scoresAccumulate() {
-        // Two strategies each returning 1.0 → total raw = 2.0 → score = 200
+        // Two applicable strategies each returning 1.0 still produce a perfect score.
         AnimalBasedMatchingServiceImpl service =
                 new AnimalBasedMatchingServiceImpl(List.of(new AlwaysOneStrategy(), new AlwaysOneStrategy()));
         List<MatchResult> results = service.match(rex, List.of(adopter));
-        assertEquals(200, results.get(0).getScore());
+        assertEquals(100, results.get(0).getScore());
     }
 
     @Test

--- a/src/test/java/shelter/service/RequestNotificationServiceImplTest.java
+++ b/src/test/java/shelter/service/RequestNotificationServiceImplTest.java
@@ -65,7 +65,7 @@ class RequestNotificationServiceImplTest {
         service = new RequestNotificationServiceImpl(staff, auditRepo);
 
         // Seed an adoption request
-        AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, null, 0, 10);
+        AdopterPreferences prefs = new AdopterPreferences(Species.DOG, null, null, null, 0, 10);
         adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null, prefs);
         dog = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3), ActivityLevel.HIGH, false, Dog.Size.LARGE, false);

--- a/src/test/java/shelter/strategy/ActivityLevelStrategyTest.java
+++ b/src/test/java/shelter/strategy/ActivityLevelStrategyTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link ActivityLevelStrategy}.
+ * Covers null guards, applicability behavior, exact matches, partial matches, no matches, and criterion identity.
  */
 class ActivityLevelStrategyTest {
 
@@ -25,12 +26,19 @@ class ActivityLevelStrategyTest {
     }
 
     @Test
-    void isApplicable_withActivityPreference_returnsTrue() {
-        assertTrue(strategy.isApplicable(mediumActivityAdopter, dog(ActivityLevel.MEDIUM)));
+    void score_nullAdopter_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> strategy.score(null, dog(ActivityLevel.MEDIUM)));
     }
 
     @Test
-    void isApplicable_withoutActivityPreference_returnsFalse() {
+    void score_nullAnimal_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> strategy.score(mediumActivityAdopter, null));
+    }
+
+    @Test
+    void isApplicable_noPreferenceSet_returnsFalse() {
         Adopter noPreference = new Adopter("Bob", LivingSpace.APARTMENT,
                 DailySchedule.AWAY_MOST_OF_DAY, null,
                 new AdopterPreferences(null, null, null, null, 0, 10));
@@ -38,21 +46,26 @@ class ActivityLevelStrategyTest {
     }
 
     @Test
-    void score_exactMatch_returnsOne() {
+    void score_exactMatch_returnsFullScore() {
         assertEquals(1.0, strategy.score(mediumActivityAdopter, dog(ActivityLevel.MEDIUM)));
     }
 
     @Test
-    void score_oneLevelAway_returnsHalf() {
+    void score_partialMatch_returnsPartialScore() {
         assertEquals(0.5, strategy.score(mediumActivityAdopter, dog(ActivityLevel.HIGH)));
     }
 
     @Test
-    void score_twoLevelsAway_returnsZero() {
+    void score_noMatch_returnsZero() {
         Adopter lowActivityAdopter = new Adopter("Cara", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null,
                 new AdopterPreferences(null, null, ActivityLevel.LOW, null, 0, 10));
         assertEquals(0.0, strategy.score(lowActivityAdopter, dog(ActivityLevel.HIGH)));
+    }
+
+    @Test
+    void getCriterion_returnsCorrectEnum() {
+        assertEquals(MatchingCriterion.ACTIVITY_LEVEL, strategy.getCriterion());
     }
 
     private Dog dog(ActivityLevel activityLevel) {

--- a/src/test/java/shelter/strategy/ActivityLevelStrategyTest.java
+++ b/src/test/java/shelter/strategy/ActivityLevelStrategyTest.java
@@ -1,0 +1,62 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.*;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ActivityLevelStrategy}.
+ */
+class ActivityLevelStrategyTest {
+
+    private ActivityLevelStrategy strategy;
+    private Adopter mediumActivityAdopter;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new ActivityLevelStrategy();
+        mediumActivityAdopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, null,
+                new AdopterPreferences(null, null, ActivityLevel.MEDIUM, null, 0, 10));
+    }
+
+    @Test
+    void isApplicable_withActivityPreference_returnsTrue() {
+        assertTrue(strategy.isApplicable(mediumActivityAdopter, dog(ActivityLevel.MEDIUM)));
+    }
+
+    @Test
+    void isApplicable_withoutActivityPreference_returnsFalse() {
+        Adopter noPreference = new Adopter("Bob", LivingSpace.APARTMENT,
+                DailySchedule.AWAY_MOST_OF_DAY, null,
+                new AdopterPreferences(null, null, null, null, 0, 10));
+        assertFalse(strategy.isApplicable(noPreference, dog(ActivityLevel.MEDIUM)));
+    }
+
+    @Test
+    void score_exactMatch_returnsOne() {
+        assertEquals(1.0, strategy.score(mediumActivityAdopter, dog(ActivityLevel.MEDIUM)));
+    }
+
+    @Test
+    void score_oneLevelAway_returnsHalf() {
+        assertEquals(0.5, strategy.score(mediumActivityAdopter, dog(ActivityLevel.HIGH)));
+    }
+
+    @Test
+    void score_twoLevelsAway_returnsZero() {
+        Adopter lowActivityAdopter = new Adopter("Cara", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, null,
+                new AdopterPreferences(null, null, ActivityLevel.LOW, null, 0, 10));
+        assertEquals(0.0, strategy.score(lowActivityAdopter, dog(ActivityLevel.HIGH)));
+    }
+
+    private Dog dog(ActivityLevel activityLevel) {
+        return new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
+                activityLevel, false, Dog.Size.LARGE, false);
+    }
+}

--- a/src/test/java/shelter/strategy/AgePreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/AgePreferenceStrategyTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link AgePreferenceStrategy}.
+ * Covers null guards, applicability behavior, exact matches, partial matches, no matches, and criterion identity.
  */
 class AgePreferenceStrategyTest {
 
@@ -25,12 +26,19 @@ class AgePreferenceStrategyTest {
     }
 
     @Test
-    void isApplicable_withAgePreference_returnsTrue() {
-        assertTrue(strategy.isApplicable(prefersTwoYearOld, dogAtBirthday(LocalDate.now().minusYears(2))));
+    void score_nullAdopter_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> strategy.score(null, dogAtBirthday(LocalDate.now().minusYears(2))));
     }
 
     @Test
-    void isApplicable_withSentinelRange_returnsFalse() {
+    void score_nullAnimal_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> strategy.score(prefersTwoYearOld, null));
+    }
+
+    @Test
+    void isApplicable_noPreferenceSet_returnsFalse() {
         Adopter noAgePreference = new Adopter("Bob", LivingSpace.APARTMENT,
                 DailySchedule.AWAY_MOST_OF_DAY, null,
                 new AdopterPreferences(null, null, null, null, 0, Integer.MAX_VALUE));
@@ -38,13 +46,13 @@ class AgePreferenceStrategyTest {
     }
 
     @Test
-    void score_insidePreferredRange_returnsOne() {
+    void score_exactMatch_returnsFullScore() {
         assertEquals(1.0, strategy.score(prefersTwoYearOld,
                 dogAtBirthday(LocalDate.now().minusYears(2))));
     }
 
     @Test
-    void score_upToHalfYearOutsideRange_returnsPointEight() {
+    void score_partialMatch_returnsPartialScore() {
         assertEquals(0.8, strategy.score(prefersTwoYearOld,
                 dogAtBirthday(LocalDate.now().minusYears(2).minusMonths(3))));
     }
@@ -56,9 +64,14 @@ class AgePreferenceStrategyTest {
     }
 
     @Test
-    void score_moreThanOneYearOutsideRange_returnsZero() {
+    void score_noMatch_returnsZero() {
         assertEquals(0.0, strategy.score(prefersTwoYearOld,
                 dogAtBirthday(LocalDate.now().minusYears(3).minusMonths(6))));
+    }
+
+    @Test
+    void getCriterion_returnsCorrectEnum() {
+        assertEquals(MatchingCriterion.AGE, strategy.getCriterion());
     }
 
     private Dog dogAtBirthday(LocalDate birthday) {

--- a/src/test/java/shelter/strategy/AgePreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/AgePreferenceStrategyTest.java
@@ -1,0 +1,68 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.*;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link AgePreferenceStrategy}.
+ */
+class AgePreferenceStrategyTest {
+
+    private AgePreferenceStrategy strategy;
+    private Adopter prefersTwoYearOld;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new AgePreferenceStrategy();
+        prefersTwoYearOld = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, null,
+                new AdopterPreferences(null, null, null, null, 2, 2));
+    }
+
+    @Test
+    void isApplicable_withAgePreference_returnsTrue() {
+        assertTrue(strategy.isApplicable(prefersTwoYearOld, dogAtBirthday(LocalDate.now().minusYears(2))));
+    }
+
+    @Test
+    void isApplicable_withSentinelRange_returnsFalse() {
+        Adopter noAgePreference = new Adopter("Bob", LivingSpace.APARTMENT,
+                DailySchedule.AWAY_MOST_OF_DAY, null,
+                new AdopterPreferences(null, null, null, null, 0, Integer.MAX_VALUE));
+        assertFalse(strategy.isApplicable(noAgePreference, dogAtBirthday(LocalDate.now().minusYears(2))));
+    }
+
+    @Test
+    void score_insidePreferredRange_returnsOne() {
+        assertEquals(1.0, strategy.score(prefersTwoYearOld,
+                dogAtBirthday(LocalDate.now().minusYears(2))));
+    }
+
+    @Test
+    void score_upToHalfYearOutsideRange_returnsPointEight() {
+        assertEquals(0.8, strategy.score(prefersTwoYearOld,
+                dogAtBirthday(LocalDate.now().minusYears(2).minusMonths(3))));
+    }
+
+    @Test
+    void score_halfToOneYearOutsideRange_returnsPointFive() {
+        assertEquals(0.5, strategy.score(prefersTwoYearOld,
+                dogAtBirthday(LocalDate.now().minusYears(2).minusMonths(9))));
+    }
+
+    @Test
+    void score_moreThanOneYearOutsideRange_returnsZero() {
+        assertEquals(0.0, strategy.score(prefersTwoYearOld,
+                dogAtBirthday(LocalDate.now().minusYears(3).minusMonths(6))));
+    }
+
+    private Dog dogAtBirthday(LocalDate birthday) {
+        return new Dog("Rex", "Labrador", birthday,
+                ActivityLevel.MEDIUM, false, Dog.Size.MEDIUM, false);
+    }
+}

--- a/src/test/java/shelter/strategy/BreedPreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/BreedPreferenceStrategyTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link BreedPreferenceStrategy}.
+ * Covers null guards, applicability behavior, exact matches, no matches, and criterion identity.
  */
 class BreedPreferenceStrategyTest {
 
@@ -30,12 +31,17 @@ class BreedPreferenceStrategyTest {
     }
 
     @Test
-    void isApplicable_withBreedPreference_returnsTrue() {
-        assertTrue(strategy.isApplicable(adopter, labrador));
+    void score_nullAdopter_throws() {
+        assertThrows(IllegalArgumentException.class, () -> strategy.score(null, labrador));
     }
 
     @Test
-    void isApplicable_withBlankBreedPreference_returnsFalse() {
+    void score_nullAnimal_throws() {
+        assertThrows(IllegalArgumentException.class, () -> strategy.score(adopter, null));
+    }
+
+    @Test
+    void isApplicable_noPreferenceSet_returnsFalse() {
         Adopter noPreference = new Adopter("Bob", LivingSpace.APARTMENT,
                 DailySchedule.AWAY_MOST_OF_DAY, null,
                 new AdopterPreferences(null, " ", null, null, 0, 10));
@@ -43,12 +49,19 @@ class BreedPreferenceStrategyTest {
     }
 
     @Test
-    void score_matchingBreedIgnoringCase_returnsOne() {
+    void score_exactMatch_returnsFullScore() {
         assertEquals(1.0, strategy.score(adopter, labrador));
     }
 
+    // BreedPreferenceStrategy is binary, so there is no partial-match score to test.
+
     @Test
-    void score_differentBreed_returnsZero() {
+    void score_noMatch_returnsZero() {
         assertEquals(0.0, strategy.score(adopter, poodle));
+    }
+
+    @Test
+    void getCriterion_returnsCorrectEnum() {
+        assertEquals(MatchingCriterion.BREED, strategy.getCriterion());
     }
 }

--- a/src/test/java/shelter/strategy/BreedPreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/BreedPreferenceStrategyTest.java
@@ -1,0 +1,54 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.*;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link BreedPreferenceStrategy}.
+ */
+class BreedPreferenceStrategyTest {
+
+    private BreedPreferenceStrategy strategy;
+    private Adopter adopter;
+    private Dog labrador;
+    private Dog poodle;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new BreedPreferenceStrategy();
+        adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
+                null, new AdopterPreferences(null, "labrador", null, null, 0, 10));
+        labrador = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
+                ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
+        poodle = new Dog("Buddy", "Poodle", LocalDate.now().minusYears(2),
+                ActivityLevel.LOW, false, Dog.Size.SMALL, false);
+    }
+
+    @Test
+    void isApplicable_withBreedPreference_returnsTrue() {
+        assertTrue(strategy.isApplicable(adopter, labrador));
+    }
+
+    @Test
+    void isApplicable_withBlankBreedPreference_returnsFalse() {
+        Adopter noPreference = new Adopter("Bob", LivingSpace.APARTMENT,
+                DailySchedule.AWAY_MOST_OF_DAY, null,
+                new AdopterPreferences(null, " ", null, null, 0, 10));
+        assertFalse(strategy.isApplicable(noPreference, labrador));
+    }
+
+    @Test
+    void score_matchingBreedIgnoringCase_returnsOne() {
+        assertEquals(1.0, strategy.score(adopter, labrador));
+    }
+
+    @Test
+    void score_differentBreed_returnsZero() {
+        assertEquals(0.0, strategy.score(adopter, poodle));
+    }
+}

--- a/src/test/java/shelter/strategy/LifestyleCompatibilityStrategyTest.java
+++ b/src/test/java/shelter/strategy/LifestyleCompatibilityStrategyTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link LifestyleCompatibilityStrategy}.
+ * Covers null guards, exact matches, partial matches, no matches, and criterion identity.
  */
 class LifestyleCompatibilityStrategyTest {
 
@@ -21,29 +22,45 @@ class LifestyleCompatibilityStrategyTest {
     }
 
     @Test
-    void isApplicable_withValidInputs_returnsTrue() {
-        assertTrue(strategy.isApplicable(adopter(LivingSpace.APARTMENT, DailySchedule.AWAY_MOST_OF_DAY),
-                dog(ActivityLevel.HIGH, Dog.Size.LARGE)));
+    void score_nullAdopter_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> strategy.score(null, dog(ActivityLevel.LOW, Dog.Size.SMALL)));
     }
 
     @Test
-    void score_largeHighEnergyDogInApartmentWithAwaySchedule_returnsZero() {
-        assertEquals(0.0, strategy.score(
-                adopter(LivingSpace.APARTMENT, DailySchedule.AWAY_MOST_OF_DAY),
-                dog(ActivityLevel.HIGH, Dog.Size.LARGE)));
+    void score_nullAnimal_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> strategy.score(adopter(LivingSpace.APARTMENT, DailySchedule.AWAY_MOST_OF_DAY),
+                        null));
     }
 
+    // LifestyleCompatibilityStrategy has no nullable preference field; it uses living space and schedule.
+    // Therefore, the issue's score_noPreferenceSet_returnsZero case is intentionally skipped.
+
     @Test
-    void score_largeDogWithYardAndHomeSchedule_returnsOne() {
+    void score_exactMatch_returnsFullScore() {
         assertEquals(1.0, strategy.score(
                 adopter(LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY),
                 dog(ActivityLevel.HIGH, Dog.Size.LARGE)));
     }
 
     @Test
-    void score_nullInput_throws() {
-        assertThrows(IllegalArgumentException.class,
-                () -> strategy.score(null, dog(ActivityLevel.LOW, Dog.Size.SMALL)));
+    void score_partialMatch_returnsPartialScore() {
+        assertEquals(0.5, strategy.score(
+                adopter(LivingSpace.HOUSE_NO_YARD, DailySchedule.AWAY_PART_OF_DAY),
+                dog(ActivityLevel.HIGH, Dog.Size.LARGE)));
+    }
+
+    @Test
+    void score_noMatch_returnsZero() {
+        assertEquals(0.0, strategy.score(
+                adopter(LivingSpace.APARTMENT, DailySchedule.AWAY_MOST_OF_DAY),
+                dog(ActivityLevel.HIGH, Dog.Size.LARGE)));
+    }
+
+    @Test
+    void getCriterion_returnsCorrectEnum() {
+        assertEquals(MatchingCriterion.LIFESTYLE, strategy.getCriterion());
     }
 
     private Adopter adopter(LivingSpace livingSpace, DailySchedule dailySchedule) {

--- a/src/test/java/shelter/strategy/LifestyleCompatibilityStrategyTest.java
+++ b/src/test/java/shelter/strategy/LifestyleCompatibilityStrategyTest.java
@@ -1,0 +1,58 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.*;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link LifestyleCompatibilityStrategy}.
+ */
+class LifestyleCompatibilityStrategyTest {
+
+    private LifestyleCompatibilityStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new LifestyleCompatibilityStrategy();
+    }
+
+    @Test
+    void isApplicable_withValidInputs_returnsTrue() {
+        assertTrue(strategy.isApplicable(adopter(LivingSpace.APARTMENT, DailySchedule.AWAY_MOST_OF_DAY),
+                dog(ActivityLevel.HIGH, Dog.Size.LARGE)));
+    }
+
+    @Test
+    void score_largeHighEnergyDogInApartmentWithAwaySchedule_returnsZero() {
+        assertEquals(0.0, strategy.score(
+                adopter(LivingSpace.APARTMENT, DailySchedule.AWAY_MOST_OF_DAY),
+                dog(ActivityLevel.HIGH, Dog.Size.LARGE)));
+    }
+
+    @Test
+    void score_largeDogWithYardAndHomeSchedule_returnsOne() {
+        assertEquals(1.0, strategy.score(
+                adopter(LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY),
+                dog(ActivityLevel.HIGH, Dog.Size.LARGE)));
+    }
+
+    @Test
+    void score_nullInput_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> strategy.score(null, dog(ActivityLevel.LOW, Dog.Size.SMALL)));
+    }
+
+    private Adopter adopter(LivingSpace livingSpace, DailySchedule dailySchedule) {
+        return new Adopter("Alice", livingSpace, dailySchedule, null,
+                new AdopterPreferences(null, null, null, null, 0, 10));
+    }
+
+    private Dog dog(ActivityLevel activityLevel, Dog.Size size) {
+        return new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
+                activityLevel, false, size, false);
+    }
+}

--- a/src/test/java/shelter/strategy/MatchingPreferencesPriorityTest.java
+++ b/src/test/java/shelter/strategy/MatchingPreferencesPriorityTest.java
@@ -1,0 +1,31 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MatchingPreferencesPriority}.
+ */
+class MatchingPreferencesPriorityTest {
+
+    @Test
+    void constructor_validArguments_storesFields() {
+        MatchingPreferencesPriority priority =
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1);
+        assertEquals(MatchingCriterion.SPECIES, priority.getCriterion());
+        assertEquals(1, priority.getRank());
+    }
+
+    @Test
+    void constructor_nullCriterion_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MatchingPreferencesPriority(null, 1));
+    }
+
+    @Test
+    void constructor_nonPositiveRank_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 0));
+    }
+}

--- a/src/test/java/shelter/strategy/MatchingPreferencesProfileTest.java
+++ b/src/test/java/shelter/strategy/MatchingPreferencesProfileTest.java
@@ -1,0 +1,70 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MatchingPreferencesProfile}.
+ */
+class MatchingPreferencesProfileTest {
+
+    @Test
+    void constructor_validPriorities_storesUnmodifiableList() {
+        MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1),
+                new MatchingPreferencesPriority(MatchingCriterion.BREED, 2)
+        ));
+
+        assertEquals(2, profile.getPriorities().size());
+        assertThrows(UnsupportedOperationException.class,
+                () -> profile.getPriorities().add(
+                        new MatchingPreferencesPriority(MatchingCriterion.AGE, 3)));
+    }
+
+    @Test
+    void getRank_existingCriterion_returnsRank() {
+        MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1)
+        ));
+
+        assertEquals(1, profile.getRank(MatchingCriterion.SPECIES));
+    }
+
+    @Test
+    void getRank_unrankedCriterion_returnsNull() {
+        MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1)
+        ));
+
+        assertNull(profile.getRank(MatchingCriterion.BREED));
+    }
+
+    @Test
+    void getLargestRank_returnsLargestRank() {
+        MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1),
+                new MatchingPreferencesPriority(MatchingCriterion.BREED, 3)
+        ));
+
+        assertEquals(3, profile.getLargestRank());
+    }
+
+    @Test
+    void constructor_duplicateCriterion_throws() {
+        assertThrows(IllegalArgumentException.class, () -> new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1),
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 2)
+        )));
+    }
+
+    @Test
+    void constructor_duplicateRank_throws() {
+        assertThrows(IllegalArgumentException.class, () -> new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1),
+                new MatchingPreferencesPriority(MatchingCriterion.BREED, 1)
+        )));
+    }
+}

--- a/src/test/java/shelter/strategy/MatchingPreferencesProfileTest.java
+++ b/src/test/java/shelter/strategy/MatchingPreferencesProfileTest.java
@@ -2,6 +2,7 @@ package shelter.strategy;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -10,6 +11,20 @@ import static org.junit.jupiter.api.Assertions.*;
  * Unit tests for {@link MatchingPreferencesProfile}.
  */
 class MatchingPreferencesProfileTest {
+
+    @Test
+    void constructor_nullPriorities_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MatchingPreferencesProfile(null));
+    }
+
+    @Test
+    void constructor_nullPriorityEntry_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MatchingPreferencesProfile(Arrays.asList(
+                        new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1),
+                        null)));
+    }
 
     @Test
     void constructor_validPriorities_storesUnmodifiableList() {
@@ -43,6 +58,15 @@ class MatchingPreferencesProfileTest {
     }
 
     @Test
+    void getRank_nullCriterion_throws() {
+        MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1)
+        ));
+
+        assertThrows(IllegalArgumentException.class, () -> profile.getRank(null));
+    }
+
+    @Test
     void getLargestRank_returnsLargestRank() {
         MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of(
                 new MatchingPreferencesPriority(MatchingCriterion.SPECIES, 1),
@@ -50,6 +74,13 @@ class MatchingPreferencesProfileTest {
         ));
 
         assertEquals(3, profile.getLargestRank());
+    }
+
+    @Test
+    void getLargestRank_emptyProfile_returnsZero() {
+        MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of());
+
+        assertEquals(0, profile.getLargestRank());
     }
 
     @Test

--- a/src/test/java/shelter/strategy/MatchingScoreCalculatorTest.java
+++ b/src/test/java/shelter/strategy/MatchingScoreCalculatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import shelter.domain.*;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -79,6 +80,14 @@ class MatchingScoreCalculatorTest {
     void constructor_emptyStrategies_throws() {
         assertThrows(IllegalArgumentException.class,
                 () -> new MatchingScoreCalculator(List.of(), null));
+    }
+
+    @Test
+    void constructor_nullStrategyEntry_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MatchingScoreCalculator(
+                        Arrays.asList(new SpeciesPreferenceStrategy(), null),
+                        null));
     }
 
 }

--- a/src/test/java/shelter/strategy/MatchingScoreCalculatorTest.java
+++ b/src/test/java/shelter/strategy/MatchingScoreCalculatorTest.java
@@ -1,0 +1,84 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MatchingScoreCalculator}.
+ */
+class MatchingScoreCalculatorTest {
+
+    private Adopter adopter;
+    private Dog dog;
+
+    @BeforeEach
+    void setUp() {
+        adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
+                null, new AdopterPreferences(Species.DOG, "Labrador", null, null, 0, 10));
+        dog = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
+                ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
+    }
+
+    @Test
+    void calculateScore_noApplicableStrategies_returnsOneHundred() {
+        Adopter noPreferenceAdopter = new Adopter("Bob", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, null,
+                new AdopterPreferences(null, null, null, null, 0, Integer.MAX_VALUE));
+        MatchingScoreCalculator calculator = new MatchingScoreCalculator(
+                List.of(new SpeciesPreferenceStrategy()), null);
+
+        assertEquals(100, calculator.calculateScore(noPreferenceAdopter, dog));
+    }
+
+    @Test
+    void calculateScore_withoutProfile_averagesApplicableStrategies() {
+        Adopter speciesMatchesBreedDoesNotMatch = new Adopter("Bob", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, null,
+                new AdopterPreferences(Species.DOG, "Poodle", null, null, 0, 10));
+        MatchingScoreCalculator calculator = new MatchingScoreCalculator(
+                List.of(
+                        new SpeciesPreferenceStrategy(),
+                        new BreedPreferenceStrategy()
+                ),
+                null);
+
+        assertEquals(50, calculator.calculateScore(speciesMatchesBreedDoesNotMatch, dog));
+    }
+
+    @Test
+    void calculateScore_withRankedProfile_appliesStrongerInfluenceToRankedCriterion() {
+        MatchingPreferencesProfile profile = new MatchingPreferencesProfile(List.of(
+                new MatchingPreferencesPriority(MatchingCriterion.BREED, 1)
+        ));
+        Adopter speciesMatchesBreedDoesNotMatch = new Adopter("Bob", LivingSpace.HOUSE_WITH_YARD,
+                DailySchedule.HOME_MOST_OF_DAY, null,
+                new AdopterPreferences(Species.DOG, "Poodle", null, null, 0, 10));
+        MatchingScoreCalculator calculator = new MatchingScoreCalculator(
+                List.of(
+                        new SpeciesPreferenceStrategy(),
+                        new BreedPreferenceStrategy()
+                ),
+                profile);
+
+        assertEquals(33, calculator.calculateScore(speciesMatchesBreedDoesNotMatch, dog));
+    }
+
+    @Test
+    void constructor_nullStrategies_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MatchingScoreCalculator(null, null));
+    }
+
+    @Test
+    void constructor_emptyStrategies_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MatchingScoreCalculator(List.of(), null));
+    }
+
+}

--- a/src/test/java/shelter/strategy/SpeciesPreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/SpeciesPreferenceStrategyTest.java
@@ -1,0 +1,60 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.*;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SpeciesPreferenceStrategy}.
+ */
+class SpeciesPreferenceStrategyTest {
+
+    private SpeciesPreferenceStrategy strategy;
+    private Adopter adopter;
+    private Dog dog;
+    private Cat cat;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new SpeciesPreferenceStrategy();
+        adopter = new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
+                null, new AdopterPreferences(Species.DOG, null, null, null, 0, 10));
+        dog = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
+                ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
+        cat = new Cat("Milo", "Tabby", LocalDate.now().minusYears(2),
+                ActivityLevel.LOW, false, true, false);
+    }
+
+    @Test
+    void isApplicable_withSpeciesPreference_returnsTrue() {
+        assertTrue(strategy.isApplicable(adopter, dog));
+    }
+
+    @Test
+    void isApplicable_withoutSpeciesPreference_returnsFalse() {
+        Adopter noPreference = new Adopter("Bob", LivingSpace.APARTMENT,
+                DailySchedule.AWAY_MOST_OF_DAY, null,
+                new AdopterPreferences(null, null, null, null, 0, 10));
+        assertFalse(strategy.isApplicable(noPreference, dog));
+    }
+
+    @Test
+    void score_matchingSpecies_returnsOne() {
+        assertEquals(1.0, strategy.score(adopter, dog));
+    }
+
+    @Test
+    void score_differentSpecies_returnsZero() {
+        assertEquals(0.0, strategy.score(adopter, cat));
+    }
+
+    @Test
+    void score_nullInput_throws() {
+        assertThrows(IllegalArgumentException.class, () -> strategy.score(null, dog));
+        assertThrows(IllegalArgumentException.class, () -> strategy.score(adopter, null));
+    }
+}

--- a/src/test/java/shelter/strategy/SpeciesPreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/SpeciesPreferenceStrategyTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link SpeciesPreferenceStrategy}.
+ * Covers null guards, applicability behavior, exact matches, no matches, and criterion identity.
  */
 class SpeciesPreferenceStrategyTest {
 
@@ -30,12 +31,17 @@ class SpeciesPreferenceStrategyTest {
     }
 
     @Test
-    void isApplicable_withSpeciesPreference_returnsTrue() {
-        assertTrue(strategy.isApplicable(adopter, dog));
+    void score_nullAdopter_throws() {
+        assertThrows(IllegalArgumentException.class, () -> strategy.score(null, dog));
     }
 
     @Test
-    void isApplicable_withoutSpeciesPreference_returnsFalse() {
+    void score_nullAnimal_throws() {
+        assertThrows(IllegalArgumentException.class, () -> strategy.score(adopter, null));
+    }
+
+    @Test
+    void isApplicable_noPreferenceSet_returnsFalse() {
         Adopter noPreference = new Adopter("Bob", LivingSpace.APARTMENT,
                 DailySchedule.AWAY_MOST_OF_DAY, null,
                 new AdopterPreferences(null, null, null, null, 0, 10));
@@ -43,18 +49,19 @@ class SpeciesPreferenceStrategyTest {
     }
 
     @Test
-    void score_matchingSpecies_returnsOne() {
+    void score_exactMatch_returnsFullScore() {
         assertEquals(1.0, strategy.score(adopter, dog));
     }
 
+    // SpeciesPreferenceStrategy is binary, so there is no partial-match score to test.
+
     @Test
-    void score_differentSpecies_returnsZero() {
+    void score_noMatch_returnsZero() {
         assertEquals(0.0, strategy.score(adopter, cat));
     }
 
     @Test
-    void score_nullInput_throws() {
-        assertThrows(IllegalArgumentException.class, () -> strategy.score(null, dog));
-        assertThrows(IllegalArgumentException.class, () -> strategy.score(adopter, null));
+    void getCriterion_returnsCorrectEnum() {
+        assertEquals(MatchingCriterion.SPECIES, strategy.getCriterion());
     }
 }

--- a/src/test/java/shelter/strategy/VaccinationPreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/VaccinationPreferenceStrategyTest.java
@@ -1,0 +1,97 @@
+package shelter.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import shelter.domain.*;
+import shelter.service.VaccinationInfoProvider;
+import shelter.service.model.OverdueVaccination;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link VaccinationPreferenceStrategy}.
+ */
+class VaccinationPreferenceStrategyTest {
+
+    private Dog dog;
+
+    @BeforeEach
+    void setUp() {
+        dog = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
+                ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
+    }
+
+    @Test
+    void isApplicable_whenVaccinatedAnimalsRequired_returnsTrue() {
+        VaccinationPreferenceStrategy strategy =
+                new VaccinationPreferenceStrategy(new StubVaccinationInfoProvider(List.of(), List.of()));
+        assertTrue(strategy.isApplicable(adopter(true), dog));
+    }
+
+    @Test
+    void isApplicable_whenVaccinatedAnimalsNotRequired_returnsFalse() {
+        VaccinationPreferenceStrategy strategy =
+                new VaccinationPreferenceStrategy(new StubVaccinationInfoProvider(List.of(), List.of()));
+        assertFalse(strategy.isApplicable(adopter(false), dog));
+        assertFalse(strategy.isApplicable(adopter(null), dog));
+    }
+
+    @Test
+    void score_noApplicableVaccineTypes_returnsOne() {
+        VaccinationPreferenceStrategy strategy =
+                new VaccinationPreferenceStrategy(new StubVaccinationInfoProvider(List.of(), List.of()));
+        assertEquals(1.0, strategy.score(adopter(true), dog));
+    }
+
+    @Test
+    void score_validOverdueAndMissingVaccines_returnsHalf() {
+        VaccineType rabies = new VaccineType("Rabies", Species.DOG, 365);
+        VaccineType bordetella = new VaccineType("Bordetella", Species.DOG, 365);
+        VaccineType distemper = new VaccineType("Distemper", Species.DOG, 365);
+        List<VaccineType> applicableTypes = List.of(rabies, bordetella, distemper);
+        List<OverdueVaccination> overdueVaccinations = List.of(
+                new OverdueVaccination(bordetella, LocalDate.now().minusYears(2), LocalDate.now().minusDays(1)),
+                new OverdueVaccination(distemper, null, LocalDate.now().minusDays(1))
+        );
+        VaccinationPreferenceStrategy strategy =
+                new VaccinationPreferenceStrategy(
+                        new StubVaccinationInfoProvider(applicableTypes, overdueVaccinations));
+
+        assertEquals(0.5, strategy.score(adopter(true), dog));
+    }
+
+    @Test
+    void constructor_nullProvider_throws() {
+        assertThrows(IllegalArgumentException.class, () -> new VaccinationPreferenceStrategy(null));
+    }
+
+    private Adopter adopter(Boolean requiresVaccinated) {
+        return new Adopter("Alice", LivingSpace.HOUSE_WITH_YARD, DailySchedule.HOME_MOST_OF_DAY,
+                null, new AdopterPreferences(null, null, null, requiresVaccinated, 0, 10));
+    }
+
+    private static class StubVaccinationInfoProvider implements VaccinationInfoProvider {
+
+        private final List<VaccineType> applicableTypes;
+        private final List<OverdueVaccination> overdueVaccinations;
+
+        private StubVaccinationInfoProvider(List<VaccineType> applicableTypes,
+                                            List<OverdueVaccination> overdueVaccinations) {
+            this.applicableTypes = applicableTypes;
+            this.overdueVaccinations = overdueVaccinations;
+        }
+
+        @Override
+        public List<VaccineType> getApplicableVaccineTypes(Animal animal) {
+            return applicableTypes;
+        }
+
+        @Override
+        public List<OverdueVaccination> getOverdueVaccinations(Animal animal) {
+            return overdueVaccinations;
+        }
+    }
+}

--- a/src/test/java/shelter/strategy/VaccinationPreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/VaccinationPreferenceStrategyTest.java
@@ -13,41 +13,64 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link VaccinationPreferenceStrategy}.
+ * Covers null guards, applicability behavior, exact matches, no matches, and criterion identity.
  */
 class VaccinationPreferenceStrategyTest {
 
+    private VaccinationPreferenceStrategy strategy;
     private Dog dog;
 
     @BeforeEach
     void setUp() {
+        strategy = new VaccinationPreferenceStrategy(
+                new StubVaccinationInfoProvider(List.of(), List.of()));
         dog = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
                 ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
     }
 
     @Test
-    void isApplicable_whenVaccinatedAnimalsRequired_returnsTrue() {
-        VaccinationPreferenceStrategy strategy =
-                new VaccinationPreferenceStrategy(new StubVaccinationInfoProvider(List.of(), List.of()));
-        assertTrue(strategy.isApplicable(adopter(true), dog));
+    void score_nullAdopter_throws() {
+        assertThrows(IllegalArgumentException.class, () -> strategy.score(null, dog));
     }
 
     @Test
-    void isApplicable_whenVaccinatedAnimalsNotRequired_returnsFalse() {
-        VaccinationPreferenceStrategy strategy =
-                new VaccinationPreferenceStrategy(new StubVaccinationInfoProvider(List.of(), List.of()));
-        assertFalse(strategy.isApplicable(adopter(false), dog));
+    void score_nullAnimal_throws() {
+        assertThrows(IllegalArgumentException.class, () -> strategy.score(adopter(true), null));
+    }
+
+    @Test
+    void isApplicable_noPreferenceSet_returnsFalse() {
         assertFalse(strategy.isApplicable(adopter(null), dog));
     }
 
     @Test
-    void score_noApplicableVaccineTypes_returnsOne() {
+    void score_exactMatch_returnsFullScore() {
+        VaccineType rabies = new VaccineType("Rabies", Species.DOG, 365);
         VaccinationPreferenceStrategy strategy =
-                new VaccinationPreferenceStrategy(new StubVaccinationInfoProvider(List.of(), List.of()));
+                new VaccinationPreferenceStrategy(
+                        new StubVaccinationInfoProvider(List.of(rabies), List.of()));
+
         assertEquals(1.0, strategy.score(adopter(true), dog));
     }
 
+    // VaccinationPreferenceStrategy has binary applicability from the adopter's perspective,
+    // but the actual score supports partial credit for overdue vaccine records.
+
     @Test
-    void score_validOverdueAndMissingVaccines_returnsHalf() {
+    void score_noMatch_returnsZero() {
+        VaccineType rabies = new VaccineType("Rabies", Species.DOG, 365);
+        VaccinationPreferenceStrategy strategy =
+                new VaccinationPreferenceStrategy(
+                        new StubVaccinationInfoProvider(
+                                List.of(rabies),
+                                List.of(new OverdueVaccination(
+                                        rabies, null, LocalDate.now().minusDays(1)))));
+
+        assertEquals(0.0, strategy.score(adopter(true), dog));
+    }
+
+    @Test
+    void score_partialMatch_returnsPartialScore() {
         VaccineType rabies = new VaccineType("Rabies", Species.DOG, 365);
         VaccineType bordetella = new VaccineType("Bordetella", Species.DOG, 365);
         VaccineType distemper = new VaccineType("Distemper", Species.DOG, 365);
@@ -61,6 +84,11 @@ class VaccinationPreferenceStrategyTest {
                         new StubVaccinationInfoProvider(applicableTypes, overdueVaccinations));
 
         assertEquals(0.5, strategy.score(adopter(true), dog));
+    }
+
+    @Test
+    void getCriterion_returnsCorrectEnum() {
+        assertEquals(MatchingCriterion.VACCINATION, strategy.getCriterion());
     }
 
     @Test


### PR DESCRIPTION
Implemented and integrated the strategy-layer matching design.

## Main Changes
- Added `isApplicable()` to the matching strategy architecture so each criterion can decide whether it should participate in scoring.
- Added abstract base strategy classes for shared binary, ordinal, and range-based scoring logic.
- Added `MatchingPreferencesPriority` and `MatchingPreferencesProfile` to represent ranked user preferences.
- Added `MatchingScoreCalculator` to combine applicable strategy scores into a final weighted score.
- Updated matching services to use `MatchingScoreCalculator`.
- Added vaccination preference support and updated `VaccinationPreferenceStrategy` to score valid, overdue, and missing vaccines.
- Added JUnit tests for the strategy layer and support classes.

## Important Design Note
- If one criterion is not applicable, that strategy is skipped and does not affect the final score.
- If no criteria are applicable at all, the final score returns `100`, meaning every match is treated as equally acceptable/perfect for a user with no stated preferences.

## Other Important Changes To The Program As A Whole
- Added vaccination preference into `AdopterPreferences` and updated related constructor call sites.
- Updated adopter input/persistence flow where needed so the new vaccination preference field is carried through the program.
- Added a vaccination information abstraction and wired it through `AppContext`.
- Updated matching service implementations to delegate final score calculation to `MatchingScoreCalculator`.

These changes were needed because the strategy layer now supports preference applicability, weighted scoring, and richer vaccination scoring.
