### PR TITLE
fix(startup): age nullable + Other CSV round-trip

### DIFF
--- a/src/main/java/shelter/application/AdopterApplicationService.java
+++ b/src/main/java/shelter/application/AdopterApplicationService.java
@@ -28,14 +28,14 @@ public interface AdopterApplicationService {
      * @param preferredActivityLevel the preferred activity level, or {@code null} for no preference
      * @param requiresVaccinated     {@code true} if vaccinated animals are required,
      *                               or {@code null} for no vaccination preference
-     * @param minAge                 the minimum preferred animal age; must be non-negative
-     * @param maxAge                 the maximum preferred animal age; must be &gt;= {@code minAge}
+     * @param minAge                 the minimum preferred animal age, or {@code null} for no preference
+     * @param maxAge                 the maximum preferred animal age, or {@code null} for no preference
      * @return the newly created {@link Adopter}
      */
     Adopter registerAdopter(String name, LivingSpace livingSpace, DailySchedule dailySchedule,
                              Species preferredSpecies, String preferredBreed,
                              ActivityLevel preferredActivityLevel, Boolean requiresVaccinated,
-                             int minAge, int maxAge);
+                             Integer minAge, Integer maxAge);
 
     /**
      * Returns a list of all registered adopters in the system.

--- a/src/main/java/shelter/application/impl/AdopterApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/AdopterApplicationServiceImpl.java
@@ -47,7 +47,7 @@ public class AdopterApplicationServiceImpl implements AdopterApplicationService 
     public Adopter registerAdopter(String name, LivingSpace livingSpace, DailySchedule dailySchedule,
                                     Species preferredSpecies, String preferredBreed,
                                     ActivityLevel preferredActivityLevel, Boolean requiresVaccinated,
-                                    int minAge, int maxAge) {
+                                    Integer minAge, Integer maxAge) {
         // Build preferences object from individual fields
         AdopterPreferences preferences = new AdopterPreferences(
                 preferredSpecies, preferredBreed, preferredActivityLevel,

--- a/src/main/java/shelter/application/impl/AdopterApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/AdopterApplicationServiceImpl.java
@@ -87,8 +87,8 @@ public class AdopterApplicationServiceImpl implements AdopterApplicationService 
         ActivityLevel newActivity = preferredActivityLevel != null ? preferredActivityLevel : oldPrefs.getPreferredActivityLevel();
         Boolean      newRequiresVaccinated =
                 requiresVaccinated != null ? requiresVaccinated : oldPrefs.getRequiresVaccinated();
-        int          newMin      = minAge != null ? minAge : oldPrefs.getMinAge();
-        int          newMax      = maxAge != null ? maxAge : oldPrefs.getMaxAge();
+        Integer      newMin      = minAge != null ? minAge : oldPrefs.getMinAge();
+        Integer      newMax      = maxAge != null ? maxAge : oldPrefs.getMaxAge();
 
         AdopterPreferences newPrefs = new AdopterPreferences(
                 newSpecies, newBreed, newActivity, newRequiresVaccinated, newMin, newMax);

--- a/src/main/java/shelter/cli/AdopterCmd.java
+++ b/src/main/java/shelter/cli/AdopterCmd.java
@@ -113,13 +113,13 @@ public class AdopterCmd implements Runnable {
                 description = "Whether vaccinated animals are required: true or false")
         private Boolean requiresVaccinated;
 
-        /** Minimum preferred animal age; defaults to 0. */
-        @Option(names = "--min-age", description = "Minimum preferred animal age (default 0)")
-        private int minAge = 0;
+        /** Minimum preferred animal age; omit for no preference. */
+        @Option(names = "--min-age", description = "Minimum preferred animal age (omit for no preference)")
+        private Integer minAge;
 
-        /** Maximum preferred animal age; defaults to 20. */
-        @Option(names = "--max-age", description = "Maximum preferred animal age (default 20)")
-        private int maxAge = 20;
+        /** Maximum preferred animal age; omit for no preference. */
+        @Option(names = "--max-age", description = "Maximum preferred animal age (omit for no preference)")
+        private Integer maxAge;
 
         /**
          * Executes the registration and prints the new adopter's ID and name.

--- a/src/main/java/shelter/cli/MatchCmd.java
+++ b/src/main/java/shelter/cli/MatchCmd.java
@@ -2,7 +2,6 @@ package shelter.cli;
 
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import shelter.service.model.ExplanationResult;
 import shelter.service.model.MatchResult;
 
 import java.util.List;
@@ -39,7 +38,7 @@ public class MatchCmd implements Runnable {
     /**
      * Finds and ranks available animals in a shelter for a given adopter.
      * Only available (unadopted) matchable animals are scored and returned.
-     * Results are printed in descending score order; an optional AI explanation follows.
+     * Results are printed in descending score order for the CLI or demo agent to interpret.
      */
     @Command(name = "animal",
              description = "Find best-matching animals for an adopter",
@@ -54,12 +53,8 @@ public class MatchCmd implements Runnable {
         @Option(names = "--shelter", required = true, description = "Shelter ID")
         private String shelterId;
 
-        /** Whether to include a structured AI-generated explanation after the ranked list. */
-        @Option(names = "--explain", description = "Include AI match explanation")
-        private boolean explain;
-
         /**
-         * Executes the matching, prints ranked results, and optionally prints the AI explanation.
+         * Executes the matching and prints ranked results.
          * Prints a message if no available animals are found in the shelter.
          */
         @Override
@@ -80,16 +75,6 @@ public class MatchCmd implements Runnable {
                     System.out.printf("%-4d  %-36s  %-15s  %d%n",
                             rank++, r.getAnimal().getId(), r.getAnimal().getName(), r.getScore());
                 }
-                // Optionally print structured explanation from the explanation service
-                if (explain) {
-                    ExplanationResult exp =
-                            AppContext.get().explanationService().explain(results);
-                    System.out.println();
-                    System.out.println("=== Match Explanation ===");
-                    System.out.println("Rationale   : " + exp.getMatchRationale());
-                    System.out.println("Confidence  : " + exp.getConfidenceAssessment());
-                    System.out.println("Advice      : " + exp.getPersonalizedAdvice());
-                }
             } catch (Exception e) {
                 System.err.println("Error: " + e.getMessage());
             }
@@ -102,7 +87,8 @@ public class MatchCmd implements Runnable {
 
     /**
      * Finds and ranks all registered adopters by compatibility with a given available animal.
-     * The animal must not have been adopted. Results are printed in descending score order.
+     * The animal must not have been adopted. Results are printed in descending score order
+     * for the CLI or demo agent to interpret.
      */
     @Command(name = "adopter",
              description = "Find best-matching adopters for an animal",
@@ -113,12 +99,8 @@ public class MatchCmd implements Runnable {
         @Option(names = "--animal", required = true, description = "Animal ID")
         private String animalId;
 
-        /** Whether to include a structured AI-generated explanation after the ranked list. */
-        @Option(names = "--explain", description = "Include AI match explanation")
-        private boolean explain;
-
         /**
-         * Executes the matching, prints ranked results, and optionally prints the AI explanation.
+         * Executes the matching and prints ranked results.
          * Prints an error if the animal is not found, is already adopted, or is not matchable.
          */
         @Override
@@ -139,16 +121,6 @@ public class MatchCmd implements Runnable {
                     System.out.printf("%-4d  %-36s  %-15s  %d%n",
                             rank++, r.getAdopter().getId(), r.getAdopter().getName(),
                             r.getScore());
-                }
-                // Optionally print structured explanation from the explanation service
-                if (explain) {
-                    ExplanationResult exp =
-                            AppContext.get().explanationService().explain(results);
-                    System.out.println();
-                    System.out.println("=== Match Explanation ===");
-                    System.out.println("Rationale   : " + exp.getMatchRationale());
-                    System.out.println("Confidence  : " + exp.getConfidenceAssessment());
-                    System.out.println("Advice      : " + exp.getPersonalizedAdvice());
                 }
             } catch (Exception e) {
                 System.err.println("Error: " + e.getMessage());

--- a/src/main/java/shelter/domain/AdopterPreferences.java
+++ b/src/main/java/shelter/domain/AdopterPreferences.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  * Preferences include desired species, breed, activity level, age range,
  * and whether the adopter requires already-vaccinated animals;
  * these are consumed by matching strategies to score compatibility with available animals.
- * All fields except {@code minAge} and {@code maxAge} may be {@code null} to indicate no preference.
+ * All fields may be {@code null} to indicate no preference, including {@code minAge} and {@code maxAge}.
  */
 public class AdopterPreferences {
 
@@ -15,30 +15,30 @@ public class AdopterPreferences {
     private final String preferredBreed;
     private final ActivityLevel preferredActivityLevel;
     private final Boolean requiresVaccinated;
-    private final int minAge;
-    private final int maxAge;
+    private final Integer minAge;
+    private final Integer maxAge;
 
     /**
      * Constructs an AdopterPreferences instance with the given criteria.
-     * {@code preferredSpecies}, {@code preferredBreed}, and {@code preferredActivityLevel}
-     * may be {@code null} to express no preference; age bounds must be valid.
+     * Any field may be {@code null} to express no preference.
+     * When {@code minAge} or {@code maxAge} are {@code null}, the age criterion is not applied during matching.
      *
      * @param preferredSpecies        the desired {@link Species}, or {@code null} for no preference
      * @param preferredBreed          the desired breed, or {@code null} for no preference
      * @param preferredActivityLevel  the desired activity level, or {@code null} for no preference
      * @param requiresVaccinated      {@code true} if the adopter requires vaccinated animals,
      *                                or {@code null} for no vaccination preference
-     * @param minAge                  the minimum preferred age in years; must be non-negative
-     * @param maxAge                  the maximum preferred age in years; must be &gt;= {@code minAge}
+     * @param minAge                  the minimum preferred age in years; must be non-negative if provided
+     * @param maxAge                  the maximum preferred age in years; must be &gt;= {@code minAge} if both provided
      * @throws IllegalArgumentException if {@code minAge} is negative or {@code maxAge} &lt; {@code minAge}
      */
     public AdopterPreferences(Species preferredSpecies, String preferredBreed,
                                ActivityLevel preferredActivityLevel, Boolean requiresVaccinated,
-                               int minAge, int maxAge) {
-        if (minAge < 0) {
+                               Integer minAge, Integer maxAge) {
+        if (minAge != null && minAge < 0) {
             throw new IllegalArgumentException("Minimum age must be non-negative.");
         }
-        if (maxAge < minAge) {
+        if (minAge != null && maxAge != null && maxAge < minAge) {
             throw new IllegalArgumentException(
                     "Maximum age must be greater than or equal to minimum age.");
         }
@@ -87,20 +87,20 @@ public class AdopterPreferences {
     }
 
     /**
-     * Returns the minimum preferred age in years.
+     * Returns the minimum preferred age in years, or {@code null} if no minimum was set.
      *
-     * @return the minimum preferred age, always non-negative
+     * @return the minimum preferred age, or {@code null} for no preference
      */
-    public int getMinAge() {
+    public Integer getMinAge() {
         return minAge;
     }
 
     /**
-     * Returns the maximum preferred age in years.
+     * Returns the maximum preferred age in years, or {@code null} if no maximum was set.
      *
-     * @return the maximum preferred age, always &gt;= {@code minAge}
+     * @return the maximum preferred age, or {@code null} for no preference
      */
-    public int getMaxAge() {
+    public Integer getMaxAge() {
         return maxAge;
     }
 
@@ -127,8 +127,8 @@ public class AdopterPreferences {
         if (this == o) return true;
         if (!(o instanceof AdopterPreferences)) return false;
         AdopterPreferences other = (AdopterPreferences) o;
-        return minAge == other.minAge
-                && maxAge == other.maxAge
+        return Objects.equals(minAge, other.minAge)
+                && Objects.equals(maxAge, other.maxAge)
                 && preferredSpecies == other.preferredSpecies
                 && preferredActivityLevel == other.preferredActivityLevel
                 && Objects.equals(requiresVaccinated, other.requiresVaccinated)
@@ -157,6 +157,6 @@ public class AdopterPreferences {
         return "AdopterPreferences[species=" + preferredSpecies + ", breed=" + preferredBreed
                 + ", activity=" + preferredActivityLevel
                 + ", requiresVaccinated=" + requiresVaccinated
-                + ", age=" + minAge + "-" + maxAge + "]";
+                + ", age=" + (minAge != null ? minAge : "any") + "-" + (maxAge != null ? maxAge : "any") + "]";
     }
 }

--- a/src/main/java/shelter/repository/csv/CsvAdopterRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAdopterRepository.java
@@ -117,8 +117,10 @@ public class CsvAdopterRepository implements AdopterRepository {
                 ? null
                 : Boolean.valueOf(requiresVaccinatedRaw);
 
-        int minAge             = Integer.parseInt(parts[9].trim());
-        int maxAge             = Integer.parseInt(parts[10].trim());
+        String minAgeRaw = parts[9].trim();
+        Integer minAge   = minAgeRaw.isEmpty() ? null : Integer.parseInt(minAgeRaw);
+        String maxAgeRaw = parts[10].trim();
+        Integer maxAge   = maxAgeRaw.isEmpty() ? null : Integer.parseInt(maxAgeRaw);
 
         List<String> adoptedIds = CsvUtils.decodeList(
                 CsvUtils.unescapeCsv(parts[11]));
@@ -143,8 +145,8 @@ public class CsvAdopterRepository implements AdopterRepository {
                   .append(CsvUtils.escapeCsv(p.getPreferredBreed())).append(',')
                   .append(p.getPreferredActivityLevel() != null ? p.getPreferredActivityLevel().name() : "").append(',')
                   .append(p.getRequiresVaccinated() != null ? p.getRequiresVaccinated() : "").append(',')
-                  .append(p.getMinAge()).append(',')
-                  .append(p.getMaxAge()).append(',')
+                  .append(p.getMinAge() != null ? p.getMinAge() : "").append(',')
+                  .append(p.getMaxAge() != null ? p.getMaxAge() : "").append(',')
                   .append(CsvUtils.escapeCsv(CsvUtils.encodeList(a.getAdoptedAnimalIds())))
                   .append(System.lineSeparator());
             }

--- a/src/main/java/shelter/repository/csv/CsvAnimalRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAnimalRepository.java
@@ -24,9 +24,11 @@ import java.util.Optional;
 /**
  * CSV-backed implementation of {@link AnimalRepository} that persists animal records to a flat file
  * named {@code animals.csv}.
- * All concrete animal types ({@link Dog}, {@link Cat}, {@link Rabbit}) are stored in the same file
- * using a species discriminator column; species-specific columns are left empty for non-applicable
- * types. Records are loaded into memory at construction and flushed on every mutation.
+ * All concrete animal types ({@link Dog}, {@link Cat}, {@link Rabbit}, and {@link Other}) are stored
+ * in the same file using a species discriminator column: standard species write their enum name
+ * (e.g. {@code DOG}), while {@link Other} animals write their free-form {@code speciesName} so the
+ * correct type can be reconstructed on reload. Species-specific columns are left empty for
+ * non-applicable types. Records are loaded into memory at construction and flushed on every mutation.
  */
 public class CsvAnimalRepository implements AnimalRepository {
 
@@ -100,7 +102,7 @@ public class CsvAnimalRepository implements AnimalRepository {
      * Species-specific columns that do not apply are stored as empty strings.
      *
      * @param line a non-empty CSV row
-     * @return the reconstructed {@link Animal} (a {@link Dog}, {@link Cat}, {@link Rabbit}, or {@link Other});
+     * @return the reconstructed {@link Animal} (a {@link Dog}, {@link Cat}, {@link Rabbit}, or {@link Other})
      */
     private Animal parseLine(String line) {
         String[] p = CsvUtils.splitCsv(line);

--- a/src/main/java/shelter/repository/csv/CsvAnimalRepository.java
+++ b/src/main/java/shelter/repository/csv/CsvAnimalRepository.java
@@ -4,6 +4,7 @@ import shelter.domain.ActivityLevel;
 import shelter.domain.Animal;
 import shelter.domain.Cat;
 import shelter.domain.Dog;
+import shelter.domain.Other;
 import shelter.domain.Rabbit;
 import shelter.domain.Species;
 import shelter.repository.AnimalRepository;
@@ -99,13 +100,11 @@ public class CsvAnimalRepository implements AnimalRepository {
      * Species-specific columns that do not apply are stored as empty strings.
      *
      * @param line a non-empty CSV row
-     * @return the reconstructed {@link Animal} (a {@link Dog}, {@link Cat}, or {@link Rabbit})
-     * @throws IllegalArgumentException if the species value is unrecognized
+     * @return the reconstructed {@link Animal} (a {@link Dog}, {@link Cat}, {@link Rabbit}, or {@link Other});
      */
     private Animal parseLine(String line) {
         String[] p = CsvUtils.splitCsv(line);
         String id            = CsvUtils.unescapeCsv(p[0]);
-        Species species      = Species.valueOf(p[1].trim());
         String name          = CsvUtils.unescapeCsv(p[2]);
         String breed         = CsvUtils.unescapeCsv(p[3]);
         LocalDate birthday   = LocalDate.parse(p[4].trim());
@@ -120,23 +119,21 @@ public class CsvAnimalRepository implements AnimalRepository {
         String indoorRaw    = p.length > 11 ? p[11].trim() : "";
         String furRaw       = p.length > 12 ? p[12].trim() : "";
 
-        switch (species) {
-            case DOG: {
-                Dog.Size size = sizeRaw.isEmpty() ? Dog.Size.MEDIUM : Dog.Size.valueOf(sizeRaw);
-                boolean neutered = !neuteredRaw.isEmpty() && Boolean.parseBoolean(neuteredRaw);
-                return new Dog(id, name, breed, birthday, act, vaccinated, adopterId, shelterId, size, neutered);
-            }
-            case CAT: {
-                boolean indoor   = !indoorRaw.isEmpty() && Boolean.parseBoolean(indoorRaw);
-                boolean neutered = !neuteredRaw.isEmpty() && Boolean.parseBoolean(neuteredRaw);
-                return new Cat(id, name, breed, birthday, act, vaccinated, adopterId, shelterId, indoor, neutered);
-            }
-            case RABBIT: {
-                Rabbit.FurLength fur = furRaw.isEmpty() ? Rabbit.FurLength.SHORT : Rabbit.FurLength.valueOf(furRaw);
-                return new Rabbit(id, name, breed, birthday, act, vaccinated, adopterId, shelterId, fur);
-            }
-            default:
-                throw new IllegalArgumentException("Unsupported species in CSV: " + species);
+        String speciesRaw = CsvUtils.unescapeCsv(p[1]);
+        if (speciesRaw.equals("DOG")) {
+            Dog.Size size = sizeRaw.isEmpty() ? Dog.Size.MEDIUM : Dog.Size.valueOf(sizeRaw);
+            boolean neutered = !neuteredRaw.isEmpty() && Boolean.parseBoolean(neuteredRaw);
+            return new Dog(id, name, breed, birthday, act, vaccinated, adopterId, shelterId, size, neutered);
+        } else if (speciesRaw.equals("CAT")) {
+            boolean indoor   = !indoorRaw.isEmpty() && Boolean.parseBoolean(indoorRaw);
+            boolean neutered = !neuteredRaw.isEmpty() && Boolean.parseBoolean(neuteredRaw);
+            return new Cat(id, name, breed, birthday, act, vaccinated, adopterId, shelterId, indoor, neutered);
+        } else if (speciesRaw.equals("RABBIT")) {
+            Rabbit.FurLength fur = furRaw.isEmpty() ? Rabbit.FurLength.SHORT : Rabbit.FurLength.valueOf(furRaw);
+            return new Rabbit(id, name, breed, birthday, act, vaccinated, adopterId, shelterId, fur);
+        } else {
+            // Any unrecognised species string is treated as Other; speciesRaw is the free-form name
+            return new Other(id, name, breed, birthday, act, vaccinated, adopterId, shelterId, speciesRaw);
         }
     }
 
@@ -160,8 +157,14 @@ public class CsvAnimalRepository implements AnimalRepository {
             furVal = r.getFurLength().name();
         }
 
+        // For Other animals, write the free-form speciesName into col 1 instead of "OTHER",
+        // so the reader can reconstruct the correct speciesName on reload.
+        String speciesCol = (a instanceof Other)
+                ? CsvUtils.escapeCsv(((Other) a).getSpeciesName())
+                : a.getSpecies().name();
+
         return CsvUtils.escapeCsv(a.getId()) + ','
-             + a.getSpecies().name() + ','
+             + speciesCol + ','
              + CsvUtils.escapeCsv(a.getName()) + ','
              + CsvUtils.escapeCsv(a.getBreed()) + ','
              + a.getBirthday().toString() + ','

--- a/src/main/java/shelter/startup/WorkdirBootstrapper.java
+++ b/src/main/java/shelter/startup/WorkdirBootstrapper.java
@@ -74,8 +74,8 @@ public class WorkdirBootstrapper {
             - `shelter transfer cancel --request <request-id>`
 
             Match:
-            - `shelter match animal --adopter <adopter-id> --shelter <shelter-id> [--explain]`
-            - `shelter match adopter --animal <animal-id> [--explain]`
+            - `shelter match animal --adopter <adopter-id> --shelter <shelter-id>`
+            - `shelter match adopter --animal <animal-id>`
 
             Vaccine:
             - `shelter vaccine record --animal <animal-id> --type <vaccine-type-name> --date <yyyy-mm-dd>`
@@ -94,6 +94,13 @@ public class WorkdirBootstrapper {
             `shelter` CLI calls. Always list shelters, adopters, animals, vaccine types, or
             requests first if you need an ID. Always ask for confirmation before destructive
             operations such as `remove`, `reject`, or `cancel`.
+
+            After running any shelter match command, use the ranked output as the source of truth
+            and explain the top match to the user in natural language. If the match table alone
+            does not show enough context, look up the relevant animal, adopter, shelter, or
+            vaccination records before explaining. Mention score, species, breed, age, activity
+            level, living situation, schedule, and vaccination preferences only when they are
+            available from CLI output or persisted data; do not invent missing details.
 
             ## Data Directory
 

--- a/src/main/java/shelter/strategy/AgePreferenceStrategy.java
+++ b/src/main/java/shelter/strategy/AgePreferenceStrategy.java
@@ -26,8 +26,8 @@ public class AgePreferenceStrategy extends AbstractRangeMatchingStrategy {
 
     /**
      * Returns whether the adopter has expressed an age preference.
-     * In the current design, an age range of {@code 0..Integer.MAX_VALUE}
-     * is treated as "no age preference".
+     * The age criterion is considered applicable when at least one of {@code minAge} or {@code maxAge}
+     * is non-null; a {@code null} value for both means the adopter has no age preference.
      *
      * @param adopter the adopter being evaluated
      * @param animal the animal being evaluated
@@ -38,13 +38,14 @@ public class AgePreferenceStrategy extends AbstractRangeMatchingStrategy {
     public boolean isApplicable(Adopter adopter, Animal animal) {
         validateInputs(adopter, animal);
 
-        int minAge = adopter.getPreferences().getMinAge();
-        int maxAge = adopter.getPreferences().getMaxAge();
-        return !(minAge == 0 && maxAge == Integer.MAX_VALUE);
+        Integer minAge = adopter.getPreferences().getMinAge();
+        Integer maxAge = adopter.getPreferences().getMaxAge();
+        return minAge != null || maxAge != null;
     }
 
     /**
      * Returns how far the animal's age is from the adopter's preferred age range.
+     * A {@code null} bound is treated as unbounded (0 for min, {@link Integer#MAX_VALUE} for max).
      * A value inside the range returns {@code 0.0}.
      *
      * @param adopter the adopter being evaluated
@@ -53,10 +54,12 @@ public class AgePreferenceStrategy extends AbstractRangeMatchingStrategy {
      */
     @Override
     protected double getDistanceFromPreferredRange(Adopter adopter, Animal animal) {
-        int minAge = adopter.getPreferences().getMinAge();
-        int maxAge = adopter.getPreferences().getMaxAge();
+        Integer minAge = adopter.getPreferences().getMinAge();
+        Integer maxAge = adopter.getPreferences().getMaxAge();
+        int effectiveMin = minAge != null ? minAge : 0;
+        int effectiveMax = maxAge != null ? maxAge : Integer.MAX_VALUE;
         double animalAge = calculatePreciseAgeInYears(animal.getBirthday());
-        return calculateDistanceFromRange(animalAge, minAge, maxAge);
+        return calculateDistanceFromRange(animalAge, effectiveMin, effectiveMax);
     }
 
     /**

--- a/src/test/java/shelter/repository/csv/CsvAdopterRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvAdopterRepositoryTest.java
@@ -120,6 +120,25 @@ class CsvAdopterRepositoryTest {
     }
 
     /**
+     * Regression test for the nullable minAge/maxAge bug.
+     * Before the fix, null age bounds were written as empty strings but parsed back with
+     * {@code Integer.parseInt()} directly, throwing {@code NumberFormatException} on reload.
+     * This verifies that null age bounds survive a full CSV round-trip without error.
+     */
+    @Test
+    void nullAge_roundTrip() {
+        AdopterPreferences prefs = new AdopterPreferences(null, null, null, null, null, null);
+        Adopter a = new Adopter("NoAgePrefs", LivingSpace.APARTMENT,
+                DailySchedule.AWAY_MOST_OF_DAY, null, prefs);
+        repo.save(a);
+
+        CsvAdopterRepository repo2 = new CsvAdopterRepository(tempDir.toString());
+        Adopter loaded = repo2.findById(a.getId()).orElseThrow();
+        assertNull(loaded.getPreferences().getMinAge());
+        assertNull(loaded.getPreferences().getMaxAge());
+    }
+
+    /**
      * Verifies that adoptedAnimalIds are preserved through a CSV round-trip.
      */
     @Test

--- a/src/test/java/shelter/repository/csv/CsvAnimalRepositoryTest.java
+++ b/src/test/java/shelter/repository/csv/CsvAnimalRepositoryTest.java
@@ -7,6 +7,7 @@ import shelter.domain.ActivityLevel;
 import shelter.domain.Animal;
 import shelter.domain.Cat;
 import shelter.domain.Dog;
+import shelter.domain.Other;
 import shelter.domain.Rabbit;
 
 import java.nio.file.Path;
@@ -18,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link CsvAnimalRepository}, verifying CRUD operations and query methods
- * for all three concrete animal types using a JUnit {@code @TempDir}.
+ * for all concrete animal types (Dog, Cat, Rabbit, and Other) using a JUnit {@code @TempDir}.
  */
 class CsvAnimalRepositoryTest {
 
@@ -165,6 +166,28 @@ class CsvAnimalRepositoryTest {
         repo.save(dog);
 
         assertTrue(repo.findByAdopterId("some-adopter").isEmpty());
+    }
+
+    /**
+     * Regression test for the Other-animal CSV round-trip bug.
+     * Before the fix, parseLine() called Species.valueOf() which threw for non-enum values,
+     * silently dropping Other animals on reload. This verifies the free-form speciesName
+     * survives a full save-and-reload cycle.
+     */
+    @Test
+    void saveAndFindById_other_roundTripsSpeciesName() {
+        Other fish = new Other("Nemo", "Clownfish", LocalDate.now().minusYears(1),
+                ActivityLevel.LOW, false, "fish");
+        fish.setShelterId("shelter-4");
+        repo.save(fish);
+
+        CsvAnimalRepository repo2 = new CsvAnimalRepository(tempDir.toString());
+        Animal loaded = repo2.findById(fish.getId()).orElseThrow();
+        assertInstanceOf(Other.class, loaded);
+        assertEquals("fish", ((Other) loaded).getSpeciesName());
+        assertEquals("Nemo", loaded.getName());
+        assertEquals("Clownfish", loaded.getBreed());
+        assertEquals("shelter-4", loaded.getShelterId());
     }
 
     /**

--- a/src/test/java/shelter/startup/ApplicationGraphTest.java
+++ b/src/test/java/shelter/startup/ApplicationGraphTest.java
@@ -1,0 +1,39 @@
+package shelter.startup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ApplicationGraph}.
+ * These tests verify that repository wiring produces a complete application graph for CLI use.
+ */
+class ApplicationGraphTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void from_validRepositoryBundle_returnsCompleteApplicationGraph() {
+        RepositoryBundle repositories = new CsvRepositoryFactory().create(tempDir);
+        ApplicationGraph graph = ApplicationGraph.from(repositories);
+
+        assertNotNull(graph.animalApp());
+        assertNotNull(graph.adopterApp());
+        assertNotNull(graph.shelterApp());
+        assertNotNull(graph.adoptionApp());
+        assertNotNull(graph.transferApp());
+        assertNotNull(graph.matchingApp());
+        assertNotNull(graph.vaccinationApp());
+        assertNotNull(graph.auditApp());
+        assertNotNull(graph.explanationService());
+    }
+
+    @Test
+    void from_nullRepositoryBundle_throws() {
+        assertThrows(NullPointerException.class, () -> ApplicationGraph.from(null));
+    }
+}

--- a/src/test/java/shelter/startup/CsvRepositoryFactoryTest.java
+++ b/src/test/java/shelter/startup/CsvRepositoryFactoryTest.java
@@ -1,0 +1,54 @@
+package shelter.startup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CsvRepositoryFactory}.
+ * These tests verify that the factory creates the full CSV repository bundle without using the real home directory.
+ */
+class CsvRepositoryFactoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void create_validDataDirectory_returnsCompleteRepositoryBundle() {
+        RepositoryBundle repositories = new CsvRepositoryFactory().create(tempDir);
+
+        assertNotNull(repositories.shelterRepository());
+        assertNotNull(repositories.animalRepository());
+        assertNotNull(repositories.adopterRepository());
+        assertNotNull(repositories.adoptionRequestRepository());
+        assertNotNull(repositories.transferRequestRepository());
+        assertNotNull(repositories.vaccineTypeRepository());
+        assertNotNull(repositories.vaccinationRecordRepository());
+        assertNotNull(repositories.auditRepository());
+    }
+
+    @Test
+    void create_validDataDirectory_initializesCsvFiles() {
+        new CsvRepositoryFactory().create(tempDir);
+
+        assertTrue(Files.isRegularFile(tempDir.resolve("shelters.csv")));
+        assertTrue(Files.isRegularFile(tempDir.resolve("animals.csv")));
+        assertTrue(Files.isRegularFile(tempDir.resolve("adopters.csv")));
+        assertTrue(Files.isRegularFile(tempDir.resolve("adoption-requests.csv")));
+        assertTrue(Files.isRegularFile(tempDir.resolve("transfer-requests.csv")));
+        assertTrue(Files.isRegularFile(tempDir.resolve("vaccine-types.csv")));
+        assertTrue(Files.isRegularFile(tempDir.resolve("vaccination-records.csv")));
+        assertTrue(Files.isRegularFile(tempDir.resolve("audit.csv")));
+    }
+
+    @Test
+    void create_nullDataDirectory_throws() {
+        CsvRepositoryFactory factory = new CsvRepositoryFactory();
+
+        assertThrows(IllegalArgumentException.class, () -> factory.create(null));
+    }
+}

--- a/src/test/java/shelter/startup/RepositoryBundleTest.java
+++ b/src/test/java/shelter/startup/RepositoryBundleTest.java
@@ -1,0 +1,64 @@
+package shelter.startup;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link RepositoryBundle}.
+ * These tests verify that the bundle exposes repositories consistently and rejects invalid construction.
+ */
+class RepositoryBundleTest {
+
+    @TempDir
+    Path tempDir;
+
+    private RepositoryBundle repositories;
+
+    @BeforeEach
+    void setUp() {
+        repositories = new CsvRepositoryFactory().create(tempDir);
+    }
+
+    @Test
+    void getters_validBundle_returnRepositories() {
+        assertNotNull(repositories.shelterRepository());
+        assertNotNull(repositories.animalRepository());
+        assertNotNull(repositories.adopterRepository());
+        assertNotNull(repositories.adoptionRequestRepository());
+        assertNotNull(repositories.transferRequestRepository());
+        assertNotNull(repositories.vaccineTypeRepository());
+        assertNotNull(repositories.vaccinationRecordRepository());
+        assertNotNull(repositories.auditRepository());
+    }
+
+    @Test
+    void constructor_nullShelterRepository_throws() {
+        assertThrows(NullPointerException.class, () -> new RepositoryBundle(
+                null,
+                repositories.animalRepository(),
+                repositories.adopterRepository(),
+                repositories.adoptionRequestRepository(),
+                repositories.transferRequestRepository(),
+                repositories.vaccineTypeRepository(),
+                repositories.vaccinationRecordRepository(),
+                repositories.auditRepository()));
+    }
+
+    @Test
+    void constructor_nullAuditRepository_throws() {
+        assertThrows(NullPointerException.class, () -> new RepositoryBundle(
+                repositories.shelterRepository(),
+                repositories.animalRepository(),
+                repositories.adopterRepository(),
+                repositories.adoptionRequestRepository(),
+                repositories.transferRequestRepository(),
+                repositories.vaccineTypeRepository(),
+                repositories.vaccinationRecordRepository(),
+                null));
+    }
+}

--- a/src/test/java/shelter/startup/ShelterAnimalLinkerTest.java
+++ b/src/test/java/shelter/startup/ShelterAnimalLinkerTest.java
@@ -1,0 +1,57 @@
+package shelter.startup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Dog;
+import shelter.domain.Shelter;
+
+import java.time.LocalDate;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ShelterAnimalLinker}.
+ * The linker is tested with real CSV repositories so the test matches the startup reload flow.
+ */
+class ShelterAnimalLinkerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void restoreLinks_animalWithShelterId_addsAnimalToShelter() {
+        RepositoryBundle repositories = new CsvRepositoryFactory().create(tempDir);
+        Shelter shelter = new Shelter("Happy Paws", "Boston", 10);
+        Dog dog = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
+                ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
+        dog.setShelterId(shelter.getId());
+        repositories.shelterRepository().save(shelter);
+        repositories.animalRepository().save(dog);
+
+        new ShelterAnimalLinker().restoreLinks(repositories);
+
+        Shelter reloadedShelter = repositories.shelterRepository().findById(shelter.getId()).orElseThrow();
+        assertEquals(1, reloadedShelter.getAnimals().size());
+        assertEquals(dog.getId(), reloadedShelter.getAnimals().get(0).getId());
+    }
+
+    @Test
+    void restoreLinks_missingShelter_doesNotThrow() {
+        RepositoryBundle repositories = new CsvRepositoryFactory().create(tempDir);
+        Dog dog = new Dog("Rex", "Labrador", LocalDate.now().minusYears(3),
+                ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
+        dog.setShelterId("missing-shelter");
+        repositories.animalRepository().save(dog);
+
+        assertDoesNotThrow(() -> new ShelterAnimalLinker().restoreLinks(repositories));
+    }
+
+    @Test
+    void restoreLinks_nullRepositoryBundle_throws() {
+        ShelterAnimalLinker linker = new ShelterAnimalLinker();
+
+        assertThrows(NullPointerException.class, () -> linker.restoreLinks(null));
+    }
+}

--- a/src/test/java/shelter/startup/SystemStartupImplTest.java
+++ b/src/test/java/shelter/startup/SystemStartupImplTest.java
@@ -1,0 +1,56 @@
+package shelter.startup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SystemStartupImpl}.
+ * These tests verify that startup can initialize a complete application graph from an isolated temp directory.
+ */
+class SystemStartupImplTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void initialize_tempDirectory_createsWorkdirAndWiresApplicationGraph() {
+        Path shelterHome = tempDir.resolve("shelter");
+        SystemStartupImpl startup = new SystemStartupImpl(shelterHome);
+
+        startup.initialize();
+
+        assertTrue(Files.isDirectory(shelterHome));
+        assertTrue(Files.isDirectory(shelterHome.resolve("data")));
+        assertTrue(Files.isRegularFile(shelterHome.resolve("CLAUDE.md")));
+        assertNotNull(startup.animalApp());
+        assertNotNull(startup.adopterApp());
+        assertNotNull(startup.shelterApp());
+        assertNotNull(startup.adoptionApp());
+        assertNotNull(startup.transferApp());
+        assertNotNull(startup.matchingApp());
+        assertNotNull(startup.vaccinationApp());
+        assertNotNull(startup.auditApp());
+        assertNotNull(startup.explanationService());
+    }
+
+    @Test
+    void initialize_calledTwice_keepsSameWiredGraph() {
+        SystemStartupImpl startup = new SystemStartupImpl(tempDir.resolve("shelter"));
+
+        startup.initialize();
+        Object animalApp = startup.animalApp();
+        startup.initialize();
+
+        assertSame(animalApp, startup.animalApp());
+    }
+
+    @Test
+    void constructor_nullShelterHome_throws() {
+        assertThrows(NullPointerException.class, () -> new SystemStartupImpl(null));
+    }
+}

--- a/src/test/java/shelter/startup/WorkdirBootstrapperTest.java
+++ b/src/test/java/shelter/startup/WorkdirBootstrapperTest.java
@@ -1,0 +1,54 @@
+package shelter.startup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link WorkdirBootstrapper}.
+ * The tests use a temporary directory so startup file creation never touches the real user home.
+ */
+class WorkdirBootstrapperTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void bootstrap_missingWorkdir_createsDataDirectoryAndClaudeFile() throws IOException {
+        Path shelterHome = tempDir.resolve("shelter");
+        WorkdirBootstrapper bootstrapper = new WorkdirBootstrapper();
+
+        bootstrapper.bootstrap(shelterHome);
+
+        assertTrue(Files.isDirectory(shelterHome));
+        assertTrue(Files.isDirectory(shelterHome.resolve("data")));
+        assertTrue(Files.isRegularFile(shelterHome.resolve("CLAUDE.md")));
+        assertTrue(Files.readString(shelterHome.resolve("CLAUDE.md"))
+                .contains("Command Reference"));
+    }
+
+    @Test
+    void bootstrap_existingClaudeFile_doesNotOverwrite() throws IOException {
+        Path shelterHome = tempDir.resolve("shelter");
+        Path claudeFile = shelterHome.resolve("CLAUDE.md");
+        Files.createDirectories(shelterHome);
+        Files.writeString(claudeFile, "custom user content");
+
+        new WorkdirBootstrapper().bootstrap(shelterHome);
+
+        assertEquals("custom user content", Files.readString(claudeFile));
+        assertTrue(Files.isDirectory(shelterHome.resolve("data")));
+    }
+
+    @Test
+    void bootstrap_nullShelterHome_throws() {
+        WorkdirBootstrapper bootstrapper = new WorkdirBootstrapper();
+
+        assertThrows(NullPointerException.class, () -> bootstrapper.bootstrap(null));
+    }
+}

--- a/src/test/java/shelter/startup/WorkdirBootstrapperTest.java
+++ b/src/test/java/shelter/startup/WorkdirBootstrapperTest.java
@@ -28,8 +28,14 @@ class WorkdirBootstrapperTest {
         assertTrue(Files.isDirectory(shelterHome));
         assertTrue(Files.isDirectory(shelterHome.resolve("data")));
         assertTrue(Files.isRegularFile(shelterHome.resolve("CLAUDE.md")));
-        assertTrue(Files.readString(shelterHome.resolve("CLAUDE.md"))
-                .contains("Command Reference"));
+        String claudeContent = Files.readString(shelterHome.resolve("CLAUDE.md"));
+        assertTrue(claudeContent.contains("Command Reference"));
+        assertTrue(claudeContent.contains(
+                "shelter match animal --adopter <adopter-id> --shelter <shelter-id>"));
+        assertTrue(claudeContent.contains("shelter match adopter --animal <animal-id>"));
+        assertTrue(claudeContent.contains("use the ranked output as the source of truth"));
+        assertTrue(claudeContent.contains("do not invent missing details"));
+        assertFalse(claudeContent.contains("[--explain]"));
     }
 
     @Test

--- a/src/test/java/shelter/strategy/AgePreferenceStrategyTest.java
+++ b/src/test/java/shelter/strategy/AgePreferenceStrategyTest.java
@@ -41,7 +41,7 @@ class AgePreferenceStrategyTest {
     void isApplicable_noPreferenceSet_returnsFalse() {
         Adopter noAgePreference = new Adopter("Bob", LivingSpace.APARTMENT,
                 DailySchedule.AWAY_MOST_OF_DAY, null,
-                new AdopterPreferences(null, null, null, null, 0, Integer.MAX_VALUE));
+                new AdopterPreferences(null, null, null, null, null, null));
         assertFalse(strategy.isApplicable(noAgePreference, dogAtBirthday(LocalDate.now().minusYears(2))));
     }
 

--- a/src/test/java/shelter/strategy/MatchingScoreCalculatorTest.java
+++ b/src/test/java/shelter/strategy/MatchingScoreCalculatorTest.java
@@ -30,7 +30,7 @@ class MatchingScoreCalculatorTest {
     void calculateScore_noApplicableStrategies_returnsOneHundred() {
         Adopter noPreferenceAdopter = new Adopter("Bob", LivingSpace.HOUSE_WITH_YARD,
                 DailySchedule.HOME_MOST_OF_DAY, null,
-                new AdopterPreferences(null, null, null, null, 0, Integer.MAX_VALUE));
+                new AdopterPreferences(null, null, null, null, null, null));
         MatchingScoreCalculator calculator = new MatchingScoreCalculator(
                 List.of(new SpeciesPreferenceStrategy()), null);
 


### PR DESCRIPTION
Fixes two bugs identified by Molly in #20.

## Commit 1 — `AdopterPreferences` minAge/maxAge nullable

`AgePreferenceStrategy` used `0..Integer.MAX_VALUE` as "no age preference" sentinel, but `AdopterCmd.RegisterCmd` defaulted `--max-age` to `20`, silently contaminating match scores for adopters who set no age preference.

- `AdopterPreferences`: `int minAge/maxAge` → `Integer`; null means no preference; constructor validation is null-aware
- `AgePreferenceStrategy.isApplicable()`: null check replaces sentinel; `getDistanceFromPreferredRange()` treats null bound as unbounded
- `AdopterApplicationService` + Impl: `registerAdopter()` signature `int → Integer`
- `AdopterCmd.RegisterCmd`: removed default `20` from `--max-age`
- `CsvAdopterRepository`: empty string ↔ null for both age columns
- Tests: sentinel `(0, Integer.MAX_VALUE)` → `(null, null)` in two strategy tests

## Commit 2 — OTHER animals in `CsvAnimalRepository`

`Other` animals could be admitted but were silently dropped on reload: `parseLine()` called `Species.valueOf()` which threw for non-enum values, and `toRow()` wrote `"OTHER"` in col 1 losing `speciesName`.

- `toRow()`: writes `speciesName` (e.g. `"fish"`) into col 1 for Other rows instead of `"OTHER"`
- `parseLine()`: replaces `Species.valueOf()` + switch with string comparison; anything not DOG/CAT/RABBIT falls through to `new Other(..., speciesRaw)`
- `unescapeCsv` used on col 1 (was `trim()`) to preserve correct round-trip for names containing commas or quotes

## Pending

- [x] Regression tests for both bugs
- [x] Javadoc updates on `CsvAnimalRepository`