### PR TITLE
Final: integration tests, demo tooling, and agent-driven CLI demo polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,17 +76,26 @@ shelter shelter remove --id <id>
 ### Animal (UC-02)
 ```
 shelter animal list [--shelter <id>]
+# list columns: ID / Species / Name / Breed / Age / Activity / Neutered / Indoor / Size / Fur / Status
+# species-specific columns show "N/A" when not applicable to that species
+
 shelter animal admit --species dog    --name <name> --breed <breed> --age <years> --activity <LOW|MEDIUM|HIGH> --shelter <id> [--size <SMALL|MEDIUM|LARGE>] [--neutered]
 shelter animal admit --species cat    --name <name> --breed <breed> --age <years> --activity <LOW|MEDIUM|HIGH> --shelter <id> [--indoor] [--neutered]
 shelter animal admit --species rabbit --name <name> --breed <breed> --age <years> --activity <LOW|MEDIUM|HIGH> --shelter <id> [--fur <SHORT|LONG>]
 shelter animal admit --species other  --name <name> --breed <breed> --age <years> --activity <LOW|MEDIUM|HIGH> --shelter <id> --species-name <e.g. fish>
-shelter animal update --id <id> [--name <name>] [--activity <LOW|MEDIUM|HIGH>]
+# --neutered in admit is a boolean flag (presence = true); in update it takes a value: --neutered true|false
+
+shelter animal update --id <id> [--name <name>] [--activity <LOW|MEDIUM|HIGH>] [--neutered <true|false>]
+# --neutered applies to dogs and cats only; silently ignored for rabbit/other
 shelter animal remove --id <id>
 ```
 
 ### Adopter (UC-03)
 ```
 shelter adopter list
+# list columns: ID / Name / Living Space / Schedule / Species / Breed / Activity / Vaccinated / Min Age / Max Age
+# unset preference fields show "any"
+
 shelter adopter register --name <name> --space <APARTMENT|HOUSE_NO_YARD|HOUSE_WITH_YARD> --schedule <HOME_MOST_OF_DAY|AWAY_PART_OF_DAY|AWAY_MOST_OF_DAY> [--species <DOG|CAT|RABBIT|OTHER>] [--breed <breed>] [--activity <LOW|MEDIUM|HIGH>] [--requires-vaccinated <true|false>] [--min-age <n>] [--max-age <n>]
 shelter adopter update --id <id> [--name <name>] [--space <...>] [--schedule <...>] [--species <...>] [--breed <...>] [--activity <...>] [--requires-vaccinated <true|false>] [--min-age <n>] [--max-age <n>]
 shelter adopter remove --id <id>
@@ -136,6 +145,12 @@ IDs are not known in advance — always run `list` first to retrieve them. Typic
 3. Run the target command with the retrieved IDs
 
 For demo purposes, Claude Code is used as the AI agent: the user speaks natural language, Claude interprets the intent and executes the appropriate `shelter` commands.
+
+### Agent behavior rules (enforced during demo)
+
+**Deletion requires confirmation.** Before executing any `remove` command (`shelter shelter remove`, `shelter animal remove`, `shelter adopter remove`, `shelter vaccine type remove`), ask the user to confirm. Do not proceed until the user explicitly says yes.
+
+**Approval-step commands: submit only, then wait.** When the user asks to submit an adoption request, transfer request, or similar workflow request, only run the `submit` / `request` command. Do NOT automatically follow up with `approve`, `reject`, or `cancel`. Stop after creation and wait for an explicit instruction such as "批准" / "approve" / "拒绝" / "reject" / "取消" / "cancel" before running the next step.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,16 +146,6 @@ IDs are not known in advance — always run `list` first to retrieve them. Typic
 
 For demo purposes, Claude Code is used as the AI agent: the user speaks natural language, Claude interprets the intent and executes the appropriate `shelter` commands.
 
-### Agent behavior rules (enforced during demo)
-
-**Language: English only.** All responses during the demo must be in English, regardless of the language the user speaks. Do not switch to any other language even if the user writes in Chinese or another language.
-
-**Ignore personal memory.** Do not apply, cite, or reference any memory stored about the user (e.g. in `~/.claude/`). Respond only based on the current conversation and this CLAUDE.md file.
-
-**Deletion requires confirmation.** Before executing any `remove` command (`shelter shelter remove`, `shelter animal remove`, `shelter adopter remove`, `shelter vaccine type remove`), ask the user to confirm. Do not proceed until the user explicitly says yes.
-
-**Approval-step commands: submit only, then wait.** When the user asks to submit an adoption request, transfer request, or similar workflow request, only run the `submit` / `request` command. Do NOT automatically follow up with `approve`, `reject`, or `cancel`. Stop after creation and wait for an explicit instruction such as "批准" / "approve" / "拒绝" / "reject" / "取消" / "cancel" before running the next step.
-
 ---
 
 ## Scoring Rubric (100 pts)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,10 @@ For demo purposes, Claude Code is used as the AI agent: the user speaks natural 
 
 ### Agent behavior rules (enforced during demo)
 
+**Language: English only.** All responses during the demo must be in English, regardless of the language the user speaks. Do not switch to any other language even if the user writes in Chinese or another language.
+
+**Ignore personal memory.** Do not apply, cite, or reference any memory stored about the user (e.g. in `~/.claude/`). Respond only based on the current conversation and this CLAUDE.md file.
+
 **Deletion requires confirmation.** Before executing any `remove` command (`shelter shelter remove`, `shelter animal remove`, `shelter adopter remove`, `shelter vaccine type remove`), ask the user to confirm. Do not proceed until the user explicitly says yes.
 
 **Approval-step commands: submit only, then wait.** When the user asks to submit an adoption request, transfer request, or similar workflow request, only run the `submit` / `request` command. Do NOT automatically follow up with `approve`, `reject`, or `cancel`. Stop after creation and wait for an explicit instruction such as "批准" / "approve" / "拒绝" / "reject" / "取消" / "cancel" before running the next step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Domain Layer        ←  core entities (Animal, Shelter, Adopter, AdoptionReques
 ```
 
 **Domain Layer** (`shelter.domain`):
-- `Animal` (abstract base) → `Dog`, `Cat`, `Rabbit`
+- `Animal` (abstract base) → `Dog`, `Cat`, `Rabbit`, `Other` (free-form species name)
   - `adopterId`: `null` = available; non-null = adopted by that adopter
 - `Shelter`: holds a collection of animals, manages capacity
 - `Adopter`: adopter info, preferences, lifestyle context
@@ -124,7 +124,9 @@ For demo purposes, Claude Code is used as the AI agent: the user speaks natural 
   - Group code into logical blocks and add one comment per block (not per line)
   - Explain **why** or **what the block achieves**, not just what the code literally does
   - Example blocks to comment: guard checks, business rule validations, domain delegation, side effects, persistence calls
-- **Testing**: JUnit unit tests covering normal paths and edge cases; use `MockExplanationService` for AI module tests
+- **Testing**: Two levels of tests, both run via `./gradlew test`:
+  - **Unit tests**: JUnit, cover normal paths and edge cases; use `MockExplanationService` for AI module tests
+  - **Integration tests**: tagged `@Tag("integration")`, spawn real `shelter` subprocesses via `ProcessBuilder`; isolated via `SHELTER_HOME` env var pointing to a `@TempDir` — the real `~/shelter` directory is never touched; 78 tests covering all UC-01 through UC-08 including error cases
 - **Build**: Gradle with `application` plugin; main class is `shelter.cli.Main`; CLI dependency is Picocli
 
 ### Domain Class Requirements
@@ -162,6 +164,7 @@ Every domain class must implement the following:
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — team roles, branch strategy, commit conventions
 - [docs/use-cases.md](docs/use-cases.md) — full use case list with application layer method signatures
+- [docs/integration-test-plan.md](docs/integration-test-plan.md) — CLI integration test design and isolation strategy
 - [docs/proposal/proposal-for-pdf.md](docs/proposal/proposal-for-pdf.md) — human-readable proposal
 - [docs/diagram-class.mmd](docs/diagram-class.mmd) — class diagram (Mermaid source)
 - [docs/diagram-layer.mmd](docs/diagram-layer.mmd) — layer architecture diagram

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,18 +65,75 @@ Domain Layer        ←  core entities (Animal, Shelter, Adopter, AdoptionReques
 
 The system is operated as a stateless CLI. Data is persisted to `~/shelter/data/` as CSV files. Each command loads data, performs the operation, and saves back.
 
+### Shelter (UC-01)
 ```
 shelter shelter list
-shelter shelter register --name "Happy Paws" --location "Boston" --capacity 20
-shelter animal list [--shelter <id>]
-shelter animal admit --species dog --name "Max" --breed "Labrador" --age 3 --activity MEDIUM --shelter <id>
-shelter adopt submit --adopter <id> --animal <id>
-shelter adopt approve --request <id>
-shelter match animal --adopter <id> --shelter <id> [--explain]
-shelter match adopter --animal <id> [--explain]
-shelter vaccine record --animal <id> --type <name> --date <yyyy-mm-dd>
-shelter vaccine overdue --animal <id>
+shelter shelter register --name <name> --location <location> --capacity <n>
+shelter shelter update --id <id> [--name <name>] [--location <location>] [--capacity <n>]
+shelter shelter remove --id <id>
 ```
+
+### Animal (UC-02)
+```
+shelter animal list [--shelter <id>]
+shelter animal admit --species dog    --name <name> --breed <breed> --age <years> --activity <LOW|MEDIUM|HIGH> --shelter <id> [--size <SMALL|MEDIUM|LARGE>] [--neutered]
+shelter animal admit --species cat    --name <name> --breed <breed> --age <years> --activity <LOW|MEDIUM|HIGH> --shelter <id> [--indoor] [--neutered]
+shelter animal admit --species rabbit --name <name> --breed <breed> --age <years> --activity <LOW|MEDIUM|HIGH> --shelter <id> [--fur <SHORT|LONG>]
+shelter animal admit --species other  --name <name> --breed <breed> --age <years> --activity <LOW|MEDIUM|HIGH> --shelter <id> --species-name <e.g. fish>
+shelter animal update --id <id> [--name <name>] [--activity <LOW|MEDIUM|HIGH>]
+shelter animal remove --id <id>
+```
+
+### Adopter (UC-03)
+```
+shelter adopter list
+shelter adopter register --name <name> --space <APARTMENT|HOUSE_NO_YARD|HOUSE_WITH_YARD> --schedule <HOME_MOST_OF_DAY|AWAY_PART_OF_DAY|AWAY_MOST_OF_DAY> [--species <DOG|CAT|RABBIT|OTHER>] [--breed <breed>] [--activity <LOW|MEDIUM|HIGH>] [--requires-vaccinated <true|false>] [--min-age <n>] [--max-age <n>]
+shelter adopter update --id <id> [--name <name>] [--space <...>] [--schedule <...>] [--species <...>] [--breed <...>] [--activity <...>] [--requires-vaccinated <true|false>] [--min-age <n>] [--max-age <n>]
+shelter adopter remove --id <id>
+```
+
+### Matching (UC-04)
+```
+shelter match animal  --adopter <id> --shelter <id>
+shelter match adopter --animal <id>
+```
+
+### Adoption (UC-05)
+```
+shelter adopt submit  --adopter <id> --animal <id>
+shelter adopt approve --request <id>
+shelter adopt reject  --request <id>
+shelter adopt cancel  --request <id>
+```
+
+### Transfer (UC-06)
+```
+shelter transfer request --animal <id> --from <shelter-id> --to <shelter-id>
+shelter transfer approve --request <id>
+shelter transfer reject  --request <id>
+shelter transfer cancel  --request <id>
+```
+
+### Vaccination (UC-07)
+```
+shelter vaccine record  --animal <id> --type <vaccine-type-name> --date <yyyy-mm-dd>
+shelter vaccine overdue --animal <id>
+shelter vaccine type list
+shelter vaccine type add    --name <name> --species <DOG|CAT|RABBIT|OTHER> --days <n>
+shelter vaccine type update --id <id> [--name <name>] [--species <...>] [--days <n>]
+shelter vaccine type remove --id <id>
+```
+
+### Audit (UC-08)
+```
+shelter audit log
+```
+
+### Demo workflow note
+IDs are not known in advance — always run `list` first to retrieve them. Typical sequence:
+1. `shelter shelter list` → get shelter ID
+2. `shelter animal list` / `shelter adopter list` → get animal/adopter IDs
+3. Run the target command with the retrieved IDs
 
 For demo purposes, Claude Code is used as the AI agent: the user speaks natural language, Claude interprets the intent and executes the appropriate `shelter` commands.
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,4 +35,5 @@ jar {
 
 test {
     useJUnitPlatform()
+    dependsOn installDist
 }

--- a/docs/demo-plan.md
+++ b/docs/demo-plan.md
@@ -1,0 +1,215 @@
+# Demo 计划
+
+**日期**：2026-04-21 1:00–4:00 PM（课堂 demo + Q&A）
+**操作员**：Claude Code（AI agent）解读自然语言 → 执行 `shelter` CLI
+**建议时长**：正式 demo 约 15–20 分钟，预留 Q&A 时间
+
+---
+
+## 叙事背景
+
+> 波士顿地区爆发了一场宠物救助热潮。
+> **Boston Paws**（容量 15）和 **Cambridge Care**（容量 10）两家庇护所需要协作管理：
+> 动物入住、领养人匹配、跨庇护所转移、疫苗合规——所有操作都通过一套统一的 CLI 工具完成。
+> 今天，工作人员打开终端，Claude Code 作为 AI 助手，解读口令、执行命令。
+
+---
+
+## 准备工作（演示前完成）
+
+```bash
+./gradlew installDist          # 构建二进制
+rm -rf ~/shelter/data          # 清空数据，干净环境
+export PATH="$PWD/build/install/shelter/bin:$PATH"
+shelter --version              # 验证 CLI 可用
+```
+
+---
+
+## 场景一：庇护所上线（UC-01）⏱ 约 2 分钟
+
+**口令** → **动作** → **亮点**
+
+| # | 对 Claude 说 | Claude 执行的命令 | 演示亮点 |
+|---|---|---|---|
+| 1 | 注册两个庇护所：Boston Paws 在 Boston 容量 15，Cambridge Care 在 Cambridge 容量 10 | `shelter shelter register ...` × 2 | 数据持久化写入 CSV |
+| 2 | 列出所有庇护所 | `shelter shelter list` | 表格显示 ID/名称/地点/容量 |
+| 3 | 把 Boston Paws 的容量扩大到 20 | `shelter shelter update --id <id> --capacity 20` | 部分字段更新，未提供的字段保持不变 |
+
+> **OOD 亮点**：
+> - `ShelterApplicationService` 与 `ShelterService` 分层；
+> - `AuditService.log("registered shelter", shelter)` 每次操作自动记录。
+
+---
+
+## 场景二：收容动物（UC-02）⏱ 约 3 分钟
+
+| # | 对 Claude 说 | 演示亮点 |
+|---|---|---|
+| 1 | 往 Boston Paws 收容一只 3 岁拉布拉多犬 Buddy，活跃度 HIGH | `Dog` 多态子类，size/neutered 可选参数 |
+| 2 | 再收容一只 2 岁暹罗猫 Luna，活跃度 LOW，室内猫 | `Cat` 子类，indoor 属性 |
+| 3 | 往 Cambridge Care 收容一只 1 岁荷兰垂耳兔 Fluffy，活跃度 MEDIUM | 跨庇护所收容 |
+| 4 | 往 Boston Paws 收容一条热带鱼 Nemo，品种 Clownfish，物种名 fish | `Other` 自由物种名，体现开放扩展 |
+| 5 | 列出 Boston Paws 的动物 | 只显示该庇护所的动物，Fluffy 不出现 |
+
+> **OOD 亮点**：
+> - `Animal`（抽象）→ `Dog` / `Cat` / `Rabbit` / `Other`：继承 + 多态；
+> - `Other` 无需修改枚举即可支持新物种，体现**开闭原则**；
+> - 策略层分离：动物对象不包含任何评分逻辑。
+
+---
+
+## 场景三：登记领养人（UC-03）⏱ 约 2 分钟
+
+| # | 对 Claude 说 | 演示亮点 |
+|---|---|---|
+| 1 | 注册 Alice：HOUSE_WITH_YARD，HOME_MOST_OF_DAY，偏好 DOG，年龄 1–5 岁 | `AdopterPreferences` 值对象封装偏好 |
+| 2 | 注册 Bob：APARTMENT，AWAY_PART_OF_DAY，无特定偏好 | 可选偏好字段 |
+| 3 | 把 Bob 的日程改为 HOME_MOST_OF_DAY | 部分字段更新 |
+
+---
+
+## 场景四：智能匹配（UC-04）⏱ 约 3 分钟  ★ 核心亮点
+
+| # | 对 Claude 说 | 演示亮点 |
+|---|---|---|
+| 1 | 为 Alice 在 Boston Paws 里做动物匹配 | 显示 Rank/Animal/Score 表格 |
+| 2 | 解读结果：为什么 Buddy 排名第一？ | 讲解各 Strategy 的得分贡献 |
+| 3 | 为 Buddy 匹配合适的领养人 | 反向匹配，Alice 应排名靠前 |
+
+**展示各 Strategy 的贡献**（讲解时提及，无需执行命令）：
+
+| 策略 | 作用 |
+|---|---|
+| `SpeciesPreferenceStrategy` | Alice 偏好 DOG → Buddy 得满分 |
+| `AgePreferenceStrategy` | Alice 要求 1–5 岁，Buddy 3 岁 → 满分 |
+| `ActivityLevelStrategy` | Buddy HIGH，Alice HOME_MOST_OF_DAY → 匹配 |
+| `LifestyleCompatibilityStrategy` | HOUSE_WITH_YARD 适合大型犬 |
+| `VaccinationPreferenceStrategy` | 若领养人要求已接种，未接种动物降分 |
+
+> **OOD 亮点**：
+> - **策略模式**：`IMatchingStrategy` 接口 → 6 个独立实现，可随时增减；
+> - **开闭原则**：新增评分维度只需实现接口，无需改动 Service；
+> - **依赖倒置**：`MatchingApplicationService` 依赖接口列表，不依赖具体策略。
+
+---
+
+## 场景五：领养流程（UC-05）⏱ 约 2 分钟
+
+| # | 对 Claude 说 | 演示亮点 |
+|---|---|---|
+| 1 | Alice 想领养 Buddy，提交申请 | `AdoptionRequest` 状态机 PENDING |
+| 2 | 批准这个申请 | 状态变 APPROVED，Buddy 标记为 adopted |
+| 3 | 列出 Boston Paws 动物，看 Buddy 状态 | 表格显示 `adopted` vs `available` |
+| 4 | 再试一次为 Bob 提交 Buddy 的领养申请 | 报错演示：动物已被领养 |
+
+> **OOD 亮点**：
+> - 状态机：PENDING → APPROVED / REJECTED / CANCELLED，状态只能单向流转；
+> - `AdoptionService` 与 `RequestNotificationService` 解耦，通知逻辑可独立替换。
+
+---
+
+## 场景六：跨庇护所转移（UC-06）⏱ 约 2 分钟
+
+| # | 对 Claude 说 | 演示亮点 |
+|---|---|---|
+| 1 | 把 Luna 从 Boston Paws 转移到 Cambridge Care | `TransferRequest` 创建，PENDING 状态 |
+| 2 | 批准转移 | Luna 的 shelterId 变更，两庇护所占用更新 |
+| 3 | 列出 Cambridge Care 的动物 | Luna 和 Fluffy 都出现 |
+
+> **OOD 亮点**：与领养流程同构的状态机设计，体现 **DRY**（请求生命周期复用）。
+
+---
+
+## 场景七：疫苗合规（UC-07）⏱ 约 2 分钟
+
+| # | 对 Claude 说 | 演示亮点 |
+|---|---|---|
+| 1 | 添加疫苗类型：Rabies（适用 DOG，365 天）；Feline FVRCP（适用 CAT，365 天） | `VaccineType` 独立目录，与动物解耦 |
+| 2 | 给 Buddy 接种 Rabies，日期今天 | `VaccinationRecord` 记录 |
+| 3 | 检查 Buddy 有没有过期疫苗 | 显示"All vaccinations are current" |
+| 4 | 尝试给 Luna 接种 Rabies（狗专用） | 报错：物种不匹配，物种校验在 Service 层 |
+
+> **OOD 亮点**：
+> - `VaccinationPreferenceStrategy` 让疫苗状态影响匹配分数，体现层间协作；
+> - 物种校验在 Service 层，体现**单一职责**。
+
+---
+
+## 场景八：完整审计（UC-08）⏱ 约 1 分钟
+
+| # | 对 Claude 说 | 演示亮点 |
+|---|---|---|
+| 1 | 查看审计日志 | 显示 Timestamp/Staff/Action/Target 全量记录 |
+
+> **OOD 亮点**：
+> - `AuditService<T>` 泛型接口，每个应用服务注入专属实例；
+> - 所有修改操作（admit/update/approve/...）均自动记录，无需调用方手动触发。
+
+---
+
+## 补充：错误处理演示（可选，30 秒）
+
+如果时间允许，快速演示 1–2 个错误场景：
+
+- 删除 Cambridge Care（还有 Luna）→ 报错"shelter still holds animals"
+- 查询不存在的 ID → 报错"not found"
+
+> **OOD 亮点**：早期报错原则；异常只用于真正异常情况，不用于流程控制。
+
+---
+
+## OOD 设计原则速查（Q&A 准备）
+
+| 原则 | 在哪里体现 |
+|---|---|
+| 继承 + 多态 | `Animal` → `Dog/Cat/Rabbit/Other` |
+| 开闭原则 | 策略模式（新增 Strategy 不改 Service）；`Other` 不改枚举即扩展物种 |
+| 单一职责 | Application / Service / Strategy / Domain 各层独立 |
+| 依赖倒置 | 接口注入：`IMatchingStrategy`, `AuditService<T>`, `ExplanationService` |
+| DRY | `AdoptionRequest` 和 `TransferRequest` 共享状态机生命周期设计 |
+| 接口稳定性 | 公开接口不变；实现可替换（`MockExplanationService` vs `AIExplanationService`） |
+| 防御性拷贝 | `AdopterPreferences` 值对象，Copy constructor |
+| 审计横切 | `AuditService<T>` 泛型接口，统一注入所有 Application Service |
+| 状态机 | 请求状态 PENDING→APPROVED/REJECTED/CANCELLED 单向流转 |
+| 策略评分隔离 | 评分逻辑不在 Domain，不在 Application，独立在 Strategy 层 |
+
+---
+
+## 幻灯片提纲（参考）
+
+1. **标题页**：系统名、团队成员、CS 5004
+2. **问题背景**：多庇护所协作痛点
+3. **架构图**：五层架构（使用 `docs/diagram-layer.mmd`）
+4. **类图亮点**：Animal 继承体系（使用 `docs/diagram-class.mmd`）
+5. **LIVE DEMO**（按本文档顺序）
+6. **测试覆盖**：78 个集成测试 + 单元测试，展示 `./gradlew test` 全绿
+7. **OOD 原则总结**（上表）
+8. **Q&A**
+
+---
+
+## 时间分配总览
+
+| 环节 | 建议时长 |
+|---|---|
+| 开场 + 架构介绍（幻灯片） | 3 分钟 |
+| 场景一：庇护所上线 | 2 分钟 |
+| 场景二：收容动物 | 3 分钟 |
+| 场景三：登记领养人 | 2 分钟 |
+| 场景四：智能匹配 ★ | 3 分钟 |
+| 场景五：领养流程 | 2 分钟 |
+| 场景六：跨庇护所转移 | 2 分钟 |
+| 场景七：疫苗合规 | 2 分钟 |
+| 场景八：审计日志 + 错误处理 | 1 分钟 |
+| 测试展示（`./gradlew test`） | 1 分钟 |
+| **总计** | **≈ 21 分钟** |
+
+---
+
+## 注意事项
+
+- **演示前**执行完整的 `docs/test-live.md` 流程，确保所有命令输出符合预期
+- **备用策略**：若 AI agent 解析出错，可直接切换手动输入 CLI 命令（CLAUDE.md 有完整参考）
+- **ID 获取**：每个阶段先执行 `list` 命令获取 ID，再执行目标命令
+- **网络**：`MockExplanationService` 已默认使用，无需外部 API 调用，演示无需联网

--- a/docs/demo-plan.md
+++ b/docs/demo-plan.md
@@ -63,9 +63,9 @@ shelter --version              # 验证 CLI 可用
 
 | # | 对 Claude 说 | 演示亮点 |
 |---|---|---|
-| 1 | 注册 Alice：HOUSE_WITH_YARD，HOME_MOST_OF_DAY，偏好 DOG，年龄 1–5 岁 | `AdopterPreferences` 值对象封装偏好 |
-| 2 | 注册 Bob：APARTMENT，AWAY_PART_OF_DAY，无特定偏好 | 可选偏好字段 |
-| 3 | 把 Bob 的日程改为 HOME_MOST_OF_DAY | 部分字段更新 |
+| 1 | 注册 Alice：HOUSE_WITH_YARD，HOME_MOST_OF_DAY，偏好 DOG / Labrador / HIGH，要求已接种，年龄 1–5 岁 | `AdopterPreferences` 封装全部偏好字段 |
+| 2 | 注册 Bob：APARTMENT，AWAY_PART_OF_DAY，偏好 CAT / LOW，不要求接种，年龄不限 | 对比展示稀疏偏好 |
+| 3 | 把 Bob 的日程改为 HOME_MOST_OF_DAY，活跃度偏好改为 MEDIUM | 部分字段更新，其余保持不变 |
 
 ---
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -13,69 +13,79 @@ rm -rf ~/shelter/data
 ---
 
 **1 — Register a shelter**
-> Register a shelter called "Boston Paws" in Boston with a capacity of 20.
-
+```
+Register a shelter called "Boston Paws" in Boston with a capacity of 20.
+```
 ✅ One confirmation line with the shelter name and a generated ID.
 
 ---
 
 **2 — Admit a dog**
-> Admit a 3-year-old Labrador named Buddy into Boston Paws, activity level HIGH, size LARGE.
-
+```
+Admit a 3-year-old Labrador named Buddy into Boston Paws, activity level HIGH, size LARGE.
+```
 ✅ One confirmation line showing Buddy's ID and the shelter ID.
 
 ---
 
 **3 — Admit a cat**
-> Admit a 2-year-old Siamese cat named Luna into Boston Paws, activity LOW, she is indoor and neutered.
-
+```
+Admit a 2-year-old Siamese cat named Luna into Boston Paws, activity LOW, she is indoor and neutered.
+```
 ✅ One confirmation line showing Luna's ID and the shelter ID.
 
 ---
 
 **4 — Register an adopter**
-> Register an adopter named Alice — she lives in a house with yard, is home most of the day, prefers dogs, specifically Labradors, high activity level, requires vaccinated animals, age range 1 to 5.
-
+```
+Register an adopter named Alice — she lives in a house with yard, is home most of the day, prefers dogs, specifically Labradors, high activity level, requires vaccinated animals, age range 1 to 5.
+```
 ✅ One confirmation line with Alice's name and generated ID.
 
 ---
 
 **5 — Smart matching**
-> Match animals in Boston Paws for Alice.
-
+```
+Match animals in Boston Paws for Alice.
+```
 ✅ A ranked table — Buddy should score the highest because species, breed, age, and activity all match Alice's preferences.
 
 ---
 
 **6 — Submit adoption request**
-> Alice wants to adopt Buddy, submit the request.
-
+```
+Alice wants to adopt Buddy, submit the request.
+```
 ✅ One confirmation line showing the request ID, Alice's ID, and Buddy's ID.
 
 ---
 
 **7 — Approve adoption**
-> Approve that adoption request.
-
+```
+Approve that adoption request.
+```
 ✅ One confirmation line showing the request is approved. Buddy's status is now adopted.
 
 ---
 
 **8 — Vaccination**
-> Add a vaccine type called Rabies for dogs, valid for 365 days. Then record that Buddy received it today.
-
+```
+Add a vaccine type called Rabies for dogs, valid for 365 days. Then record that Buddy received it today.
+```
 ✅ Two confirmation lines — one for the new vaccine type, one for the vaccination record.
 
 ---
 
 **9 — Second shelter and transfer**
-> Register a second shelter called "Cambridge Care" in Cambridge with capacity 10. Then transfer Luna from Boston Paws to Cambridge Care.
-
+```
+Register a second shelter called "Cambridge Care" in Cambridge with capacity 10. Then transfer Luna from Boston Paws to Cambridge Care.
+```
 ✅ Two confirmation lines — one for the new shelter, one for the pending transfer request.
 
 ---
 
 **10 — Audit log**
-> Show the audit log.
-
+```
+Show the audit log.
+```
 ✅ A table listing every action taken this session, each row showing timestamp, staff name, action type, and target.

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,0 +1,81 @@
+# Demo Script (Happy Path)
+
+Quick demo covering all major features in ~10 commands.
+IDs returned at each step are used in later commands — note them as you go.
+
+**Setup** (run before demo):
+```bash
+./gradlew installDist
+export PATH="$PWD/build/install/shelter/bin:$PATH"
+rm -rf ~/shelter/data
+```
+
+---
+
+**1 — Register a shelter**
+> Register a shelter called "Boston Paws" in Boston with a capacity of 20.
+
+✅ One confirmation line with the shelter name and a generated ID.
+
+---
+
+**2 — Admit a dog**
+> Admit a 3-year-old Labrador named Buddy into Boston Paws, activity level HIGH, size LARGE.
+
+✅ One confirmation line showing Buddy's ID and the shelter ID.
+
+---
+
+**3 — Admit a cat**
+> Admit a 2-year-old Siamese cat named Luna into Boston Paws, activity LOW, she is indoor and neutered.
+
+✅ One confirmation line showing Luna's ID and the shelter ID.
+
+---
+
+**4 — Register an adopter**
+> Register an adopter named Alice — she lives in a house with yard, is home most of the day, prefers dogs, specifically Labradors, high activity level, requires vaccinated animals, age range 1 to 5.
+
+✅ One confirmation line with Alice's name and generated ID.
+
+---
+
+**5 — Smart matching**
+> Match animals in Boston Paws for Alice.
+
+✅ A ranked table — Buddy should score the highest because species, breed, age, and activity all match Alice's preferences.
+
+---
+
+**6 — Submit adoption request**
+> Alice wants to adopt Buddy, submit the request.
+
+✅ One confirmation line showing the request ID, Alice's ID, and Buddy's ID.
+
+---
+
+**7 — Approve adoption**
+> Approve that adoption request.
+
+✅ One confirmation line showing the request is approved. Buddy's status is now adopted.
+
+---
+
+**8 — Vaccination**
+> Add a vaccine type called Rabies for dogs, valid for 365 days. Then record that Buddy received it today.
+
+✅ Two confirmation lines — one for the new vaccine type, one for the vaccination record.
+
+---
+
+**9 — Second shelter and transfer**
+> Register a second shelter called "Cambridge Care" in Cambridge with capacity 10. Then transfer Luna from Boston Paws to Cambridge Care.
+
+✅ Two confirmation lines — one for the new shelter, one for the pending transfer request.
+
+---
+
+**10 — Audit log**
+> Show the audit log.
+
+✅ A table listing every action taken this session, each row showing timestamp, staff name, action type, and target.

--- a/docs/integration-test-plan.md
+++ b/docs/integration-test-plan.md
@@ -1,0 +1,169 @@
+# Integration Test Design — CLI End-to-End
+
+**Date:** 2026-04-12  
+**Branch:** `test/integration-cli`  
+**Deadline context:** Project demo 2026-04-21
+
+---
+
+## Goal
+
+Verify the full CLI stack end-to-end: Picocli parsing → Application layer → Service layer → CSV persistence → stdout output. Each test runs a real `shelter` subprocess and asserts on exit code, stdout, and (where applicable) CSV file content.
+
+---
+
+## Production Code Change (minimal)
+
+`Main.java` reads a `SHELTER_HOME` environment variable. If set, it overrides the default `~/shelter` path. Existing behavior is unchanged when the variable is absent.
+
+```java
+String shelterHomeEnv = System.getenv("SHELTER_HOME");
+Path shelterHome = shelterHomeEnv != null
+        ? Path.of(shelterHomeEnv)
+        : Path.of(System.getProperty("user.home"), "shelter");
+new SystemStartupImpl(shelterHome).initialize();
+```
+
+---
+
+## Test Infrastructure
+
+### Package
+`src/test/java/shelter/integration/`
+
+### Abstract Base Class: `CliIntegrationTest`
+
+Responsibilities:
+- Provides `@TempDir Path shelterHome` — each test method gets a fresh, isolated directory
+- `run(String... args)` — builds and executes a `shelter` subprocess with `SHELTER_HOME` set to the TempDir; returns a `RunResult` record containing `exitCode`, `stdout`, `stderr`
+- Helper assertions: `assertExitCode(int)`, `assertOutputContains(String)`, `assertOutputDoesNotContain(String)`, `assertStdErrContains(String)`
+
+### `RunResult` record
+```
+record RunResult(int exitCode, String stdout, String stderr)
+```
+
+### Subprocess mechanics
+- `ProcessBuilder` with `environment().put("SHELTER_HOME", shelterHome.toString())`
+- `inheritIO()` disabled; stdout and stderr captured separately
+- Timeout: 10 seconds per invocation (guard against hangs)
+- Binary located via `ProcessBuilder("shelter", ...)` — assumes the `shelter` script is on PATH (Gradle `installDist` task produces it)
+
+---
+
+## Test Scenarios (~30 cases)
+
+### ShelterIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `register_validArgs_printsId` | exit 0, stdout contains shelter name |
+| `list_noShelters_printsEmpty` | exit 0, stdout indicates no shelters |
+| `list_afterRegister_showsShelter` | exit 0, shelter name in output |
+| `register_missingName_printsError` | exit ≠ 0 or stderr non-empty |
+
+### AnimalIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `admit_dog_printsAnimalId` | exit 0, stdout contains animal ID |
+| `admit_cat_printsAnimalId` | exit 0 |
+| `admit_rabbit_printsAnimalId` | exit 0 |
+| `admit_other_printsAnimalId` | exit 0, speciesName preserved on `animal list` |
+| `list_byShelter_filtersCorrectly` | only animals in given shelter shown |
+| `admit_exceedsCapacity_printsError` | error message in output |
+| `admit_missingShelter_printsError` | error message in output |
+
+### AdopterIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `register_withAllPrefs_printsId` | exit 0 |
+| `register_withoutAgePrefs_noDefault` | `animal list` and match not polluted by age 20 |
+| `list_afterRegister_showsAdopter` | adopter name in output |
+
+### AdoptionIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `submit_validPair_printsRequestId` | exit 0 |
+| `approve_validRequest_printsConfirmation` | exit 0; subsequent `animal list` shows adopter |
+| `reject_validRequest_printsConfirmation` | exit 0 |
+| `cancel_validRequest_printsConfirmation` | exit 0 |
+| `approve_nonExistentRequest_printsError` | error in output |
+| `approve_alreadyAdopted_printsError` | error in output |
+
+### TransferIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `request_validTransfer_printsRequestId` | exit 0 |
+| `approve_validTransfer_animalMovedShelter` | `animal list --shelter <new>` shows animal |
+| `reject_validTransfer_printsConfirmation` | exit 0 |
+
+### MatchIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `matchAnimal_returnsRankedList` | exit 0, at least one result row |
+| `matchAnimal_noAnimalsInShelter_printsEmpty` | exit 0, empty result message |
+| `matchAdopter_returnsRankedList` | exit 0, at least one result row |
+| `matchAnimal_adopterNoAgePrefs_allAnimalsEligible` | score not zero-penalised by age sentinel |
+
+### VaccineIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `record_validVaccination_printsConfirmation` | exit 0 |
+| `overdue_noVaccinations_printsOverdue` | exit 0, animal listed as overdue |
+| `overdue_recentVaccination_notOverdue` | animal not listed as overdue |
+| `vaccineType_addAndList_showsType` | exit 0, type name in output |
+
+### AuditIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `log_afterAdmitAndAdopt_containsBothEntries` | audit output has ≥2 entries |
+
+### CrossSessionIntegrationTest
+| Test | Asserts |
+|------|---------|
+| `dataPersistedAcrossProcesses` | register shelter in process 1; new process 2 lists it |
+| `otherAnimal_persistedAcrossProcesses` | admit Other in process 1; list in process 2 shows speciesName |
+
+---
+
+## What Is NOT Tested Here
+
+- AI explanation output (non-deterministic; tested with MockExplanationService in unit tests)
+- Exact score values from matching (covered in strategy unit tests)
+- All CLI flag combinations (covered in unit tests)
+
+---
+
+## Running the Tests
+
+```bash
+# Build the CLI binary first
+./gradlew installDist
+
+# Run all tests including integration
+./gradlew test
+```
+
+Integration tests are annotated `@Tag("integration")` so they can be run or excluded independently:
+
+```bash
+./gradlew test -Dgroups=integration      # only integration
+./gradlew test -DexcludedGroups=integration  # skip integration
+```
+
+---
+
+## File Layout
+
+```
+src/test/java/shelter/integration/
+├── CliIntegrationTest.java          ← abstract base, RunResult, helpers
+├── ShelterIntegrationTest.java
+├── AnimalIntegrationTest.java
+├── AdopterIntegrationTest.java
+├── AdoptionIntegrationTest.java
+├── TransferIntegrationTest.java
+├── MatchIntegrationTest.java
+├── VaccineIntegrationTest.java
+├── AuditIntegrationTest.java
+└── CrossSessionIntegrationTest.java
+```

--- a/docs/integration-test-tasks.md
+++ b/docs/integration-test-tasks.md
@@ -1,0 +1,1151 @@
+# Integration Test — CLI End-to-End Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement ~30 end-to-end integration tests that run the real `shelter` binary against a TempDir and assert on stdout, stderr, and exit code.
+
+**Architecture:** JUnit 5 + ProcessBuilder. An abstract base class `CliIntegrationTest` provides a `run()` helper that spawns a subprocess with `SHELTER_HOME` set to `@TempDir`. Each test file covers one CLI command group. `Main.java` is patched to read `SHELTER_HOME` so tests are fully isolated from `~/shelter/data/`.
+
+**Tech Stack:** Java 17, JUnit Jupiter 5.10, Picocli 4.x, Gradle `installDist`
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Modify | `src/main/java/shelter/cli/Main.java` |
+| Modify | `build.gradle` |
+| Create | `src/test/java/shelter/integration/CliIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/ShelterIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/AnimalIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/AdopterIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/AdoptionIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/TransferIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/MatchIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/VaccineIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/AuditIntegrationTest.java` |
+| Create | `src/test/java/shelter/integration/CrossSessionIntegrationTest.java` |
+
+---
+
+## Task 1: Patch Main.java + build.gradle
+
+**Files:**
+- Modify: `src/main/java/shelter/cli/Main.java`
+- Modify: `build.gradle`
+
+- [ ] **Step 1.1: Replace hardcoded path in Main.java**
+
+Replace the `main()` method body with:
+
+```java
+public static void main(String[] args) {
+    String shelterHomeEnv = System.getenv("SHELTER_HOME");
+    Path shelterHome = shelterHomeEnv != null
+            ? Path.of(shelterHomeEnv)
+            : Path.of(System.getProperty("user.home"), "shelter");
+    new SystemStartupImpl(shelterHome).initialize();
+    int exitCode = new CommandLine(new Main()).execute(args);
+    System.exit(exitCode);
+}
+```
+
+Add import at the top if not already present: `import java.nio.file.Path;`
+
+- [ ] **Step 1.2: Make test task depend on installDist in build.gradle**
+
+Replace the existing `test { useJUnitPlatform() }` block with:
+
+```groovy
+test {
+    useJUnitPlatform()
+    dependsOn installDist
+}
+```
+
+- [ ] **Step 1.3: Verify build works**
+
+```bash
+./gradlew installDist
+```
+
+Expected: `BUILD SUCCESSFUL`. Binary appears at `build/install/shelter/bin/shelter`.
+
+- [ ] **Step 1.4: Smoke-test the binary with SHELTER_HOME**
+
+```bash
+SHELTER_HOME=/tmp/smoke-test build/install/shelter/bin/shelter shelter list
+```
+
+Expected: `No shelters registered.` (not an error, no crash).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/main/java/shelter/cli/Main.java build.gradle
+git commit -m "feat(cli): support SHELTER_HOME env var for test isolation"
+```
+
+---
+
+## Task 2: Abstract Base Class
+
+**Files:**
+- Create: `src/test/java/shelter/integration/CliIntegrationTest.java`
+
+- [ ] **Step 2.1: Create the abstract base class**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Abstract base class for CLI integration tests.
+ * Spawns real {@code shelter} subprocesses with SHELTER_HOME pointed at a JUnit TempDir
+ * so each test method runs against a completely isolated, ephemeral data directory.
+ * The binary is expected at {@code build/install/shelter/bin/shelter} (produced by installDist).
+ */
+@Tag("integration")
+abstract class CliIntegrationTest {
+
+    private static final Path BINARY = Path.of(System.getProperty("user.dir"))
+            .resolve("build/install/shelter/bin/shelter");
+
+    /** Fresh isolated data directory injected by JUnit for every test method. */
+    @TempDir
+    Path shelterHome;
+
+    /**
+     * Launches the shelter binary with the given arguments and captures output.
+     * SHELTER_HOME is set to the per-test TempDir; no real user data is touched.
+     *
+     * @param args subcommand tokens, e.g. "shelter", "register", "--name", "Paws"
+     * @return result containing exit code, stdout, and stderr
+     */
+    RunResult run(String... args) throws IOException, InterruptedException {
+        String[] command = new String[args.length + 1];
+        command[0] = BINARY.toString();
+        System.arraycopy(args, 0, command, 1, args.length);
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.environment().put("SHELTER_HOME", shelterHome.toString());
+
+        Process process = pb.start();
+        String stdout = new String(process.getInputStream().readAllBytes());
+        String stderr  = new String(process.getErrorStream().readAllBytes());
+        boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+        assertTrue(finished, "shelter process timed out after 10 s");
+
+        return new RunResult(process.exitValue(), stdout, stderr);
+    }
+
+    /**
+     * Extracts a UUID that follows {@code id=} in command output.
+     * Matches patterns like {@code "Registered shelter: Paws (id=abc-123)"}.
+     *
+     * @param output stdout string from a run() call
+     * @return the extracted UUID string
+     */
+    String extractId(String output) {
+        Matcher m = Pattern.compile("id=([a-f0-9\\-]{36})").matcher(output);
+        assertTrue(m.find(), "Expected id=<uuid> in output: " + output);
+        return m.group(1);
+    }
+
+    /** Asserts exit code is 0. */
+    void assertSuccess(RunResult r) {
+        assertEquals(0, r.exitCode(),
+                "Expected exit 0. stderr: " + r.stderr() + " stdout: " + r.stdout());
+    }
+
+    /** Asserts stdout or stderr contains the fragment. */
+    void assertOutputContains(RunResult r, String fragment) {
+        assertTrue((r.stdout() + r.stderr()).contains(fragment),
+                "Expected output to contain \"" + fragment + "\"\nstdout: " + r.stdout() + "\nstderr: " + r.stderr());
+    }
+
+    /** Asserts stdout and stderr do NOT contain the fragment. */
+    void assertOutputDoesNotContain(RunResult r, String fragment) {
+        assertFalse((r.stdout() + r.stderr()).contains(fragment),
+                "Expected output NOT to contain \"" + fragment + "\"\nstdout: " + r.stdout());
+    }
+
+    /** Immutable result of one CLI invocation. */
+    record RunResult(int exitCode, String stdout, String stderr) {}
+}
+```
+
+- [ ] **Step 2.2: Compile check**
+
+```bash
+./gradlew compileTestJava
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/CliIntegrationTest.java
+git commit -m "test(integration): add CliIntegrationTest base class with ProcessBuilder helper"
+```
+
+---
+
+## Task 3: ShelterIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/ShelterIntegrationTest.java`
+
+CLI output reference:
+- `register` → `"Registered shelter: Happy Paws (id=<uuid>)"`
+- `list` (empty) → `"No shelters registered."`
+- `list` (has data) → table rows with shelter name and location
+
+- [ ] **Step 3.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter shelter} command group.
+ * Each test runs against a fresh TempDir; no shared state between methods.
+ */
+class ShelterIntegrationTest extends CliIntegrationTest {
+
+    @Test
+    void register_validArgs_printsNameAndId() throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", "Happy Paws", "--location", "Boston", "--capacity", "20");
+        assertSuccess(r);
+        assertOutputContains(r, "Happy Paws");
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void list_noShelters_printsEmptyMessage() throws Exception {
+        RunResult r = run("shelter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "No shelters registered.");
+    }
+
+    @Test
+    void list_afterRegister_showsRegisteredShelter() throws Exception {
+        run("shelter", "register",
+                "--name", "Happy Paws", "--location", "Boston", "--capacity", "20");
+
+        RunResult r = run("shelter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Happy Paws");
+        assertOutputContains(r, "Boston");
+    }
+
+    @Test
+    void register_missingRequiredOption_exitNonZero() throws Exception {
+        // --location and --capacity are missing; Picocli should reject this
+        RunResult r = run("shelter", "register", "--name", "Incomplete");
+        assertNotEquals(0, r.exitCode());
+    }
+}
+```
+
+- [ ] **Step 3.2: Run and verify all pass**
+
+```bash
+./gradlew test --tests "shelter.integration.ShelterIntegrationTest"
+```
+
+Expected: 4 tests, all PASS.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/ShelterIntegrationTest.java
+git commit -m "test(integration): ShelterIntegrationTest — register and list"
+```
+
+---
+
+## Task 4: AnimalIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/AnimalIntegrationTest.java`
+
+CLI output reference:
+- `admit` → `"Admitted DOG: Rex (id=<uuid>, shelter=<uuid>)"`
+- `list` (empty) → `"No animals found."`
+- `list` (has data) → table rows containing species, name, status
+
+- [ ] **Step 4.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter animal} command group.
+ * Covers Dog, Cat, Rabbit, and Other species, plus list filtering and capacity enforcement.
+ */
+class AnimalIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter(String name, int capacity) throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", name, "--location", "Boston", "--capacity", String.valueOf(capacity));
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void admit_dog_printsIdAndSpecies() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Labrador",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rex");
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void admit_cat_printsIdAndSpecies() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        RunResult r = run("animal", "admit",
+                "--species", "cat", "--name", "Whiskers", "--breed", "Siamese",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Whiskers");
+    }
+
+    @Test
+    void admit_rabbit_printsIdAndSpecies() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        RunResult r = run("animal", "admit",
+                "--species", "rabbit", "--name", "Fluffy", "--breed", "Holland Lop",
+                "--age", "1", "--activity", "MEDIUM", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Fluffy");
+    }
+
+    @Test
+    void admit_other_speciesNamePreservedOnList() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "fish", "--name", "Nemo", "--breed", "Clownfish",
+                "--age", "1", "--activity", "LOW", "--shelter", shelterId);
+
+        RunResult r = run("animal", "list", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Nemo");
+    }
+
+    @Test
+    void list_byShelter_onlyShowsAnimalsInThatShelter() throws Exception {
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
+        run("animal", "admit",
+                "--species", "dog", "--name", "InA", "--breed", "Breed",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterA);
+        run("animal", "admit",
+                "--species", "dog", "--name", "InB", "--breed", "Breed",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterB);
+
+        RunResult r = run("animal", "list", "--shelter", shelterA);
+        assertOutputContains(r, "InA");
+        assertOutputDoesNotContain(r, "InB");
+    }
+
+    @Test
+    void admit_exceedsCapacity_printsError() throws Exception {
+        String shelterId = registerShelter("Tiny", 1);
+        run("animal", "admit",
+                "--species", "dog", "--name", "First", "--breed", "Breed",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Second", "--breed", "Breed",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        // Shelter is full; expect an error message
+        assertOutputContains(r, "Error");
+    }
+
+    @Test
+    void list_noAnimals_printsEmptyMessage() throws Exception {
+        String shelterId = registerShelter("Empty", 10);
+        RunResult r = run("animal", "list", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "No animals found.");
+    }
+}
+```
+
+- [ ] **Step 4.2: Run and verify**
+
+```bash
+./gradlew test --tests "shelter.integration.AnimalIntegrationTest"
+```
+
+Expected: 7 tests, all PASS.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/AnimalIntegrationTest.java
+git commit -m "test(integration): AnimalIntegrationTest — admit Dog/Cat/Rabbit/Other, list, capacity"
+```
+
+---
+
+## Task 5: AdopterIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/AdopterIntegrationTest.java`
+
+CLI output reference:
+- `register` → `"Registered adopter: Alice (id=<uuid>)"`
+- `list` (empty) → `"No adopters registered."`
+
+- [ ] **Step 5.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter adopter} command group.
+ * Verifies registration with and without age preferences, and listing behaviour.
+ */
+class AdopterIntegrationTest extends CliIntegrationTest {
+
+    @Test
+    void register_withAllPrefs_printsIdAndName() throws Exception {
+        RunResult r = run("adopter", "register",
+                "--name", "Alice",
+                "--living-space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY",
+                "--species", "DOG",
+                "--min-age", "1",
+                "--max-age", "5");
+        assertSuccess(r);
+        assertOutputContains(r, "Alice");
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void register_withoutAgePrefs_doesNotDefaultToAge20() throws Exception {
+        // Regression: --max-age previously defaulted to 20, contaminating match scores.
+        // Without --min-age / --max-age, the adopter should have null age bounds.
+        RunResult r = run("adopter", "register",
+                "--name", "Bob",
+                "--living-space", "APARTMENT",
+                "--schedule", "AWAY_MOST_OF_DAY");
+        assertSuccess(r);
+        assertOutputContains(r, "Bob");
+        // No error indicates the null age was accepted correctly
+    }
+
+    @Test
+    void list_noAdopters_printsEmptyMessage() throws Exception {
+        RunResult r = run("adopter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "No adopters registered.");
+    }
+
+    @Test
+    void list_afterRegister_showsAdopter() throws Exception {
+        run("adopter", "register",
+                "--name", "Carol",
+                "--living-space", "APARTMENT",
+                "--schedule", "HOME_MOST_OF_DAY");
+        RunResult r = run("adopter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Carol");
+    }
+}
+```
+
+- [ ] **Step 5.2: Run and verify**
+
+```bash
+./gradlew test --tests "shelter.integration.AdopterIntegrationTest"
+```
+
+Expected: 4 tests, all PASS.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/AdopterIntegrationTest.java
+git commit -m "test(integration): AdopterIntegrationTest — register with/without age prefs, list"
+```
+
+---
+
+## Task 6: AdoptionIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/AdoptionIntegrationTest.java`
+
+CLI output reference:
+- `submit` → `"Submitted adoption request: id=<uuid> (adopter=<uuid>, animal=<uuid>)"`
+- `approve` → `"Approved adoption request: <uuid>"`
+- `reject` → `"Rejected adoption request: <uuid>"`
+- `cancel` → `"Cancelled adoption request: <uuid>"`
+
+- [ ] **Step 6.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter adopt} command group.
+ * Tests the full adoption lifecycle: submit → approve/reject/cancel, plus error paths.
+ */
+class AdoptionIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter() throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        return extractId(r.stdout());
+    }
+
+    private String admitDog(String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    private String registerAdopter() throws Exception {
+        RunResult r = run("adopter", "register",
+                "--name", "Alice", "--living-space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        return extractId(r.stdout());
+    }
+
+    private String submitAdoption(String adopterId, String animalId) throws Exception {
+        RunResult r = run("adopt", "submit",
+                "--adopter", adopterId, "--animal", animalId);
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void submit_validPair_printsRequestId() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        String adopterId = registerAdopter();
+
+        RunResult r = run("adopt", "submit",
+                "--adopter", adopterId, "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void approve_validRequest_printsConfirmationAndAnimalIsAdopted() throws Exception {
+        String shelterId  = registerShelter();
+        String animalId   = admitDog(shelterId);
+        String adopterId  = registerAdopter();
+        String requestId  = submitAdoption(adopterId, animalId);
+
+        RunResult r = run("adopt", "approve", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Approved adoption request");
+
+        // Animal should now show as adopted in the list
+        RunResult list = run("animal", "list", "--shelter", shelterId);
+        assertOutputContains(list, "adopted");
+    }
+
+    @Test
+    void reject_validRequest_printsConfirmation() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        String adopterId = registerAdopter();
+        String requestId = submitAdoption(adopterId, animalId);
+
+        RunResult r = run("adopt", "reject", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rejected adoption request");
+    }
+
+    @Test
+    void cancel_validRequest_printsConfirmation() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        String adopterId = registerAdopter();
+        String requestId = submitAdoption(adopterId, animalId);
+
+        RunResult r = run("adopt", "cancel", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Cancelled adoption request");
+    }
+
+    @Test
+    void approve_nonExistentRequest_printsError() throws Exception {
+        RunResult r = run("adopt", "approve", "--request", "00000000-0000-0000-0000-000000000000");
+        assertOutputContains(r, "Error");
+    }
+
+    @Test
+    void approve_alreadyAdoptedAnimal_printsError() throws Exception {
+        String shelterId  = registerShelter();
+        String animalId   = admitDog(shelterId);
+        String adopterId  = registerAdopter();
+        String requestId1 = submitAdoption(adopterId, animalId);
+        run("adopt", "approve", "--request", requestId1);
+
+        // Try to submit a second adoption for the same animal
+        RunResult r = run("adopt", "submit",
+                "--adopter", adopterId, "--animal", animalId);
+        assertOutputContains(r, "Error");
+    }
+}
+```
+
+- [ ] **Step 6.2: Run and verify**
+
+```bash
+./gradlew test --tests "shelter.integration.AdoptionIntegrationTest"
+```
+
+Expected: 6 tests, all PASS.
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/AdoptionIntegrationTest.java
+git commit -m "test(integration): AdoptionIntegrationTest — full lifecycle, error paths"
+```
+
+---
+
+## Task 7: TransferIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/TransferIntegrationTest.java`
+
+CLI output reference:
+- `transfer request` → `"Transfer request created: id=<uuid> (animal=<uuid>, <from> → <to>)"`
+- `approve` → `"Approved transfer request: <uuid>"`
+- `reject` → `"Rejected transfer request: <uuid>"`
+
+- [ ] **Step 7.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter transfer} command group.
+ * Verifies request, approve (animal moves shelter), and reject flows.
+ */
+class TransferIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter(String name) throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", name, "--location", "Boston", "--capacity", "10");
+        return extractId(r.stdout());
+    }
+
+    private String admitDog(String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void request_validTransfer_printsRequestId() throws Exception {
+        String shelterA = registerShelter("Shelter A");
+        String shelterB = registerShelter("Shelter B");
+        String animalId = admitDog(shelterA);
+
+        RunResult r = run("transfer", "request",
+                "--animal", animalId, "--from", shelterA, "--to", shelterB);
+        assertSuccess(r);
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void approve_validTransfer_animalAppearsInNewShelter() throws Exception {
+        String shelterA = registerShelter("Shelter A");
+        String shelterB = registerShelter("Shelter B");
+        String animalId = admitDog(shelterA);
+
+        RunResult requestResult = run("transfer", "request",
+                "--animal", animalId, "--from", shelterA, "--to", shelterB);
+        String requestId = extractId(requestResult.stdout());
+
+        RunResult r = run("transfer", "approve", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Approved transfer request");
+
+        RunResult list = run("animal", "list", "--shelter", shelterB);
+        assertOutputContains(list, "Rex");
+    }
+
+    @Test
+    void reject_validTransfer_printsConfirmation() throws Exception {
+        String shelterA = registerShelter("Shelter A");
+        String shelterB = registerShelter("Shelter B");
+        String animalId = admitDog(shelterA);
+
+        RunResult requestResult = run("transfer", "request",
+                "--animal", animalId, "--from", shelterA, "--to", shelterB);
+        String requestId = extractId(requestResult.stdout());
+
+        RunResult r = run("transfer", "reject", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rejected transfer request");
+    }
+}
+```
+
+- [ ] **Step 7.2: Run and verify**
+
+```bash
+./gradlew test --tests "shelter.integration.TransferIntegrationTest"
+```
+
+Expected: 3 tests, all PASS.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/TransferIntegrationTest.java
+git commit -m "test(integration): TransferIntegrationTest — request, approve, reject"
+```
+
+---
+
+## Task 8: MatchIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/MatchIntegrationTest.java`
+
+CLI output reference:
+- `match animal` → ranked table `rank  animal-id  name  score` or `"No available animals..."`
+- `match adopter` → ranked table `rank  adopter-id  name  score`
+
+- [ ] **Step 8.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter match} command group.
+ * Verifies that ranked output is returned and that null age preferences
+ * do not zero-penalise the score (regression for the age-sentinel bug).
+ */
+class MatchIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter() throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        return extractId(r.stdout());
+    }
+
+    private String admitDog(String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    private String registerAdopter(String name) throws Exception {
+        RunResult r = run("adopter", "register",
+                "--name", name,
+                "--living-space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY",
+                "--species", "DOG");
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void matchAnimal_returnsRankedList() throws Exception {
+        String shelterId = registerShelter();
+        admitDog(shelterId);
+        String adopterId = registerAdopter("Alice");
+
+        RunResult r = run("match", "animal",
+                "--adopter", adopterId, "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rex");
+    }
+
+    @Test
+    void matchAnimal_noAnimalsInShelter_printsEmptyMessage() throws Exception {
+        String shelterId = registerShelter();
+        String adopterId = registerAdopter("Alice");
+
+        RunResult r = run("match", "animal",
+                "--adopter", adopterId, "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "No available animals");
+    }
+
+    @Test
+    void matchAdopter_returnsRankedList() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        registerAdopter("Alice");
+
+        RunResult r = run("match", "adopter", "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "Alice");
+    }
+
+    @Test
+    void matchAnimal_adopterWithNoAgePrefs_nonZeroScore() throws Exception {
+        // Regression: age sentinel 0..MAX_VALUE caused score penalisation for adopters
+        // with no age preference. Without --min-age/--max-age, score should not be 0.
+        String shelterId = registerShelter();
+        admitDog(shelterId);
+        RunResult ar = run("adopter", "register",
+                "--name", "NoAge",
+                "--living-space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        String adopterId = extractId(ar.stdout());
+
+        RunResult r = run("match", "animal",
+                "--adopter", adopterId, "--shelter", shelterId);
+        assertSuccess(r);
+        // Rex must appear in the ranked output — if age sentinel caused score 0
+        // and the animal were excluded, Rex would be absent from the output.
+        assertOutputContains(r, "Rex");
+    }
+}
+```
+
+- [ ] **Step 8.2: Run and verify**
+
+```bash
+./gradlew test --tests "shelter.integration.MatchIntegrationTest"
+```
+
+Expected: 4 tests, all PASS.
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/MatchIntegrationTest.java
+git commit -m "test(integration): MatchIntegrationTest — ranked results, null-age regression"
+```
+
+---
+
+## Task 9: VaccineIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/VaccineIntegrationTest.java`
+
+CLI output reference:
+- `vaccine type add` → `"Added vaccine type: Rabies (id=<uuid>, species=DOG, validity=365 days)"`
+- `vaccine type list` → table rows / `"No vaccine types in catalog."`
+- `vaccine record` → `"Recorded vaccination: animal=<uuid>, type=Rabies, date=<date>"`
+- `vaccine overdue` (no overdue) → `"All vaccinations are current for animal: <uuid>"`
+- `vaccine overdue` (has overdue) → table with vaccine type and due date
+
+- [ ] **Step 9.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter vaccine} command group.
+ * Covers vaccine type CRUD, recording vaccinations, and overdue checks.
+ */
+class VaccineIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter() throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        return extractId(r.stdout());
+    }
+
+    private String admitDog(String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void vaccineType_addAndList_showsType() throws Exception {
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--validity", "365");
+        RunResult r = run("vaccine", "type", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Rabies");
+    }
+
+    @Test
+    void record_validVaccination_printsConfirmation() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--validity", "365");
+
+        RunResult r = run("vaccine", "record",
+                "--animal", animalId,
+                "--type", "Rabies",
+                "--date", LocalDate.now().toString());
+        assertSuccess(r);
+        assertOutputContains(r, "Recorded vaccination");
+    }
+
+    @Test
+    void overdue_recentVaccination_notOverdue() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--validity", "365");
+        run("vaccine", "record",
+                "--animal", animalId,
+                "--type", "Rabies",
+                "--date", LocalDate.now().toString());
+
+        RunResult r = run("vaccine", "overdue", "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "All vaccinations are current");
+    }
+
+    @Test
+    void overdue_expiredVaccination_printsOverdueEntry() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--validity", "365");
+        // Record vaccination 2 years ago — well past the 365-day validity
+        String pastDate = LocalDate.now().minusYears(2).toString();
+        run("vaccine", "record",
+                "--animal", animalId, "--type", "Rabies", "--date", pastDate);
+
+        RunResult r = run("vaccine", "overdue", "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rabies");
+    }
+}
+```
+
+- [ ] **Step 9.2: Run and verify**
+
+```bash
+./gradlew test --tests "shelter.integration.VaccineIntegrationTest"
+```
+
+Expected: 4 tests, all PASS.
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/VaccineIntegrationTest.java
+git commit -m "test(integration): VaccineIntegrationTest — type CRUD, record, overdue"
+```
+
+---
+
+## Task 10: AuditIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/AuditIntegrationTest.java`
+
+CLI output reference:
+- `audit log` (empty) → `"Audit log is empty."`
+- `audit log` (has data) → table rows with entity type, action, timestamp
+
+- [ ] **Step 10.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter audit} command group.
+ * Verifies that mutations are recorded in the audit log and are visible via CLI.
+ */
+class AuditIntegrationTest extends CliIntegrationTest {
+
+    @Test
+    void log_noActions_printsEmptyMessage() throws Exception {
+        RunResult r = run("audit", "log");
+        assertSuccess(r);
+        assertOutputContains(r, "Audit log is empty.");
+    }
+
+    @Test
+    void log_afterAdmitAndAdopt_containsBothEntries() throws Exception {
+        RunResult sr = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        String shelterId = extractId(sr.stdout());
+
+        run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+
+        RunResult r = run("audit", "log");
+        assertSuccess(r);
+        // Audit log should contain at least entries for shelter register and animal admit
+        assertOutputDoesNotContain(r, "Audit log is empty.");
+    }
+}
+```
+
+- [ ] **Step 10.2: Run and verify**
+
+```bash
+./gradlew test --tests "shelter.integration.AuditIntegrationTest"
+```
+
+Expected: 2 tests, all PASS.
+
+- [ ] **Step 10.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/AuditIntegrationTest.java
+git commit -m "test(integration): AuditIntegrationTest — empty log, entries after mutations"
+```
+
+---
+
+## Task 11: CrossSessionIntegrationTest
+
+**Files:**
+- Create: `src/test/java/shelter/integration/CrossSessionIntegrationTest.java`
+
+These tests verify that data written by one subprocess is readable by a subsequent subprocess — the core persistence guarantee.
+
+- [ ] **Step 11.1: Write the test file**
+
+```java
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests verifying that data persists across separate shelter processes.
+ * Each test runs two independent subprocesses against the same TempDir, simulating
+ * a real shutdown-and-restart cycle.
+ */
+class CrossSessionIntegrationTest extends CliIntegrationTest {
+
+    @Test
+    void shelterRegistered_inProcess1_visibleInProcess2() throws Exception {
+        // Process 1: register a shelter
+        run("shelter", "register",
+                "--name", "Persistent Paws", "--location", "Boston", "--capacity", "10");
+
+        // Process 2: list shelters — data must survive across process boundary
+        RunResult r = run("shelter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Persistent Paws");
+    }
+
+    @Test
+    void otherAnimal_admittedInProcess1_speciesNamePreservedInProcess2() throws Exception {
+        // Regression: Other animals were silently dropped on CSV reload.
+        RunResult sr = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        String shelterId = extractId(sr.stdout());
+
+        // Process 1: admit an Other animal
+        run("animal", "admit",
+                "--species", "fish", "--name", "Nemo", "--breed", "Clownfish",
+                "--age", "1", "--activity", "LOW", "--shelter", shelterId);
+
+        // Process 2: list — Nemo must still appear with correct species
+        RunResult r = run("animal", "list", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Nemo");
+    }
+}
+```
+
+- [ ] **Step 11.2: Run and verify**
+
+```bash
+./gradlew test --tests "shelter.integration.CrossSessionIntegrationTest"
+```
+
+Expected: 2 tests, all PASS.
+
+- [ ] **Step 11.3: Commit**
+
+```bash
+git add src/test/java/shelter/integration/CrossSessionIntegrationTest.java
+git commit -m "test(integration): CrossSessionIntegrationTest — data persistence across processes"
+```
+
+---
+
+## Task 12: Full Run and Push
+
+- [ ] **Step 12.1: Run all tests**
+
+```bash
+./gradlew test
+```
+
+Expected: all unit tests + all integration tests PASS. Check the HTML report at `build/reports/tests/test/index.html` and confirm the `shelter.integration` package appears.
+
+- [ ] **Step 12.2: Push branch**
+
+```bash
+git push -u origin test/integration-cli
+```
+
+- [ ] **Step 12.3: Open PR against dev**
+
+```bash
+gh pr create --base dev --title "test(integration): CLI end-to-end integration tests" \
+  --body "Adds ~30 CLI integration tests using ProcessBuilder + JUnit TempDir.
+  
+- Patches Main.java to read SHELTER_HOME env var for test isolation
+- Abstract base class CliIntegrationTest with run(), extractId(), assertions
+- 10 test files covering all CLI command groups
+- Cross-session tests verify CSV persistence survives process restart
+
+Tests run as part of ./gradlew test (installDist runs automatically first)."
+```

--- a/docs/test-live.md
+++ b/docs/test-live.md
@@ -15,29 +15,33 @@ shelter --version
 ## Phase 1 — Shelter Management (UC-01)
 
 **1.1 — Register two shelters**
-> Register two shelters: the first called "Boston Paws" in Boston with capacity 15, the second called "Cambridge Care" in Cambridge with capacity 10.
-
+```
+Register two shelters: the first called "Boston Paws" in Boston with capacity 15, the second called "Cambridge Care" in Cambridge with capacity 10.
+```
 ✅ Two confirmation lines, each showing the shelter name and a generated ID.
 
 ---
 
 **1.2 — List all shelters**
-> List all shelters.
-
+```
+List all shelters.
+```
 ✅ A table with two rows showing ID, Name, Location, and Capacity columns.
 
 ---
 
 **1.3 — Update shelter capacity**
-> Change Boston Paws's capacity to 20.
-
+```
+Change Boston Paws's capacity to 20.
+```
 ✅ One confirmation line: `Updated shelter: Boston Paws (id=...)`
 
 ---
 
 **1.4 — Delete and recreate an empty shelter**
-> Delete Boston Paws, then re-register it with the same name in Boston, capacity 20.
-
+```
+Delete Boston Paws, then re-register it with the same name in Boston, capacity 20.
+```
 ✅ First a removal confirmation, then a registration confirmation. Empty shelters can be deleted freely; we recreate it for the next phases.
 
 ---
@@ -45,50 +49,57 @@ shelter --version
 ## Phase 2 — Animal Management (UC-02)
 
 **2.1 — Admit a dog**
-> Admit a 3-year-old Labrador named Max into Boston Paws, activity HIGH.
-
+```
+Admit a 3-year-old Labrador named Max into Boston Paws, activity HIGH.
+```
 ✅ One confirmation line: `Admitted DOG: Max (id=..., shelter=...)`
 
 ---
 
 **2.2 — Admit a cat**
-> Admit a 2-year-old Siamese cat named Luna into Boston Paws, activity LOW, indoor, neutered.
-
+```
+Admit a 2-year-old Siamese cat named Luna into Boston Paws, activity LOW, indoor, neutered.
+```
 ✅ One confirmation line: `Admitted CAT: Luna (id=..., shelter=...)`
 
 ---
 
 **2.3 — Admit a rabbit**
-> Admit a 1-year-old Dutch rabbit named Fluffy into Cambridge Care, activity MEDIUM.
-
+```
+Admit a 1-year-old Dutch rabbit named Fluffy into Cambridge Care, activity MEDIUM.
+```
 ✅ One confirmation line: `Admitted RABBIT: Fluffy (id=..., shelter=...)`
 
 ---
 
 **2.4 — Admit an other-species animal**
-> Admit a tropical fish named Nemo into Boston Paws, breed Clownfish, activity LOW, species name "fish".
-
+```
+Admit a tropical fish named Nemo into Boston Paws, breed Clownfish, activity LOW, species name "fish".
+```
 ✅ One confirmation line: `Admitted OTHER: Nemo (id=..., shelter=...)` — species shows as OTHER.
 
 ---
 
 **2.5 — List animals by shelter**
-> List all animals in Boston Paws.
-
+```
+List all animals in Boston Paws.
+```
 ✅ Max, Luna, and Nemo appear. Fluffy does not appear. The Shelter column shows "Boston Paws" for each row.
 
 ---
 
 **2.6 — Update animal name**
-> Rename Max to Buddy.
-
+```
+Rename Max to Buddy.
+```
 ✅ One confirmation line: `Updated animal: Buddy (id=...)`
 
 ---
 
 **2.7 — List all animals system-wide**
-> List all animals without filtering by shelter.
-
+```
+List all animals without filtering by shelter.
+```
 ✅ Buddy, Luna, Nemo, and Fluffy all appear. Each row shows its correct shelter name in the Shelter column.
 
 ---
@@ -96,29 +107,33 @@ shelter --version
 ## Phase 3 — Adopter Management (UC-03)
 
 **3.1 — Register adopter with full preferences**
-> Register an adopter named Alice — she lives in a house with yard, is home most of the day, prefers dogs, specifically Labradors, high activity level, requires vaccinated animals, age range 1 to 5.
-
+```
+Register an adopter named Alice — she lives in a house with yard, is home most of the day, prefers dogs, specifically Labradors, high activity level, requires vaccinated animals, age range 1 to 5.
+```
 ✅ One confirmation line: `Registered adopter: Alice (id=...)`
 
 ---
 
 **3.2 — Register adopter with minimal preferences**
-> Register an adopter named Bob — he lives in an apartment, is away part of the day, prefers cats, activity LOW, no vaccination requirement, no age preference.
-
+```
+Register an adopter named Bob — he lives in an apartment, is away part of the day, prefers cats, activity LOW, no vaccination requirement, no age preference.
+```
 ✅ One confirmation line: `Registered adopter: Bob (id=...)`
 
 ---
 
 **3.3 — List all adopters**
-> List all adopters.
-
+```
+List all adopters.
+```
 ✅ Both Alice and Bob appear. All preference columns are shown; unset fields display "any".
 
 ---
 
 **3.4 — Update adopter preferences**
-> Change Bob's schedule to HOME_MOST_OF_DAY and his preferred activity level to MEDIUM.
-
+```
+Change Bob's schedule to HOME_MOST_OF_DAY and his preferred activity level to MEDIUM.
+```
 ✅ One confirmation line: `Updated adopter: Bob (id=...)`
 
 ---
@@ -126,15 +141,17 @@ shelter --version
 ## Phase 4 — Matching (UC-04)
 
 **4.1 — Match animals for an adopter**
-> Match animals in Boston Paws for Alice.
-
+```
+Match animals in Boston Paws for Alice.
+```
 ✅ A ranked table with Rank, Animal ID, Name, and Score columns. Buddy should rank first — species, breed, and age all match Alice's preferences.
 
 ---
 
 **4.2 — Match adopters for an animal**
-> Find the best adopters for Buddy.
-
+```
+Find the best adopters for Buddy.
+```
 ✅ A ranked table with Rank, Adopter ID, Name, and Score columns. Alice should rank first.
 
 ---
@@ -142,43 +159,49 @@ shelter --version
 ## Phase 5 — Adoption Workflow (UC-05)
 
 **5.1 — Submit adoption request**
-> Alice wants to adopt Buddy — submit the request.
-
+```
+Alice wants to adopt Buddy — submit the request.
+```
 ✅ One confirmation line: `Submitted adoption request: id=... (adopter=..., animal=...)`
 
 ---
 
 **5.2 — Approve adoption**
-> Approve that adoption request.
-
+```
+Approve that adoption request.
+```
 ✅ One confirmation line: `Approved adoption request: ...`
 
 ---
 
 **5.3 — Verify adopted status**
-> List animals in Boston Paws and check Buddy's status.
-
+```
+List animals in Boston Paws and check Buddy's status.
+```
 ✅ Buddy's row shows `adopted`; Luna and Nemo show `available`.
 
 ---
 
 **5.4 — Reject a second request on an adopted animal**
-> Try to submit another adoption request for Buddy on behalf of Bob.
-
+```
+Try to submit another adoption request for Buddy on behalf of Bob.
+```
 ✅ Error — the animal is already adopted.
 
 ---
 
 **5.5 — Reject an adoption request**
-> Bob wants to adopt Luna — submit the request, then reject it.
-
+```
+Bob wants to adopt Luna — submit the request, then reject it.
+```
 ✅ Submission succeeds. Rejection outputs: `Rejected adoption request: ...`
 
 ---
 
 **5.6 — Cancel an adoption request**
-> Submit another adoption request for Bob to adopt Luna, then cancel it.
-
+```
+Submit another adoption request for Bob to adopt Luna, then cancel it.
+```
 ✅ Submission succeeds. Cancellation outputs: `Cancelled adoption request: ...`
 
 ---
@@ -186,29 +209,33 @@ shelter --version
 ## Phase 6 — Transfer Workflow (UC-06)
 
 **6.1 — Request a transfer**
-> Transfer Luna from Boston Paws to Cambridge Care.
-
+```
+Transfer Luna from Boston Paws to Cambridge Care.
+```
 ✅ One confirmation line: `Transfer request created: id=... (animal=..., Boston Paws → Cambridge Care)`
 
 ---
 
 **6.2 — Approve the transfer**
-> Approve that transfer request.
-
+```
+Approve that transfer request.
+```
 ✅ One confirmation line: `Approved transfer request: ...`
 
 ---
 
 **6.3 — Verify transfer result**
-> List animals in Cambridge Care.
-
+```
+List animals in Cambridge Care.
+```
 ✅ Both Luna and Fluffy appear.
 
 ---
 
 **6.4 — Reject a transfer request**
-> Transfer Nemo from Boston Paws to Cambridge Care, then reject it.
-
+```
+Transfer Nemo from Boston Paws to Cambridge Care, then reject it.
+```
 ✅ Request creation succeeds. Rejection outputs: `Rejected transfer request: ...`
 
 ---
@@ -216,43 +243,49 @@ shelter --version
 ## Phase 7 — Vaccination Management (UC-07)
 
 **7.1 — Add vaccine types**
-> Add two vaccine types: Rabies for dogs, valid 365 days; Feline FVRCP for cats, valid 365 days.
-
+```
+Add two vaccine types: Rabies for dogs, valid 365 days; Feline FVRCP for cats, valid 365 days.
+```
 ✅ Two confirmation lines: `Added vaccine type: Rabies (id=...)` and `Added vaccine type: Feline FVRCP (id=...)`
 
 ---
 
 **7.2 — List vaccine types**
-> List all vaccine types.
-
+```
+List all vaccine types.
+```
 ✅ Both Rabies and Feline FVRCP appear.
 
 ---
 
 **7.3 — Record a vaccination**
-> Give Buddy the Rabies vaccine today.
-
+```
+Give Buddy the Rabies vaccine today.
+```
 ✅ One confirmation line: `Recorded vaccination: animal=..., type=Rabies, date=...`
 
 ---
 
 **7.4 — Check overdue vaccinations**
-> Check whether Buddy has any overdue vaccinations.
-
+```
+Check whether Buddy has any overdue vaccinations.
+```
 ✅ Output confirms all vaccinations are current for Buddy.
 
 ---
 
 **7.5 — Species mismatch error**
-> Try to give Luna the Rabies vaccine (which is for dogs only).
-
+```
+Try to give Luna the Rabies vaccine (which is for dogs only).
+```
 ✅ Error — species mismatch. Luna is a cat; Rabies is only applicable to dogs.
 
 ---
 
 **7.6 — Update a vaccine type**
-> Rename Feline FVRCP to Cat FVRCP.
-
+```
+Rename Feline FVRCP to Cat FVRCP.
+```
 ✅ One confirmation line: `Updated vaccine type: Cat FVRCP (id=...)`
 
 ---
@@ -260,8 +293,9 @@ shelter --version
 ## Phase 8 — Audit Log (UC-08)
 
 **8.1 — View audit log**
-> Show the audit log.
-
+```
+Show the audit log.
+```
 ✅ A table with Timestamp, Staff, Action, and Target columns covering every operation performed in this session.
 
 ---
@@ -269,22 +303,25 @@ shelter --version
 ## Phase 9 — Error Cases
 
 **9.1 — Remove an animal without pending requests**
-> Delete Fluffy — Fluffy has no pending adoption requests.
-
+```
+Delete Fluffy — Fluffy has no pending adoption requests.
+```
 ✅ One confirmation line: `Removed animal: ...`
 
 ---
 
 **9.2 — Remove a shelter that still holds animals**
-> Try to delete Cambridge Care — it still has Luna inside.
-
+```
+Try to delete Cambridge Care — it still has Luna inside.
+```
 ✅ Error — shelter still holds animals.
 
 ---
 
 **9.3 — Look up a non-existent ID**
-> Look up shelter with ID "abc-123".
-
+```
+Look up shelter with ID "abc-123".
+```
 ✅ Error — not found.
 
 ---

--- a/docs/test-live.md
+++ b/docs/test-live.md
@@ -1,241 +1,297 @@
-# 实机测试计划（Claude Agent 执行）
+# Live Test Plan (Claude Agent)
 
-测试目的：在 demo 前验证系统全流程无误。由 Claude Code 作为 AI agent，解读自然语言并执行 `shelter` CLI 命令。
+Full end-to-end verification before demo. Claude Code acts as AI agent — interpreting natural language and executing `shelter` CLI commands.
 
-**前置条件**（在项目根目录 `management-system-for-multi-shelter-animal-adoption/` 执行）：
+**Setup** (run from project root `management-system-for-multi-shelter-animal-adoption/`):
 ```bash
-./gradlew installDist                                  # 构建二进制
-export PATH="$PWD/build/install/shelter/bin:$PATH"    # 注册 shelter 命令
-rm -rf ~/shelter/data                                  # 清空历史数据，保证干净状态
-shelter --version                                      # 验证 CLI 可用
+./gradlew installDist
+export PATH="$PWD/build/install/shelter/bin:$PATH"
+rm -rf ~/shelter/data
+shelter --version
 ```
 
 ---
 
-## 阶段一：庇护所管理（UC-01）
+## Phase 1 — Shelter Management (UC-01)
 
-**对 Claude 说：**
-> 注册两个庇护所：第一个叫 "Boston Paws"，位于 Boston，容量 15；第二个叫 "Cambridge Care"，位于 Cambridge，容量 10。
+**1.1 — Register two shelters**
+> Register two shelters: the first called "Boston Paws" in Boston with capacity 15, the second called "Cambridge Care" in Cambridge with capacity 10.
 
-✅ 期望：两行 `Registered shelter: ... (id=...)` 输出
-
-**对 Claude 说：**
-> 列出所有庇护所。
-
-✅ 期望：显示两行记录，有 ID、Name、Location、Capacity 列
-
-**对 Claude 说：**
-> 把 Boston Paws 的容量改成 20。
-
-✅ 期望：`Updated shelter: Boston Paws (id=...)`
-
-**对 Claude 说：**
-> 删除 Boston Paws，然后重新注册一个同名庇护所（容量 20）。
-
-✅ 期望：先输出 `Removed shelter: ...`，再输出 `Registered shelter: Boston Paws (id=...)`（空庇护所可以正常删除；重建是为了后续阶段继续使用）
+✅ Two confirmation lines, each showing the shelter name and a generated ID.
 
 ---
 
-## 阶段二：动物管理（UC-02）
+**1.2 — List all shelters**
+> List all shelters.
 
-**对 Claude 说：**
-> 往 Boston Paws 收容一只 3 岁的拉布拉多犬，叫 Max，活跃度 HIGH。
-
-✅ 期望：`Admitted dog: Max (id=..., shelter=...)`
-
-**对 Claude 说：**
-> 再往 Boston Paws 收容一只 2 岁的暹罗猫，叫 Luna，活跃度 LOW，室内猫，已绝育。
-
-✅ 期望：`Admitted cat: Luna (id=..., shelter=...)`
-
-**对 Claude 说：**
-> 往 Cambridge Care 收容一只 1 岁的荷兰垂耳兔，叫 Fluffy，活跃度 MEDIUM。
-
-✅ 期望：`Admitted rabbit: Fluffy (id=..., shelter=...)`
-
-**对 Claude 说：**
-> 往 Boston Paws 再收容一条热带鱼，叫 Nemo，品种 Clownfish，活跃度 LOW。
-
-✅ 期望：`Admitted fish: Nemo (id=..., shelter=...)`（species 显示 fish）
-
-**对 Claude 说：**
-> 列出 Boston Paws 里的所有动物。
-
-✅ 期望：Max、Luna、Nemo 出现，Fluffy 不出现
-
-**对 Claude 说：**
-> 把 Max 的名字改成 Buddy。
-
-✅ 期望：`Updated animal: Buddy (id=...)`
-
-**对 Claude 说：**
-> 列出所有动物（不过滤庇护所）。
-
-✅ 期望：Buddy、Luna、Fluffy、Nemo 全部出现
+✅ A table with two rows showing ID, Name, Location, and Capacity columns.
 
 ---
 
-## 阶段三：领养人管理（UC-03）
+**1.3 — Update shelter capacity**
+> Change Boston Paws's capacity to 20.
 
-**对 Claude 说：**
-> 注册领养人 Alice，住 HOUSE_WITH_YARD，日程 HOME_MOST_OF_DAY，偏好 DOG，偏好品种 Labrador，活跃度偏好 HIGH，要求已接种疫苗，年龄范围 1 到 5 岁。
-
-✅ 期望：`Registered adopter: Alice (id=...)`
-
-**对 Claude 说：**
-> 注册领养人 Bob，住 APARTMENT，日程 AWAY_PART_OF_DAY，偏好 CAT，活跃度偏好 LOW，不要求接种疫苗，年龄范围不限。
-
-✅ 期望：`Registered adopter: Bob (id=...)`
-
-**对 Claude 说：**
-> 列出所有领养人。
-
-✅ 期望：Alice 和 Bob 都出现
-
-**对 Claude 说：**
-> 把 Bob 的日程改成 HOME_MOST_OF_DAY，同时把他的活跃度偏好改成 MEDIUM。
-
-✅ 期望：`Updated adopter: Bob (id=...)`
+✅ One confirmation line: `Updated shelter: Boston Paws (id=...)`
 
 ---
 
-## 阶段四：匹配（UC-04）
+**1.4 — Delete and recreate an empty shelter**
+> Delete Boston Paws, then re-register it with the same name in Boston, capacity 20.
 
-**对 Claude 说：**
-> 为 Alice 在 Boston Paws 里做动物匹配。
-
-✅ 期望：显示 Rank/Animal ID/Name/Score 表格，Buddy 应该得分最高（狗+年龄符合）
-
-**对 Claude 说：**
-> 为 Buddy 匹配合适的领养人。
-
-✅ 期望：显示 Rank/Adopter ID/Name/Score 表格，Alice 应排名靠前
+✅ First a removal confirmation, then a registration confirmation. Empty shelters can be deleted freely; we recreate it for the next phases.
 
 ---
 
-## 阶段五：领养流程（UC-05）
+## Phase 2 — Animal Management (UC-02)
 
-**对 Claude 说：**
-> Alice 想领养 Buddy，提交申请。
+**2.1 — Admit a dog**
+> Admit a 3-year-old Labrador named Max into Boston Paws, activity HIGH.
 
-✅ 期望：`Submitted adoption request: id=... (adopter=..., animal=...)`
-
-**对 Claude 说：**
-> 批准这个领养申请。
-
-✅ 期望：`Approved adoption request: ...`
-
-**对 Claude 说：**
-> 列出 Boston Paws 的动物，看看 Buddy 状态。
-
-✅ 期望：Buddy 一行显示 `adopted`，其他动物显示 `available`
-
-**对 Claude 说：**
-> 再试一次为 Buddy 提交 Bob 的领养申请。
-
-✅ 期望：报错（动物已被领养）
-
-**对 Claude 说：**
-> Bob 想领养 Luna，提交申请，然后拒绝它。
-
-✅ 期望：submit 成功，reject 输出 `Rejected adoption request: ...`
-
-**对 Claude 说：**
-> Bob 再提交一个领养 Luna 的申请，然后取消。
-
-✅ 期望：submit 成功，cancel 输出 `Cancelled adoption request: ...`
+✅ One confirmation line: `Admitted DOG: Max (id=..., shelter=...)`
 
 ---
 
-## 阶段六：转移流程（UC-06）
+**2.2 — Admit a cat**
+> Admit a 2-year-old Siamese cat named Luna into Boston Paws, activity LOW, indoor, neutered.
 
-**对 Claude 说：**
-> 把 Luna 从 Boston Paws 转移到 Cambridge Care。
-
-✅ 期望：`Transfer request created: id=... (animal=..., Boston Paws → Cambridge Care)`
-
-**对 Claude 说：**
-> 批准这个转移请求。
-
-✅ 期望：`Approved transfer request: ...`
-
-**对 Claude 说：**
-> 列出 Cambridge Care 的动物。
-
-✅ 期望：Luna 和 Fluffy 都出现
-
-**对 Claude 说：**
-> 把 Nemo 从 Boston Paws 转移到 Cambridge Care，然后拒绝。
-
-✅ 期望：request 成功，reject 输出 `Rejected transfer request: ...`
+✅ One confirmation line: `Admitted CAT: Luna (id=..., shelter=...)`
 
 ---
 
-## 阶段七：疫苗管理（UC-07）
+**2.3 — Admit a rabbit**
+> Admit a 1-year-old Dutch rabbit named Fluffy into Cambridge Care, activity MEDIUM.
 
-**对 Claude 说：**
-> 添加两种疫苗类型：Rabies，适用于 DOG，有效期 365 天；Feline FVRCP，适用于 CAT，有效期 365 天。
-
-✅ 期望：两行 `Added vaccine type: ...`
-
-**对 Claude 说：**
-> 列出所有疫苗类型。
-
-✅ 期望：显示 Rabies 和 Feline FVRCP
-
-**对 Claude 说：**
-> 给 Buddy 接种 Rabies 疫苗，日期今天。
-
-✅ 期望：`Recorded vaccination: animal=..., type=Rabies, date=...`
-
-**对 Claude 说：**
-> 检查 Buddy 有没有过期疫苗。
-
-✅ 期望：`All vaccinations are current for animal: ...`
-
-**对 Claude 说：**
-> 给 Luna 接种 Rabies（狗专用疫苗）。
-
-✅ 期望：报错（物种不匹配）
-
-**对 Claude 说：**
-> 把 Feline FVRCP 改名为 Cat FVRCP。
-
-✅ 期望：`Updated vaccine type: Cat FVRCP (id=...)`
+✅ One confirmation line: `Admitted RABBIT: Fluffy (id=..., shelter=...)`
 
 ---
 
-## 阶段八：审计日志（UC-08）
+**2.4 — Admit an other-species animal**
+> Admit a tropical fish named Nemo into Boston Paws, breed Clownfish, activity LOW, species name "fish".
 
-**对 Claude 说：**
-> 查看审计日志。
-
-✅ 期望：显示 Timestamp/Staff/Action/Target 表格，包含本次测试所有操作记录
+✅ One confirmation line: `Admitted OTHER: Nemo (id=..., shelter=...)` — species shows as OTHER.
 
 ---
 
-## 阶段九：边界错误验证
+**2.5 — List animals by shelter**
+> List all animals in Boston Paws.
 
-**对 Claude 说：**
-> 删除 Fluffy（Fluffy 没有 pending 申请，应该可以删）。
-
-✅ 期望：`Removed animal: ...`
-
-**对 Claude 说：**
-> 删除 Cambridge Care（里面还有 Luna，不能删）。
-
-✅ 期望：报错（shelter still holds animals）
-
-**对 Claude 说：**
-> 查询不存在的庇护所 ID "abc-123"。
-
-✅ 期望：报错（not found）
+✅ Max, Luna, and Nemo appear. Fluffy does not appear. The Shelter column shows "Boston Paws" for each row.
 
 ---
 
-## 测试通过标准
+**2.6 — Update animal name**
+> Rename Max to Buddy.
 
-- [ ] 所有 ✅ 项输出符合预期
-- [ ] 所有错误场景正确报错，不崩溃
-- [ ] `shelter audit log` 显示完整操作历史
-- [ ] 重启后（重新执行任意 list 命令）数据仍然存在
+✅ One confirmation line: `Updated animal: Buddy (id=...)`
+
+---
+
+**2.7 — List all animals system-wide**
+> List all animals without filtering by shelter.
+
+✅ Buddy, Luna, Nemo, and Fluffy all appear. Each row shows its correct shelter name in the Shelter column.
+
+---
+
+## Phase 3 — Adopter Management (UC-03)
+
+**3.1 — Register adopter with full preferences**
+> Register an adopter named Alice — she lives in a house with yard, is home most of the day, prefers dogs, specifically Labradors, high activity level, requires vaccinated animals, age range 1 to 5.
+
+✅ One confirmation line: `Registered adopter: Alice (id=...)`
+
+---
+
+**3.2 — Register adopter with minimal preferences**
+> Register an adopter named Bob — he lives in an apartment, is away part of the day, prefers cats, activity LOW, no vaccination requirement, no age preference.
+
+✅ One confirmation line: `Registered adopter: Bob (id=...)`
+
+---
+
+**3.3 — List all adopters**
+> List all adopters.
+
+✅ Both Alice and Bob appear. All preference columns are shown; unset fields display "any".
+
+---
+
+**3.4 — Update adopter preferences**
+> Change Bob's schedule to HOME_MOST_OF_DAY and his preferred activity level to MEDIUM.
+
+✅ One confirmation line: `Updated adopter: Bob (id=...)`
+
+---
+
+## Phase 4 — Matching (UC-04)
+
+**4.1 — Match animals for an adopter**
+> Match animals in Boston Paws for Alice.
+
+✅ A ranked table with Rank, Animal ID, Name, and Score columns. Buddy should rank first — species, breed, and age all match Alice's preferences.
+
+---
+
+**4.2 — Match adopters for an animal**
+> Find the best adopters for Buddy.
+
+✅ A ranked table with Rank, Adopter ID, Name, and Score columns. Alice should rank first.
+
+---
+
+## Phase 5 — Adoption Workflow (UC-05)
+
+**5.1 — Submit adoption request**
+> Alice wants to adopt Buddy — submit the request.
+
+✅ One confirmation line: `Submitted adoption request: id=... (adopter=..., animal=...)`
+
+---
+
+**5.2 — Approve adoption**
+> Approve that adoption request.
+
+✅ One confirmation line: `Approved adoption request: ...`
+
+---
+
+**5.3 — Verify adopted status**
+> List animals in Boston Paws and check Buddy's status.
+
+✅ Buddy's row shows `adopted`; Luna and Nemo show `available`.
+
+---
+
+**5.4 — Reject a second request on an adopted animal**
+> Try to submit another adoption request for Buddy on behalf of Bob.
+
+✅ Error — the animal is already adopted.
+
+---
+
+**5.5 — Reject an adoption request**
+> Bob wants to adopt Luna — submit the request, then reject it.
+
+✅ Submission succeeds. Rejection outputs: `Rejected adoption request: ...`
+
+---
+
+**5.6 — Cancel an adoption request**
+> Submit another adoption request for Bob to adopt Luna, then cancel it.
+
+✅ Submission succeeds. Cancellation outputs: `Cancelled adoption request: ...`
+
+---
+
+## Phase 6 — Transfer Workflow (UC-06)
+
+**6.1 — Request a transfer**
+> Transfer Luna from Boston Paws to Cambridge Care.
+
+✅ One confirmation line: `Transfer request created: id=... (animal=..., Boston Paws → Cambridge Care)`
+
+---
+
+**6.2 — Approve the transfer**
+> Approve that transfer request.
+
+✅ One confirmation line: `Approved transfer request: ...`
+
+---
+
+**6.3 — Verify transfer result**
+> List animals in Cambridge Care.
+
+✅ Both Luna and Fluffy appear.
+
+---
+
+**6.4 — Reject a transfer request**
+> Transfer Nemo from Boston Paws to Cambridge Care, then reject it.
+
+✅ Request creation succeeds. Rejection outputs: `Rejected transfer request: ...`
+
+---
+
+## Phase 7 — Vaccination Management (UC-07)
+
+**7.1 — Add vaccine types**
+> Add two vaccine types: Rabies for dogs, valid 365 days; Feline FVRCP for cats, valid 365 days.
+
+✅ Two confirmation lines: `Added vaccine type: Rabies (id=...)` and `Added vaccine type: Feline FVRCP (id=...)`
+
+---
+
+**7.2 — List vaccine types**
+> List all vaccine types.
+
+✅ Both Rabies and Feline FVRCP appear.
+
+---
+
+**7.3 — Record a vaccination**
+> Give Buddy the Rabies vaccine today.
+
+✅ One confirmation line: `Recorded vaccination: animal=..., type=Rabies, date=...`
+
+---
+
+**7.4 — Check overdue vaccinations**
+> Check whether Buddy has any overdue vaccinations.
+
+✅ Output confirms all vaccinations are current for Buddy.
+
+---
+
+**7.5 — Species mismatch error**
+> Try to give Luna the Rabies vaccine (which is for dogs only).
+
+✅ Error — species mismatch. Luna is a cat; Rabies is only applicable to dogs.
+
+---
+
+**7.6 — Update a vaccine type**
+> Rename Feline FVRCP to Cat FVRCP.
+
+✅ One confirmation line: `Updated vaccine type: Cat FVRCP (id=...)`
+
+---
+
+## Phase 8 — Audit Log (UC-08)
+
+**8.1 — View audit log**
+> Show the audit log.
+
+✅ A table with Timestamp, Staff, Action, and Target columns covering every operation performed in this session.
+
+---
+
+## Phase 9 — Error Cases
+
+**9.1 — Remove an animal without pending requests**
+> Delete Fluffy — Fluffy has no pending adoption requests.
+
+✅ One confirmation line: `Removed animal: ...`
+
+---
+
+**9.2 — Remove a shelter that still holds animals**
+> Try to delete Cambridge Care — it still has Luna inside.
+
+✅ Error — shelter still holds animals.
+
+---
+
+**9.3 — Look up a non-existent ID**
+> Look up shelter with ID "abc-123".
+
+✅ Error — not found.
+
+---
+
+## Pass Criteria
+
+- [ ] All ✅ steps produce the expected output
+- [ ] All error cases print a clear error message without crashing
+- [ ] `shelter audit log` shows the complete operation history
+- [ ] After restarting (re-running any list command), all data is still present

--- a/docs/test-live.md
+++ b/docs/test-live.md
@@ -44,7 +44,7 @@ shelter --version                                      # 验证 CLI 可用
 ✅ 期望：`Admitted dog: Max (id=..., shelter=...)`
 
 **对 Claude 说：**
-> 再往 Boston Paws 收容一只 2 岁的暹罗猫，叫 Luna，活跃度 LOW，室内猫。
+> 再往 Boston Paws 收容一只 2 岁的暹罗猫，叫 Luna，活跃度 LOW，室内猫，已绝育。
 
 ✅ 期望：`Admitted cat: Luna (id=..., shelter=...)`
 

--- a/docs/test-live.md
+++ b/docs/test-live.md
@@ -1,0 +1,241 @@
+# 实机测试计划（Claude Agent 执行）
+
+测试目的：在 demo 前验证系统全流程无误。由 Claude Code 作为 AI agent，解读自然语言并执行 `shelter` CLI 命令。
+
+**前置条件**（在项目根目录 `management-system-for-multi-shelter-animal-adoption/` 执行）：
+```bash
+./gradlew installDist                                  # 构建二进制
+export PATH="$PWD/build/install/shelter/bin:$PATH"    # 注册 shelter 命令
+rm -rf ~/shelter/data                                  # 清空历史数据，保证干净状态
+shelter --version                                      # 验证 CLI 可用
+```
+
+---
+
+## 阶段一：庇护所管理（UC-01）
+
+**对 Claude 说：**
+> 注册两个庇护所：第一个叫 "Boston Paws"，位于 Boston，容量 15；第二个叫 "Cambridge Care"，位于 Cambridge，容量 10。
+
+✅ 期望：两行 `Registered shelter: ... (id=...)` 输出
+
+**对 Claude 说：**
+> 列出所有庇护所。
+
+✅ 期望：显示两行记录，有 ID、Name、Location、Capacity 列
+
+**对 Claude 说：**
+> 把 Boston Paws 的容量改成 20。
+
+✅ 期望：`Updated shelter: Boston Paws (id=...)`
+
+**对 Claude 说：**
+> 试着删除 Boston Paws。
+
+✅ 期望：报错（因为后续会往里面放动物，此处可先跳过或验证空庇护所可删后重建）
+
+---
+
+## 阶段二：动物管理（UC-02）
+
+**对 Claude 说：**
+> 往 Boston Paws 收容一只 3 岁的拉布拉多犬，叫 Max，活跃度 HIGH。
+
+✅ 期望：`Admitted dog: Max (id=..., shelter=...)`
+
+**对 Claude 说：**
+> 再往 Boston Paws 收容一只 2 岁的暹罗猫，叫 Luna，活跃度 LOW，室内猫。
+
+✅ 期望：`Admitted cat: Luna (id=..., shelter=...)`
+
+**对 Claude 说：**
+> 往 Cambridge Care 收容一只 1 岁的荷兰垂耳兔，叫 Fluffy，活跃度 MEDIUM。
+
+✅ 期望：`Admitted rabbit: Fluffy (id=..., shelter=...)`
+
+**对 Claude 说：**
+> 往 Boston Paws 再收容一条热带鱼，叫 Nemo，品种 Clownfish，活跃度 LOW。
+
+✅ 期望：`Admitted fish: Nemo (id=..., shelter=...)`（species 显示 fish）
+
+**对 Claude 说：**
+> 列出 Boston Paws 里的所有动物。
+
+✅ 期望：Max、Luna、Nemo 出现，Fluffy 不出现
+
+**对 Claude 说：**
+> 把 Max 的名字改成 Buddy。
+
+✅ 期望：`Updated animal: Buddy (id=...)`
+
+**对 Claude 说：**
+> 列出所有动物（不过滤庇护所）。
+
+✅ 期望：Buddy、Luna、Fluffy、Nemo 全部出现
+
+---
+
+## 阶段三：领养人管理（UC-03）
+
+**对 Claude 说：**
+> 注册领养人 Alice，住 HOUSE_WITH_YARD，日程 HOME_MOST_OF_DAY，偏好 DOG，年龄范围 1 到 5 岁。
+
+✅ 期望：`Registered adopter: Alice (id=...)`
+
+**对 Claude 说：**
+> 注册领养人 Bob，住 APARTMENT，日程 AWAY_PART_OF_DAY，无特定偏好。
+
+✅ 期望：`Registered adopter: Bob (id=...)`
+
+**对 Claude 说：**
+> 列出所有领养人。
+
+✅ 期望：Alice 和 Bob 都出现
+
+**对 Claude 说：**
+> 把 Bob 的日程改成 HOME_MOST_OF_DAY。
+
+✅ 期望：`Updated adopter: Bob (id=...)`
+
+---
+
+## 阶段四：匹配（UC-04）
+
+**对 Claude 说：**
+> 为 Alice 在 Boston Paws 里做动物匹配。
+
+✅ 期望：显示 Rank/Animal ID/Name/Score 表格，Buddy 应该得分最高（狗+年龄符合）
+
+**对 Claude 说：**
+> 为 Buddy 匹配合适的领养人。
+
+✅ 期望：显示 Rank/Adopter ID/Name/Score 表格，Alice 应排名靠前
+
+---
+
+## 阶段五：领养流程（UC-05）
+
+**对 Claude 说：**
+> Alice 想领养 Buddy，提交申请。
+
+✅ 期望：`Submitted adoption request: id=... (adopter=..., animal=...)`
+
+**对 Claude 说：**
+> 批准这个领养申请。
+
+✅ 期望：`Approved adoption request: ...`
+
+**对 Claude 说：**
+> 列出 Boston Paws 的动物，看看 Buddy 状态。
+
+✅ 期望：Buddy 一行显示 `adopted`，其他动物显示 `available`
+
+**对 Claude 说：**
+> 再试一次为 Buddy 提交 Bob 的领养申请。
+
+✅ 期望：报错（动物已被领养）
+
+**对 Claude 说：**
+> Bob 想领养 Luna，提交申请，然后拒绝它。
+
+✅ 期望：submit 成功，reject 输出 `Rejected adoption request: ...`
+
+**对 Claude 说：**
+> Bob 再提交一个领养 Luna 的申请，然后取消。
+
+✅ 期望：submit 成功，cancel 输出 `Cancelled adoption request: ...`
+
+---
+
+## 阶段六：转移流程（UC-06）
+
+**对 Claude 说：**
+> 把 Luna 从 Boston Paws 转移到 Cambridge Care。
+
+✅ 期望：`Transfer request created: id=... (animal=..., Boston Paws → Cambridge Care)`
+
+**对 Claude 说：**
+> 批准这个转移请求。
+
+✅ 期望：`Approved transfer request: ...`
+
+**对 Claude 说：**
+> 列出 Cambridge Care 的动物。
+
+✅ 期望：Luna 和 Fluffy 都出现
+
+**对 Claude 说：**
+> 把 Nemo 从 Boston Paws 转移到 Cambridge Care，然后拒绝。
+
+✅ 期望：request 成功，reject 输出 `Rejected transfer request: ...`
+
+---
+
+## 阶段七：疫苗管理（UC-07）
+
+**对 Claude 说：**
+> 添加两种疫苗类型：Rabies，适用于 DOG，有效期 365 天；Feline FVRCP，适用于 CAT，有效期 365 天。
+
+✅ 期望：两行 `Added vaccine type: ...`
+
+**对 Claude 说：**
+> 列出所有疫苗类型。
+
+✅ 期望：显示 Rabies 和 Feline FVRCP
+
+**对 Claude 说：**
+> 给 Buddy 接种 Rabies 疫苗，日期今天。
+
+✅ 期望：`Recorded vaccination: animal=..., type=Rabies, date=...`
+
+**对 Claude 说：**
+> 检查 Buddy 有没有过期疫苗。
+
+✅ 期望：`All vaccinations are current for animal: ...`
+
+**对 Claude 说：**
+> 给 Luna 接种 Rabies（狗专用疫苗）。
+
+✅ 期望：报错（物种不匹配）
+
+**对 Claude 说：**
+> 把 Feline FVRCP 改名为 Cat FVRCP。
+
+✅ 期望：`Updated vaccine type: Cat FVRCP (id=...)`
+
+---
+
+## 阶段八：审计日志（UC-08）
+
+**对 Claude 说：**
+> 查看审计日志。
+
+✅ 期望：显示 Timestamp/Staff/Action/Target 表格，包含本次测试所有操作记录
+
+---
+
+## 阶段九：边界错误验证
+
+**对 Claude 说：**
+> 删除 Fluffy（Fluffy 没有 pending 申请，应该可以删）。
+
+✅ 期望：`Removed animal: ...`
+
+**对 Claude 说：**
+> 删除 Cambridge Care（里面还有 Luna，不能删）。
+
+✅ 期望：报错（shelter still holds animals）
+
+**对 Claude 说：**
+> 查询不存在的庇护所 ID "abc-123"。
+
+✅ 期望：报错（not found）
+
+---
+
+## 测试通过标准
+
+- [ ] 所有 ✅ 项输出符合预期
+- [ ] 所有错误场景正确报错，不崩溃
+- [ ] `shelter audit log` 显示完整操作历史
+- [ ] 重启后（重新执行任意 list 命令）数据仍然存在

--- a/docs/test-live.md
+++ b/docs/test-live.md
@@ -30,9 +30,9 @@ shelter --version                                      # 验证 CLI 可用
 ✅ 期望：`Updated shelter: Boston Paws (id=...)`
 
 **对 Claude 说：**
-> 试着删除 Boston Paws。
+> 删除 Boston Paws，然后重新注册一个同名庇护所（容量 20）。
 
-✅ 期望：报错（因为后续会往里面放动物，此处可先跳过或验证空庇护所可删后重建）
+✅ 期望：先输出 `Removed shelter: ...`，再输出 `Registered shelter: Boston Paws (id=...)`（空庇护所可以正常删除；重建是为了后续阶段继续使用）
 
 ---
 
@@ -78,12 +78,12 @@ shelter --version                                      # 验证 CLI 可用
 ## 阶段三：领养人管理（UC-03）
 
 **对 Claude 说：**
-> 注册领养人 Alice，住 HOUSE_WITH_YARD，日程 HOME_MOST_OF_DAY，偏好 DOG，年龄范围 1 到 5 岁。
+> 注册领养人 Alice，住 HOUSE_WITH_YARD，日程 HOME_MOST_OF_DAY，偏好 DOG，偏好品种 Labrador，活跃度偏好 HIGH，要求已接种疫苗，年龄范围 1 到 5 岁。
 
 ✅ 期望：`Registered adopter: Alice (id=...)`
 
 **对 Claude 说：**
-> 注册领养人 Bob，住 APARTMENT，日程 AWAY_PART_OF_DAY，无特定偏好。
+> 注册领养人 Bob，住 APARTMENT，日程 AWAY_PART_OF_DAY，偏好 CAT，活跃度偏好 LOW，不要求接种疫苗，年龄范围不限。
 
 ✅ 期望：`Registered adopter: Bob (id=...)`
 
@@ -93,7 +93,7 @@ shelter --version                                      # 验证 CLI 可用
 ✅ 期望：Alice 和 Bob 都出现
 
 **对 Claude 说：**
-> 把 Bob 的日程改成 HOME_MOST_OF_DAY。
+> 把 Bob 的日程改成 HOME_MOST_OF_DAY，同时把他的活跃度偏好改成 MEDIUM。
 
 ✅ 期望：`Updated adopter: Bob (id=...)`
 

--- a/scripts/init-demo.sh
+++ b/scripts/init-demo.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SHELTER_HOME="${SHELTER_HOME:-$HOME/shelter}"
+
+echo "==> Removing existing shelter home: $SHELTER_HOME"
+rm -rf "$SHELTER_HOME"
+
+echo "==> Building project (installDist)"
+cd "$PROJECT_ROOT"
+./gradlew installDist
+
+echo "==> Generating fresh shelter home via first CLI invocation"
+export PATH="$PROJECT_ROOT/build/install/shelter/bin:$PATH"
+shelter --version >/dev/null
+
+echo "==> Done. Shelter home initialized at: $SHELTER_HOME"
+echo "==> Entering $SHELTER_HOME (interactive shell with shelter on PATH)"
+cd "$SHELTER_HOME"
+export PATH="$PROJECT_ROOT/build/install/shelter/bin:$PATH"
+exec "$SHELL"

--- a/src/main/java/shelter/application/AnimalApplicationService.java
+++ b/src/main/java/shelter/application/AnimalApplicationService.java
@@ -94,14 +94,17 @@ public interface AnimalApplicationService {
      * Updates an existing animal's mutable fields with the provided values.
      * Only non-null parameters are applied; omitted (null) fields retain their current values.
      * Breed and birthday are immutable and cannot be changed after admission.
+     * The {@code neutered} flag is only applied when the animal is a {@link Dog} or {@link Cat};
+     * passing a non-null value for other species has no effect.
      * Throws an exception if the animal is not found.
      *
      * @param animalId      the ID of the animal to update; must not be null or blank
      * @param name          the new name, or {@code null} to keep the current value
      * @param activityLevel the new activity level, or {@code null} to keep the current value
+     * @param neutered      the new neutered status, or {@code null} to keep the current value
      * @return the updated {@link Animal}
      */
-    Animal updateAnimal(String animalId, String name, ActivityLevel activityLevel);
+    Animal updateAnimal(String animalId, String name, ActivityLevel activityLevel, Boolean neutered);
 
     /**
      * Removes an animal from the system by ID.

--- a/src/main/java/shelter/application/AnimalApplicationService.java
+++ b/src/main/java/shelter/application/AnimalApplicationService.java
@@ -1,5 +1,6 @@
 package shelter.application;
 
+import shelter.application.model.AnimalView;
 import shelter.domain.ActivityLevel;
 import shelter.domain.Animal;
 import shelter.domain.Cat;
@@ -105,6 +106,17 @@ public interface AnimalApplicationService {
      * @return the updated {@link Animal}
      */
     Animal updateAnimal(String animalId, String name, ActivityLevel activityLevel, Boolean neutered);
+
+    /**
+     * Returns a list of {@link AnimalView} objects, each pairing an animal with its shelter's
+     * display name. Filters by shelter when {@code shelterId} is provided, or returns all animals
+     * system-wide when {@code shelterId} is {@code null}. The shelter name is resolved by the
+     * Application layer so that callers do not need to perform cross-domain lookups.
+     *
+     * @param shelterId the ID of the shelter to filter by, or {@code null} for all animals
+     * @return a list of enriched animal views matching the filter
+     */
+    List<AnimalView> listAnimalsWithShelterName(String shelterId);
 
     /**
      * Removes an animal from the system by ID.

--- a/src/main/java/shelter/application/impl/AdopterApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/AdopterApplicationServiceImpl.java
@@ -7,7 +7,10 @@ import shelter.domain.AdopterPreferences;
 import shelter.domain.DailySchedule;
 import shelter.domain.LivingSpace;
 import shelter.domain.Species;
+import shelter.domain.AdoptionRequest;
+import shelter.domain.RequestStatus;
 import shelter.service.AdopterService;
+import shelter.service.AdoptionService;
 import shelter.service.AuditService;
 
 import java.util.List;
@@ -21,22 +24,27 @@ import java.util.List;
 public class AdopterApplicationServiceImpl implements AdopterApplicationService {
 
     private final AdopterService adopterService;
+    private final AdoptionService adoptionService;
     private final AuditService<Adopter> auditService;
 
     /**
      * Constructs an AdopterApplicationServiceImpl with the required service dependencies.
-     * Both services are mandatory; neither may be null.
+     * All three services are mandatory; none may be null.
      *
-     * @param adopterService the service for adopter persistence; must not be null
-     * @param auditService   the service for recording audit log entries; must not be null
-     * @throws IllegalArgumentException if either argument is null
+     * @param adopterService  the service for adopter persistence; must not be null
+     * @param adoptionService the service for querying adoption requests; must not be null
+     * @param auditService    the service for recording audit log entries; must not be null
+     * @throws IllegalArgumentException if any argument is null
      */
     public AdopterApplicationServiceImpl(AdopterService adopterService,
+                                          AdoptionService adoptionService,
                                           AuditService<Adopter> auditService) {
-        if (adopterService == null) throw new IllegalArgumentException("AdopterService must not be null.");
-        if (auditService == null)   throw new IllegalArgumentException("AuditService must not be null.");
-        this.adopterService = adopterService;
-        this.auditService   = auditService;
+        if (adopterService == null)  throw new IllegalArgumentException("AdopterService must not be null.");
+        if (adoptionService == null) throw new IllegalArgumentException("AdoptionService must not be null.");
+        if (auditService == null)    throw new IllegalArgumentException("AuditService must not be null.");
+        this.adopterService  = adopterService;
+        this.adoptionService = adoptionService;
+        this.auditService    = auditService;
     }
 
     /**
@@ -104,11 +112,20 @@ public class AdopterApplicationServiceImpl implements AdopterApplicationService 
 
     /**
      * {@inheritDoc}
-     * Throws if the adopter is not found.
+     * Throws if the adopter is not found or has a pending adoption request.
      */
     @Override
     public void removeAdopter(String adopterId) {
         Adopter adopter = adopterService.findById(adopterId);
+
+        // Guard: an adopter with a pending adoption request cannot be removed
+        boolean hasPending = adoptionService.getRequestsByAdopter(adopter).stream()
+                .anyMatch(r -> r.getStatus() == RequestStatus.PENDING);
+        if (hasPending) {
+            throw new IllegalStateException(
+                    "Cannot remove adopter with a pending adoption request: " + adopterId);
+        }
+
         adopterService.remove(adopter);
         auditService.log("removed adopter", adopter);
     }

--- a/src/main/java/shelter/application/impl/AnimalApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/AnimalApplicationServiceImpl.java
@@ -8,7 +8,6 @@ import shelter.domain.Dog;
 import shelter.domain.Other;
 import shelter.domain.Rabbit;
 import shelter.domain.Shelter;
-import shelter.domain.AdoptionRequest;
 import shelter.domain.RequestStatus;
 import shelter.service.AdoptionService;
 import shelter.service.AnimalService;
@@ -148,15 +147,22 @@ public class AnimalApplicationServiceImpl implements AnimalApplicationService {
     /**
      * {@inheritDoc}
      * Fetches the current animal, applies only the non-null fields via setters, then persists.
-     * Breed and birthday are immutable; only name and activity level can be changed.
+     * Breed and birthday are immutable; only name, activity level, and neutered status can be changed.
+     * The neutered flag is silently ignored for species that do not support it (Rabbit, Other).
      */
     @Override
-    public Animal updateAnimal(String animalId, String name, ActivityLevel activityLevel) {
+    public Animal updateAnimal(String animalId, String name, ActivityLevel activityLevel, Boolean neutered) {
         Animal existing = animalService.findById(animalId);
 
         // Apply only the provided (non-null) fields via setters
         if (name != null) existing.setName(name);
         if (activityLevel != null) existing.setActivityLevel(activityLevel);
+
+        // Apply neutered status only for species that support it
+        if (neutered != null) {
+            if (existing instanceof Dog dog) dog.setNeutered(neutered);
+            else if (existing instanceof Cat cat) cat.setNeutered(neutered);
+        }
 
         animalService.update(existing);
         auditService.log("updated animal", existing);

--- a/src/main/java/shelter/application/impl/AnimalApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/AnimalApplicationServiceImpl.java
@@ -8,6 +8,9 @@ import shelter.domain.Dog;
 import shelter.domain.Other;
 import shelter.domain.Rabbit;
 import shelter.domain.Shelter;
+import shelter.domain.AdoptionRequest;
+import shelter.domain.RequestStatus;
+import shelter.service.AdoptionService;
 import shelter.service.AnimalService;
 import shelter.service.AuditService;
 import shelter.service.ShelterService;
@@ -25,26 +28,31 @@ public class AnimalApplicationServiceImpl implements AnimalApplicationService {
 
     private final AnimalService animalService;
     private final ShelterService shelterService;
+    private final AdoptionService adoptionService;
     private final AuditService<Animal> auditService;
 
     /**
      * Constructs an AnimalApplicationServiceImpl with the required service dependencies.
-     * All three services are mandatory; none may be null.
+     * All four services are mandatory; none may be null.
      *
-     * @param animalService  the service for animal persistence; must not be null
-     * @param shelterService the service for shelter lookups and capacity checks; must not be null
-     * @param auditService   the service for recording audit log entries; must not be null
+     * @param animalService   the service for animal persistence; must not be null
+     * @param shelterService  the service for shelter lookups and capacity checks; must not be null
+     * @param adoptionService the service for querying adoption requests; must not be null
+     * @param auditService    the service for recording audit log entries; must not be null
      * @throws IllegalArgumentException if any argument is null
      */
     public AnimalApplicationServiceImpl(AnimalService animalService,
                                         ShelterService shelterService,
+                                        AdoptionService adoptionService,
                                         AuditService<Animal> auditService) {
-        if (animalService == null)  throw new IllegalArgumentException("AnimalService must not be null.");
-        if (shelterService == null) throw new IllegalArgumentException("ShelterService must not be null.");
-        if (auditService == null)   throw new IllegalArgumentException("AuditService must not be null.");
-        this.animalService  = animalService;
-        this.shelterService = shelterService;
-        this.auditService   = auditService;
+        if (animalService == null)   throw new IllegalArgumentException("AnimalService must not be null.");
+        if (shelterService == null)  throw new IllegalArgumentException("ShelterService must not be null.");
+        if (adoptionService == null) throw new IllegalArgumentException("AdoptionService must not be null.");
+        if (auditService == null)    throw new IllegalArgumentException("AuditService must not be null.");
+        this.animalService   = animalService;
+        this.shelterService  = shelterService;
+        this.adoptionService = adoptionService;
+        this.auditService    = auditService;
     }
 
     /**
@@ -157,11 +165,20 @@ public class AnimalApplicationServiceImpl implements AnimalApplicationService {
 
     /**
      * {@inheritDoc}
-     * Throws if the animal is not found.
+     * Throws if the animal is not found or has a pending adoption request.
      */
     @Override
     public void removeAnimal(String animalId) {
         Animal animal = animalService.findById(animalId);
+
+        // Guard: an animal with a pending adoption request cannot be removed
+        boolean hasPending = adoptionService.getRequestsByAnimal(animal).stream()
+                .anyMatch(r -> r.getStatus() == RequestStatus.PENDING);
+        if (hasPending) {
+            throw new IllegalStateException(
+                    "Cannot remove animal with a pending adoption request: " + animalId);
+        }
+
         animalService.remove(animal);
         auditService.log("removed animal", animal);
     }

--- a/src/main/java/shelter/application/impl/AnimalApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/AnimalApplicationServiceImpl.java
@@ -1,6 +1,7 @@
 package shelter.application.impl;
 
 import shelter.application.AnimalApplicationService;
+import shelter.application.model.AnimalView;
 import shelter.domain.ActivityLevel;
 import shelter.domain.Animal;
 import shelter.domain.Cat;
@@ -142,6 +143,29 @@ public class AnimalApplicationServiceImpl implements AnimalApplicationService {
         }
         Shelter shelter = shelterService.findById(shelterId);
         return animalService.getAnimalsByShelter(shelter);
+    }
+
+    /**
+     * {@inheritDoc}
+     * Delegates to {@link #listAnimals(String)} to obtain the base animal list, then resolves
+     * each animal's shelter name via {@code shelterService} and wraps the pair in an {@link AnimalView}.
+     * The shelter name lookup is centralised here so the CLI layer needs no knowledge of shelters.
+     */
+    @Override
+    public List<AnimalView> listAnimalsWithShelterName(String shelterId) {
+        List<Animal> animals = listAnimals(shelterId);
+        List<AnimalView> views = new java.util.ArrayList<>();
+        for (Animal a : animals) {
+            String name;
+            try {
+                name = shelterService.findById(a.getShelterId()).getName();
+            } catch (Exception e) {
+                // Fall back to the raw ID if the shelter cannot be resolved
+                name = a.getShelterId();
+            }
+            views.add(new AnimalView(a, name));
+        }
+        return views;
     }
 
     /**

--- a/src/main/java/shelter/application/model/AnimalView.java
+++ b/src/main/java/shelter/application/model/AnimalView.java
@@ -1,0 +1,99 @@
+package shelter.application.model;
+
+import shelter.domain.Animal;
+
+import java.util.Objects;
+
+/**
+ * A read-only view of an animal enriched with its shelter's display name.
+ * Produced by the Application layer so that the CLI does not need to perform
+ * cross-domain lookups (e.g. calling ShelterService from inside a list command).
+ * The shelter name is resolved once by the Application layer and bundled here.
+ */
+public class AnimalView {
+
+    private final Animal animal;
+    private final String shelterName;
+
+    /**
+     * Constructs an AnimalView pairing the given animal with its resolved shelter name.
+     * Neither argument may be null.
+     *
+     * @param animal      the animal to wrap; must not be null
+     * @param shelterName the display name of the shelter the animal belongs to; must not be null
+     * @throws IllegalArgumentException if either argument is null
+     */
+    public AnimalView(Animal animal, String shelterName) {
+        if (animal == null)      throw new IllegalArgumentException("Animal must not be null.");
+        if (shelterName == null) throw new IllegalArgumentException("Shelter name must not be null.");
+        this.animal      = animal;
+        this.shelterName = shelterName;
+    }
+
+    /**
+     * Copy constructor that creates a new AnimalView identical to {@code other}.
+     * Both the animal reference and the shelter name string are copied by value.
+     *
+     * @param other the AnimalView to copy; must not be null
+     */
+    public AnimalView(AnimalView other) {
+        this(other.animal, other.shelterName);
+    }
+
+    /**
+     * Returns the wrapped animal.
+     * All animal-specific getters (ID, name, species, etc.) are accessible through this object.
+     *
+     * @return the animal; never null
+     */
+    public Animal getAnimal() {
+        return animal;
+    }
+
+    /**
+     * Returns the display name of the shelter this animal currently belongs to.
+     * Resolved at construction time by the Application layer.
+     *
+     * @return the shelter name; never null
+     */
+    public String getShelterName() {
+        return shelterName;
+    }
+
+    /**
+     * Returns a string representation showing the animal name and shelter name.
+     * Intended for logging and debugging; not for user-facing output.
+     *
+     * @return a human-readable description of this view
+     */
+    @Override
+    public String toString() {
+        return "AnimalView[animal=" + animal.getName() + ", shelter=" + shelterName + "]";
+    }
+
+    /**
+     * Returns true if the other object is an AnimalView with the same animal and shelter name.
+     * Equality is value-based since this is a read-only view object with no unique identity.
+     *
+     * @param o the object to compare
+     * @return true if both fields are equal
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AnimalView other)) return false;
+        return Objects.equals(animal, other.animal)
+                && Objects.equals(shelterName, other.shelterName);
+    }
+
+    /**
+     * Returns a hash code based on the wrapped animal and shelter name.
+     * Consistent with {@link #equals(Object)}.
+     *
+     * @return the hash code
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(animal, shelterName);
+    }
+}

--- a/src/main/java/shelter/cli/AdopterCmd.java
+++ b/src/main/java/shelter/cli/AdopterCmd.java
@@ -42,15 +42,16 @@ public class AdopterCmd implements Runnable {
     // -------------------------------------------------------------------------
 
     /**
-     * Lists all registered adopters with their IDs, names, living spaces, and schedules.
+     * Lists all registered adopters with their IDs, names, living spaces, schedules,
+     * and all preference fields. Fields with no preference set are displayed as "any".
      * Prints a message if no adopters have been registered.
      */
     @Command(name = "list", description = "List all adopters", mixinStandardHelpOptions = true)
     static class ListCmd implements Runnable {
 
         /**
-         * Executes the list operation and prints each adopter's summary to stdout.
-         * Prints a message if no adopters are found.
+         * Executes the list operation and prints each adopter's full details to stdout,
+         * including all preference fields. Prints a message if no adopters are found.
          */
         @Override
         public void run() {
@@ -59,12 +60,23 @@ public class AdopterCmd implements Runnable {
                 System.out.println("No adopters registered.");
                 return;
             }
-            System.out.printf("%-36s  %-15s  %-18s  %-22s%n",
-                    "ID", "Name", "Living Space", "Schedule");
-            System.out.println("-".repeat(100));
+            System.out.printf("%-36s  %-12s  %-17s  %-20s  %-8s  %-12s  %-8s  %-10s  %-7s  %-7s%n",
+                    "ID", "Name", "Living Space", "Schedule",
+                    "Species", "Breed", "Activity", "Vaccinated", "Min Age", "Max Age");
+            System.out.println("-".repeat(155));
             for (Adopter a : adopters) {
-                System.out.printf("%-36s  %-15s  %-18s  %-22s%n",
-                        a.getId(), a.getName(), a.getLivingSpace(), a.getDailySchedule());
+                // Resolve preference fields; display "any" when no preference is set
+                shelter.domain.AdopterPreferences p = a.getPreferences();
+                String species    = p.getPreferredSpecies()       != null ? p.getPreferredSpecies().name()       : "any";
+                String breed      = p.getPreferredBreed()         != null ? p.getPreferredBreed()                : "any";
+                String activity   = p.getPreferredActivityLevel() != null ? p.getPreferredActivityLevel().name() : "any";
+                String vaccinated = p.getRequiresVaccinated()     != null ? p.getRequiresVaccinated().toString() : "any";
+                String minAge     = p.getMinAge()                 != null ? p.getMinAge().toString()             : "any";
+                String maxAge     = p.getMaxAge()                 != null ? p.getMaxAge().toString()             : "any";
+
+                System.out.printf("%-36s  %-12s  %-17s  %-20s  %-8s  %-12s  %-8s  %-10s  %-7s  %-7s%n",
+                        a.getId(), a.getName(), a.getLivingSpace(), a.getDailySchedule(),
+                        species, breed, activity, vaccinated, minAge, maxAge);
             }
         }
     }

--- a/src/main/java/shelter/cli/AnimalCmd.java
+++ b/src/main/java/shelter/cli/AnimalCmd.java
@@ -4,7 +4,9 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import shelter.domain.ActivityLevel;
 import shelter.domain.Animal;
+import shelter.domain.Cat;
 import shelter.domain.Dog;
+import shelter.domain.Other;
 import shelter.domain.Rabbit;
 
 import java.time.LocalDate;
@@ -55,6 +57,7 @@ public class AnimalCmd implements Runnable {
 
         /**
          * Executes the list operation and prints each animal's details to stdout.
+         * All columns are always shown; species-specific fields display "-" when not applicable.
          * Prints a message if no animals are found.
          */
         @Override
@@ -65,14 +68,31 @@ public class AnimalCmd implements Runnable {
                     System.out.println("No animals found.");
                     return;
                 }
-                System.out.printf("%-36s  %-10s  %-12s  %-20s  %-4s  %-8s  %s%n",
-                        "ID", "Species", "Name", "Breed", "Age", "Activity", "Status");
-                System.out.println("-".repeat(110));
+                System.out.printf("%-36s  %-8s  %-12s  %-18s  %-3s  %-8s  %-8s  %-7s  %-7s  %-6s  %s%n",
+                        "ID", "Species", "Name", "Breed", "Age", "Activity",
+                        "Neutered", "Indoor", "Size", "Fur", "Status");
+                System.out.println("-".repeat(130));
                 for (Animal a : animals) {
+                    // Resolve species-specific fields; use "N/A" when not applicable to this species
+                    String neutered = "N/A";
+                    String indoor   = "N/A";
+                    String size     = "N/A";
+                    String fur      = "N/A";
+                    if (a instanceof Dog dog) {
+                        neutered = String.valueOf(dog.isNeutered());
+                        size     = dog.getSize().name();
+                    } else if (a instanceof Cat cat) {
+                        neutered = String.valueOf(cat.isNeutered());
+                        indoor   = String.valueOf(cat.isIndoor());
+                    } else if (a instanceof Rabbit rabbit) {
+                        fur = rabbit.getFurLength().name();
+                    }
+
                     String status = a.isAvailable() ? "available" : "adopted";
-                    System.out.printf("%-36s  %-10s  %-12s  %-20s  %-4d  %-8s  %s%n",
+                    System.out.printf("%-36s  %-8s  %-12s  %-18s  %-3d  %-8s  %-8s  %-7s  %-7s  %-6s  %s%n",
                             a.getId(), a.getSpecies(), a.getName(), a.getBreed(),
-                            a.getAge(), a.getActivityLevel(), status);
+                            a.getAge(), a.getActivityLevel(),
+                            neutered, indoor, size, fur, status);
                 }
             } catch (Exception e) {
                 System.err.println("Error: " + e.getMessage());

--- a/src/main/java/shelter/cli/AnimalCmd.java
+++ b/src/main/java/shelter/cli/AnimalCmd.java
@@ -197,7 +197,8 @@ public class AnimalCmd implements Runnable {
 
     /**
      * Updates an existing animal's mutable fields.
-     * Breed and birthday are immutable; only name and activity level can be changed.
+     * Breed and birthday are immutable; name, activity level, and neutered status can be changed.
+     * The {@code --neutered} option accepts {@code true} or {@code false} and applies only to dogs and cats.
      */
     @Command(name = "update", description = "Update an animal's mutable details",
              mixinStandardHelpOptions = true)
@@ -215,6 +216,11 @@ public class AnimalCmd implements Runnable {
         @Option(names = "--activity", description = "New activity level (omit to keep current)")
         private ActivityLevel activityLevel;
 
+        /** The new neutered status (true/false); omit to keep current value. Applies to dogs and cats only. */
+        @Option(names = "--neutered", arity = "1",
+                description = "Neutered status: true or false (dogs/cats only; omit to keep current)")
+        private Boolean neutered;
+
         /**
          * Executes the update and prints a confirmation message with the updated values.
          * Prints an error message if the animal is not found.
@@ -222,7 +228,7 @@ public class AnimalCmd implements Runnable {
         @Override
         public void run() {
             try {
-                Animal a = AppContext.get().animalApp().updateAnimal(id, name, activityLevel);
+                Animal a = AppContext.get().animalApp().updateAnimal(id, name, activityLevel, neutered);
                 System.out.printf("Updated animal: %s (id=%s)%n", a.getName(), a.getId());
             } catch (Exception e) {
                 System.err.println("Error: " + e.getMessage());

--- a/src/main/java/shelter/cli/AnimalCmd.java
+++ b/src/main/java/shelter/cli/AnimalCmd.java
@@ -2,11 +2,11 @@ package shelter.cli;
 
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import shelter.application.model.AnimalView;
 import shelter.domain.ActivityLevel;
 import shelter.domain.Animal;
 import shelter.domain.Cat;
 import shelter.domain.Dog;
-import shelter.domain.Other;
 import shelter.domain.Rabbit;
 
 import java.time.LocalDate;
@@ -57,22 +57,25 @@ public class AnimalCmd implements Runnable {
 
         /**
          * Executes the list operation and prints each animal's details to stdout.
-         * All columns are always shown; species-specific fields display "-" when not applicable.
+         * All columns are always shown; species-specific fields display "N/A" when not applicable.
+         * The Shelter column shows the shelter name resolved by the Application layer.
          * Prints a message if no animals are found.
          */
         @Override
         public void run() {
             try {
-                List<Animal> animals = AppContext.get().animalApp().listAnimals(shelterId);
-                if (animals.isEmpty()) {
+                List<AnimalView> views = AppContext.get().animalApp().listAnimalsWithShelterName(shelterId);
+                if (views.isEmpty()) {
                     System.out.println("No animals found.");
                     return;
                 }
-                System.out.printf("%-36s  %-8s  %-12s  %-18s  %-3s  %-8s  %-8s  %-7s  %-7s  %-6s  %s%n",
+                System.out.printf("%-36s  %-8s  %-12s  %-18s  %-3s  %-8s  %-8s  %-7s  %-7s  %-6s  %-16s  %s%n",
                         "ID", "Species", "Name", "Breed", "Age", "Activity",
-                        "Neutered", "Indoor", "Size", "Fur", "Status");
-                System.out.println("-".repeat(130));
-                for (Animal a : animals) {
+                        "Neutered", "Indoor", "Size", "Fur", "Shelter", "Status");
+                System.out.println("-".repeat(148));
+                for (AnimalView v : views) {
+                    Animal a = v.getAnimal();
+
                     // Resolve species-specific fields; use "N/A" when not applicable to this species
                     String neutered = "N/A";
                     String indoor   = "N/A";
@@ -89,10 +92,10 @@ public class AnimalCmd implements Runnable {
                     }
 
                     String status = a.isAvailable() ? "available" : "adopted";
-                    System.out.printf("%-36s  %-8s  %-12s  %-18s  %-3d  %-8s  %-8s  %-7s  %-7s  %-6s  %s%n",
+                    System.out.printf("%-36s  %-8s  %-12s  %-18s  %-3d  %-8s  %-8s  %-7s  %-7s  %-6s  %-16s  %s%n",
                             a.getId(), a.getSpecies(), a.getName(), a.getBreed(),
                             a.getAge(), a.getActivityLevel(),
-                            neutered, indoor, size, fur, status);
+                            neutered, indoor, size, fur, v.getShelterName(), status);
                 }
             } catch (Exception e) {
                 System.err.println("Error: " + e.getMessage());

--- a/src/main/java/shelter/cli/Main.java
+++ b/src/main/java/shelter/cli/Main.java
@@ -3,12 +3,13 @@ package shelter.cli;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import shelter.startup.SystemStartupImpl;
+import java.nio.file.Path;
 
 /**
  * Entry point for the {@code shelter} CLI tool.
  * Registers all top-level subcommand groups and delegates execution to Picocli.
  * On startup, {@link SystemStartupImpl} initializes all repositories and services
- * from {@code ~/shelter/data/} before command dispatch.
+ * from the directory specified by the {@code SHELTER_HOME} environment variable, or {@code ~/shelter} by default.
  */
 @Command(
         name = "shelter",
@@ -46,7 +47,11 @@ public class Main implements Runnable {
      * @param args the CLI arguments passed from the operating system
      */
     public static void main(String[] args) {
-        new SystemStartupImpl().initialize();
+        String shelterHomeEnv = System.getenv("SHELTER_HOME");
+        Path shelterHome = shelterHomeEnv != null
+                ? Path.of(shelterHomeEnv)
+                : Path.of(System.getProperty("user.home"), "shelter");
+        new SystemStartupImpl(shelterHome).initialize();
         int exitCode = new CommandLine(new Main()).execute(args);
         System.exit(exitCode);
     }

--- a/src/main/java/shelter/startup/ApplicationGraph.java
+++ b/src/main/java/shelter/startup/ApplicationGraph.java
@@ -167,9 +167,9 @@ public class ApplicationGraph {
         ExplanationService explanationService = new MockExplanationService();
 
         AnimalApplicationService animalAppService =
-                new AnimalApplicationServiceImpl(animalService, shelterService, animalAudit);
+                new AnimalApplicationServiceImpl(animalService, shelterService, adoptionService, animalAudit);
         AdopterApplicationService adopterAppService =
-                new AdopterApplicationServiceImpl(adopterService, adopterAudit);
+                new AdopterApplicationServiceImpl(adopterService, adoptionService, adopterAudit);
         ShelterApplicationService shelterAppService =
                 new ShelterApplicationServiceImpl(shelterService, shelterAudit);
         AdoptionApplicationService adoptionAppService =

--- a/src/main/java/shelter/startup/WorkdirBootstrapper.java
+++ b/src/main/java/shelter/startup/WorkdirBootstrapper.java
@@ -40,6 +40,11 @@ public class WorkdirBootstrapper {
             automatically follow up with `approve`, `reject`, or `cancel`. Stop after creation
             and wait for an explicit instruction before running the next step.
 
+            **Always render results as tables with all fields.** Whenever you print, list, or
+            display any data returned by a `shelter` command, format the output as a table
+            (markdown table is fine) and include every field returned — do not omit, summarize,
+            or hide any column, even if the value is `N/A`, `any`, or empty.
+
             ## Project Context
 
             This directory is the runtime work directory for a Java multi-shelter animal adoption

--- a/src/main/java/shelter/startup/WorkdirBootstrapper.java
+++ b/src/main/java/shelter/startup/WorkdirBootstrapper.java
@@ -22,6 +22,24 @@ public class WorkdirBootstrapper {
     private static final String CLAUDE_TEMPLATE = """
             # CLAUDE.md - Shelter CLI Demo Context
 
+            ## Agent Behavior Rules (enforced during demo)
+
+            **Language: English only.** All responses must be in English regardless of the
+            language the user speaks. Do not switch to any other language.
+
+            **Ignore personal memory.** Do not apply, cite, or reference any memory stored
+            about the user (e.g. in ~/.claude/). Respond only based on the current conversation
+            and this CLAUDE.md file.
+
+            **Deletion requires confirmation.** Before executing any `remove` command
+            (shelter remove, animal remove, adopter remove, vaccine type remove), ask the user
+            to confirm. Do not proceed until the user explicitly says yes.
+
+            **Approval-step commands: submit only, then wait.** When the user asks to submit
+            an adoption or transfer request, only run the `submit` / `request` command. Do NOT
+            automatically follow up with `approve`, `reject`, or `cancel`. Stop after creation
+            and wait for an explicit instruction before running the next step.
+
             ## Project Context
 
             This directory is the runtime work directory for a Java multi-shelter animal adoption
@@ -48,15 +66,20 @@ public class WorkdirBootstrapper {
 
             Animal:
             - `shelter animal list [--shelter <shelter-id>]`
+              (columns: ID / Species / Name / Breed / Age / Activity / Neutered / Indoor / Size / Fur / Shelter / Status)
+              (species-specific columns show N/A when not applicable; unset fields show their current value)
             - `shelter animal admit --species dog --name <name> --breed <breed> (--birthday <yyyy-mm-dd> | --age <years>) --activity <LOW|MEDIUM|HIGH> --shelter <shelter-id> [--size <SMALL|MEDIUM|LARGE>] [--neutered]`
             - `shelter animal admit --species cat --name <name> --breed <breed> (--birthday <yyyy-mm-dd> | --age <years>) --activity <LOW|MEDIUM|HIGH> --shelter <shelter-id> [--indoor] [--neutered]`
             - `shelter animal admit --species rabbit --name <name> --breed <breed> (--birthday <yyyy-mm-dd> | --age <years>) --activity <LOW|MEDIUM|HIGH> --shelter <shelter-id> [--fur <SHORT|LONG>]`
             - `shelter animal admit --species other --name <name> --breed <description> (--birthday <yyyy-mm-dd> | --age <years>) --activity <LOW|MEDIUM|HIGH> --shelter <shelter-id> [--species-name <name>]`
-            - `shelter animal update --id <animal-id> [--name <name>] [--activity <LOW|MEDIUM|HIGH>]`
+            - `shelter animal update --id <animal-id> [--name <name>] [--activity <LOW|MEDIUM|HIGH>] [--neutered <true|false>]`
+              (--neutered applies to dogs and cats only; ignored for rabbit/other)
             - `shelter animal remove --id <animal-id>`
 
             Adopter:
             - `shelter adopter list`
+              (columns: ID / Name / Living Space / Schedule / Species / Breed / Activity / Vaccinated / Min Age / Max Age)
+              (unset preference fields show "any")
             - `shelter adopter register --name <name> --space <APARTMENT|HOUSE_NO_YARD|HOUSE_WITH_YARD> --schedule <HOME_MOST_OF_DAY|AWAY_PART_OF_DAY|AWAY_MOST_OF_DAY> [--species <DOG|CAT|RABBIT|OTHER>] [--breed <breed>] [--activity <LOW|MEDIUM|HIGH>] [--requires-vaccinated <true|false>] [--min-age <years>] [--max-age <years>]`
             - `shelter adopter update --id <adopter-id> [--name <name>] [--space <APARTMENT|HOUSE_NO_YARD|HOUSE_WITH_YARD>] [--schedule <HOME_MOST_OF_DAY|AWAY_PART_OF_DAY|AWAY_MOST_OF_DAY>] [--species <DOG|CAT|RABBIT|OTHER>] [--breed <breed>] [--activity <LOW|MEDIUM|HIGH>] [--requires-vaccinated <true|false>] [--min-age <years>] [--max-age <years>]`
             - `shelter adopter remove --id <adopter-id>`
@@ -92,15 +115,10 @@ public class WorkdirBootstrapper {
 
             The user may speak in natural language. Translate their intent into one or more
             `shelter` CLI calls. Always list shelters, adopters, animals, vaccine types, or
-            requests first if you need an ID. Always ask for confirmation before destructive
-            operations such as `remove`, `reject`, or `cancel`.
+            requests first if you need an ID.
 
             After running any shelter match command, use the ranked output as the source of truth
-            and explain the top match to the user in natural language. If the match table alone
-            does not show enough context, look up the relevant animal, adopter, shelter, or
-            vaccination records before explaining. Mention score, species, breed, age, activity
-            level, living situation, schedule, and vaccination preferences only when they are
-            available from CLI output or persisted data; do not invent missing details.
+            and explain the top match to the user in natural language.
 
             ## Data Directory
 

--- a/src/test/java/shelter/application/AdopterApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AdopterApplicationServiceImplTest.java
@@ -6,6 +6,7 @@ import shelter.application.impl.AdopterApplicationServiceImpl;
 import shelter.domain.*;
 import shelter.exception.EntityNotFoundException;
 import shelter.service.AdopterService;
+import shelter.service.AdoptionService;
 import shelter.service.AuditService;
 import shelter.service.model.AuditEntry;
 
@@ -25,14 +26,16 @@ class AdopterApplicationServiceImplTest {
     // -------------------------------------------------------------------------
 
     private StubAdopterService adopterService;
+    private StubAdoptionService adoptionService;
     private SpyAuditService<Adopter> auditService;
     private AdopterApplicationServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        adopterService = new StubAdopterService();
-        auditService   = new SpyAuditService<>();
-        service        = new AdopterApplicationServiceImpl(adopterService, auditService);
+        adopterService  = new StubAdopterService();
+        adoptionService = new StubAdoptionService();
+        auditService    = new SpyAuditService<>();
+        service         = new AdopterApplicationServiceImpl(adopterService, adoptionService, auditService);
     }
 
     // -------------------------------------------------------------------------
@@ -103,9 +106,11 @@ class AdopterApplicationServiceImplTest {
     @Test
     void constructor_nullArgument_throws() {
         assertThrows(IllegalArgumentException.class,
-                () -> new AdopterApplicationServiceImpl(null, auditService));
+                () -> new AdopterApplicationServiceImpl(null, adoptionService, auditService));
         assertThrows(IllegalArgumentException.class,
-                () -> new AdopterApplicationServiceImpl(adopterService, null));
+                () -> new AdopterApplicationServiceImpl(adopterService, null, auditService));
+        assertThrows(IllegalArgumentException.class,
+                () -> new AdopterApplicationServiceImpl(adopterService, adoptionService, null));
     }
 
     // -------------------------------------------------------------------------
@@ -167,6 +172,22 @@ class AdopterApplicationServiceImplTest {
         public List<Adopter> adoptedAnimal(Animal a) {
             return List.of();
         }
+    }
+
+    /**
+     * Stub implementation of {@link AdoptionService} that returns empty lists for all queries.
+     * Used to satisfy the dependency without simulating pending requests in most tests.
+     */
+    private static class StubAdoptionService implements AdoptionService {
+        @Override public void submit(shelter.domain.AdoptionRequest r) {}
+        @Override public void approve(shelter.domain.AdoptionRequest r) {}
+        @Override public void reject(shelter.domain.AdoptionRequest r) {}
+        @Override public void cancel(shelter.domain.AdoptionRequest r) {}
+        @Override public List<shelter.domain.AdoptionRequest> getRequestsByAdopter(Adopter a) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> getRequestsByShelter(shelter.domain.Shelter s) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> getRequestsByAnimal(Animal a) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> getRequestsAfter(java.time.LocalDate d) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> getApprovedAfter(java.time.LocalDate d) { return List.of(); }
     }
 
     /**

--- a/src/test/java/shelter/application/AnimalApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AnimalApplicationServiceImplTest.java
@@ -131,7 +131,7 @@ class AnimalApplicationServiceImplTest {
         Dog dog = new Dog("Rex", "Lab", LocalDate.now().minusYears(3), ActivityLevel.MEDIUM, false, Dog.Size.LARGE, false);
         animalService.store.put(dog.getId(), dog);
 
-        Animal updated = service.updateAnimal(dog.getId(), "Max", null);
+        Animal updated = service.updateAnimal(dog.getId(), "Max", null, null);
 
         assertEquals("Max", updated.getName());
         assertEquals("Lab", updated.getBreed()); // unchanged
@@ -142,7 +142,7 @@ class AnimalApplicationServiceImplTest {
     @Test
     void updateAnimal_notFound_throws() {
         assertThrows(EntityNotFoundException.class,
-                () -> service.updateAnimal("missing", "Max", null));
+                () -> service.updateAnimal("missing", "Max", null, null));
     }
 
     @Test

--- a/src/test/java/shelter/application/AnimalApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AnimalApplicationServiceImplTest.java
@@ -6,6 +6,7 @@ import shelter.application.impl.AnimalApplicationServiceImpl;
 import shelter.domain.*;
 import shelter.domain.Other;
 import shelter.exception.EntityNotFoundException;
+import shelter.service.AdoptionService;
 import shelter.service.AnimalService;
 import shelter.service.AuditService;
 import shelter.service.ShelterService;
@@ -28,17 +29,19 @@ class AnimalApplicationServiceImplTest {
 
     private StubAnimalService animalService;
     private StubShelterService shelterService;
+    private StubAdoptionService adoptionService;
     private SpyAuditService<Animal> auditService;
     private AnimalApplicationServiceImpl service;
     private Shelter shelter;
 
     @BeforeEach
     void setUp() {
-        animalService  = new StubAnimalService();
-        shelterService = new StubShelterService();
-        auditService   = new SpyAuditService<>();
-        service        = new AnimalApplicationServiceImpl(animalService, shelterService, auditService);
-        shelter        = new Shelter("Test Shelter", "Boston", 20);
+        animalService   = new StubAnimalService();
+        shelterService  = new StubShelterService();
+        adoptionService = new StubAdoptionService();
+        auditService    = new SpyAuditService<>();
+        service         = new AnimalApplicationServiceImpl(animalService, shelterService, adoptionService, auditService);
+        shelter         = new Shelter("Test Shelter", "Boston", 20);
         shelterService.store.put(shelter.getId(), shelter);
     }
 
@@ -161,11 +164,13 @@ class AnimalApplicationServiceImplTest {
     @Test
     void constructor_nullArgument_throws() {
         assertThrows(IllegalArgumentException.class,
-                () -> new AnimalApplicationServiceImpl(null, shelterService, auditService));
+                () -> new AnimalApplicationServiceImpl(null, shelterService, adoptionService, auditService));
         assertThrows(IllegalArgumentException.class,
-                () -> new AnimalApplicationServiceImpl(animalService, null, auditService));
+                () -> new AnimalApplicationServiceImpl(animalService, null, adoptionService, auditService));
         assertThrows(IllegalArgumentException.class,
-                () -> new AnimalApplicationServiceImpl(animalService, shelterService, null));
+                () -> new AnimalApplicationServiceImpl(animalService, shelterService, null, auditService));
+        assertThrows(IllegalArgumentException.class,
+                () -> new AnimalApplicationServiceImpl(animalService, shelterService, adoptionService, null));
     }
 
     // -------------------------------------------------------------------------
@@ -268,6 +273,22 @@ class AnimalApplicationServiceImplTest {
         public List<Shelter> listAll() {
             return new ArrayList<>(store.values());
         }
+    }
+
+    /**
+     * Stub implementation of {@link AdoptionService} that returns empty lists for all queries.
+     * Used to satisfy the dependency without simulating pending requests in most tests.
+     */
+    private static class StubAdoptionService implements AdoptionService {
+        @Override public void submit(shelter.domain.AdoptionRequest r) {}
+        @Override public void approve(shelter.domain.AdoptionRequest r) {}
+        @Override public void reject(shelter.domain.AdoptionRequest r) {}
+        @Override public void cancel(shelter.domain.AdoptionRequest r) {}
+        @Override public List<shelter.domain.AdoptionRequest> getRequestsByAdopter(Adopter a) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> getRequestsByShelter(Shelter s) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> getRequestsByAnimal(Animal a) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> getRequestsAfter(LocalDate d) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> getApprovedAfter(LocalDate d) { return List.of(); }
     }
 
     /**

--- a/src/test/java/shelter/integration/AdopterIntegrationTest.java
+++ b/src/test/java/shelter/integration/AdopterIntegrationTest.java
@@ -1,0 +1,54 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter adopter} command group.
+ * Verifies registration with and without age preferences, and listing behaviour.
+ */
+class AdopterIntegrationTest extends CliIntegrationTest {
+
+    @Test
+    void register_withAllPrefs_printsIdAndName() throws Exception {
+        RunResult r = run("adopter", "register",
+                "--name", "Alice",
+                "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY",
+                "--species", "DOG",
+                "--min-age", "1",
+                "--max-age", "5");
+        assertSuccess(r);
+        assertOutputContains(r, "Alice");
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void register_withoutAgePrefs_doesNotDefaultToAge20() throws Exception {
+        RunResult r = run("adopter", "register",
+                "--name", "Bob",
+                "--space", "APARTMENT",
+                "--schedule", "AWAY_MOST_OF_DAY");
+        assertSuccess(r);
+        assertOutputContains(r, "Bob");
+    }
+
+    @Test
+    void list_noAdopters_printsEmptyMessage() throws Exception {
+        RunResult r = run("adopter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "No adopters registered.");
+    }
+
+    @Test
+    void list_afterRegister_showsAdopter() throws Exception {
+        run("adopter", "register",
+                "--name", "Carol",
+                "--space", "APARTMENT",
+                "--schedule", "HOME_MOST_OF_DAY");
+        RunResult r = run("adopter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Carol");
+    }
+}

--- a/src/test/java/shelter/integration/AdopterIntegrationTest.java
+++ b/src/test/java/shelter/integration/AdopterIntegrationTest.java
@@ -6,34 +6,72 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the {@code shelter adopter} command group.
- * Verifies registration with and without age preferences, and listing behaviour.
+ * Covers UC-03.1 through UC-03.4: register, list, update, and remove adopters,
+ * including missing-field, not-found, and pending-adoption-blocked-removal error cases.
  */
 class AdopterIntegrationTest extends CliIntegrationTest {
 
+    // -------------------------------------------------------------------------
+    // UC-03.1: Register a New Adopter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that registering an adopter with all optional preference fields
+     * (species, min-age, max-age) exits with code 0 and prints the name and ID.
+     * A second adopter is registered with different preferences to confirm both succeed.
+     */
     @Test
     void register_withAllPrefs_printsIdAndName() throws Exception {
-        RunResult r = run("adopter", "register",
+        RunResult r1 = run("adopter", "register",
                 "--name", "Alice",
                 "--space", "HOUSE_WITH_YARD",
                 "--schedule", "HOME_MOST_OF_DAY",
                 "--species", "DOG",
                 "--min-age", "1",
                 "--max-age", "5");
-        assertSuccess(r);
-        assertOutputContains(r, "Alice");
-        assertOutputContains(r, "id=");
-    }
+        assertSuccess(r1);
+        assertOutputContains(r1, "Alice");
+        assertOutputContains(r1, "id=");
 
-    @Test
-    void register_withoutAgePrefs_doesNotDefaultToAge20() throws Exception {
-        RunResult r = run("adopter", "register",
+        RunResult r2 = run("adopter", "register",
                 "--name", "Bob",
                 "--space", "APARTMENT",
-                "--schedule", "AWAY_MOST_OF_DAY");
-        assertSuccess(r);
-        assertOutputContains(r, "Bob");
+                "--schedule", "AWAY_PART_OF_DAY",
+                "--species", "CAT",
+                "--min-age", "0",
+                "--max-age", "10");
+        assertSuccess(r2);
+        assertOutputContains(r2, "Bob");
     }
 
+    /**
+     * Verifies that registering an adopter without {@code --min-age} and {@code --max-age}
+     * succeeds without applying a default age cap. Two adopters are registered to confirm
+     * the optional-field path works independently for each.
+     */
+    @Test
+    void register_withoutAgePrefs_succeeds() throws Exception {
+        RunResult r1 = run("adopter", "register",
+                "--name", "NoAgeA",
+                "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        assertSuccess(r1);
+        RunResult r2 = run("adopter", "register",
+                "--name", "NoAgeB",
+                "--space", "APARTMENT",
+                "--schedule", "AWAY_MOST_OF_DAY");
+        assertSuccess(r2);
+        assertOutputContains(r2, "NoAgeB");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-03.2: View All Adopters
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that listing adopters when none have been registered prints an empty-list
+     * message rather than crashing or returning blank output.
+     */
     @Test
     void list_noAdopters_printsEmptyMessage() throws Exception {
         RunResult r = run("adopter", "list");
@@ -41,14 +79,146 @@ class AdopterIntegrationTest extends CliIntegrationTest {
         assertOutputContains(r, "No adopters registered.");
     }
 
+    /**
+     * Verifies that two registered adopters both appear in the list output,
+     * confirming the command aggregates all entries correctly.
+     */
     @Test
-    void list_afterRegister_showsAdopter() throws Exception {
+    void list_multipleAdopters_showsAll() throws Exception {
         run("adopter", "register",
                 "--name", "Carol",
                 "--space", "APARTMENT",
                 "--schedule", "HOME_MOST_OF_DAY");
+        run("adopter", "register",
+                "--name", "Dave",
+                "--space", "HOUSE_WITH_YARD",
+                "--schedule", "AWAY_PART_OF_DAY");
         RunResult r = run("adopter", "list");
         assertSuccess(r);
         assertOutputContains(r, "Carol");
+        assertOutputContains(r, "Dave");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-03.3: Update Adopter Information
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that updating an existing adopter's name succeeds and the confirmation
+     * message reflects the new name. A second adopter is registered so the list can
+     * confirm only the targeted adopter was renamed.
+     */
+    @Test
+    void update_name_printsUpdatedName() throws Exception {
+        run("adopter", "register",
+                "--name", "Bystander",
+                "--space", "APARTMENT",
+                "--schedule", "HOME_MOST_OF_DAY");
+        RunResult reg = run("adopter", "register",
+                "--name", "Old Name",
+                "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        String adopterId = extractId(reg.stdout());
+        RunResult r = run("adopter", "update", "--id", adopterId, "--name", "New Name");
+        assertSuccess(r);
+        assertOutputContains(r, "Updated adopter");
+        assertOutputContains(r, "New Name");
+    }
+
+    /**
+     * Verifies that updating only the name leaves the living space unchanged.
+     * After the update, the list must still show the original living space for that adopter.
+     */
+    @Test
+    void update_nameOnly_livingSpaceUnchanged() throws Exception {
+        run("adopter", "register",
+                "--name", "Other",
+                "--space", "APARTMENT",
+                "--schedule", "AWAY_MOST_OF_DAY");
+        RunResult reg = run("adopter", "register",
+                "--name", "Original",
+                "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        String adopterId = extractId(reg.stdout());
+        run("adopter", "update", "--id", adopterId, "--name", "Renamed");
+        RunResult list = run("adopter", "list");
+        assertOutputContains(list, "Renamed");
+        assertOutputContains(list, "HOUSE_WITH_YARD");
+    }
+
+    /**
+     * Verifies that attempting to update an adopter with an unknown ID prints an error.
+     * This exercises the not-found guard in the application layer.
+     */
+    @Test
+    void update_nonExistentId_printsError() throws Exception {
+        RunResult r = run("adopter", "update",
+                "--id", "00000000-0000-0000-0000-000000000000", "--name", "Ghost");
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-03.4: Remove an Adopter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that removing an adopter succeeds and the adopter no longer appears in the list.
+     * A second adopter is registered so the list confirms only the targeted adopter is absent.
+     */
+    @Test
+    void remove_existingAdopter_disappearsFromList() throws Exception {
+        run("adopter", "register",
+                "--name", "Survivor",
+                "--space", "APARTMENT",
+                "--schedule", "HOME_MOST_OF_DAY");
+        RunResult reg = run("adopter", "register",
+                "--name", "Doomed",
+                "--space", "APARTMENT",
+                "--schedule", "AWAY_MOST_OF_DAY");
+        String adopterId = extractId(reg.stdout());
+        RunResult r = run("adopter", "remove", "--id", adopterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Removed adopter");
+        RunResult list = run("adopter", "list");
+        assertOutputDoesNotContain(list, "Doomed");
+        assertOutputContains(list, "Survivor");
+    }
+
+    /**
+     * Verifies that attempting to remove an adopter who has a pending adoption request
+     * prints an error. A request is submitted first to put the adopter in a blocked state.
+     * A second adopter without a pending request is registered to confirm the block is
+     * scoped to the requesting adopter only.
+     */
+    @Test
+    void remove_adopterWithPendingAdoption_printsError() throws Exception {
+        RunResult shelterResult = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        String shelterId = extractId(shelterResult.stdout());
+        RunResult animalResult = run("animal", "admit",
+                "--species", "dog", "--name", "Rover", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        String animalId = extractId(animalResult.stdout());
+        run("adopter", "register",
+                "--name", "Free", "--space", "APARTMENT", "--schedule", "HOME_MOST_OF_DAY");
+        RunResult adopterResult = run("adopter", "register",
+                "--name", "Blocked",
+                "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        String adopterId = extractId(adopterResult.stdout());
+        run("adopt", "submit", "--adopter", adopterId, "--animal", animalId);
+        RunResult r = run("adopter", "remove", "--id", adopterId);
+        assertOutputContains(r, "Error");
+    }
+
+    /**
+     * Verifies that attempting to remove an adopter with an unknown ID prints an error.
+     * This tests the not-found guard without any adopters registered.
+     */
+    @Test
+    void remove_nonExistentId_printsError() throws Exception {
+        RunResult r = run("adopter", "remove",
+                "--id", "00000000-0000-0000-0000-000000000000");
+        assertOutputContains(r, "Error");
     }
 }

--- a/src/test/java/shelter/integration/AdoptionIntegrationTest.java
+++ b/src/test/java/shelter/integration/AdoptionIntegrationTest.java
@@ -6,98 +6,213 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the {@code shelter adopt} command group.
- * Tests the full adoption lifecycle: submit → approve/reject/cancel, plus error paths.
+ * Covers UC-05.1 through UC-05.4: submit, approve, reject, and cancel adoption requests,
+ * including not-found errors, state-transition guards (double-approve, double-reject,
+ * double-cancel), and the already-adopted submission error.
  */
 class AdoptionIntegrationTest extends CliIntegrationTest {
 
+    /** Registers a shelter with ample capacity and returns its ID. */
     private String registerShelter() throws Exception {
         RunResult r = run("shelter", "register",
-                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+                "--name", "Paws", "--location", "Boston", "--capacity", "20");
         return extractId(r.stdout());
     }
 
-    private String admitDog(String shelterId) throws Exception {
+    /** Admits a dog with the given name to the given shelter and returns its ID. */
+    private String admitDog(String shelterId, String name) throws Exception {
         RunResult r = run("animal", "admit",
-                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--species", "dog", "--name", name, "--breed", "Lab",
                 "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         return extractId(r.stdout());
     }
 
-    private String registerAdopter() throws Exception {
+    /** Registers an adopter with the given name and returns its ID. */
+    private String registerAdopter(String name) throws Exception {
         RunResult r = run("adopter", "register",
-                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
+                "--name", name, "--space", "HOUSE_WITH_YARD",
                 "--schedule", "HOME_MOST_OF_DAY");
         return extractId(r.stdout());
     }
 
+    /** Submits an adoption request and returns the generated request ID. */
     private String submitAdoption(String adopterId, String animalId) throws Exception {
         RunResult r = run("adopt", "submit",
                 "--adopter", adopterId, "--animal", animalId);
         return extractId(r.stdout());
     }
 
+    // -------------------------------------------------------------------------
+    // UC-05.1: Submit an Adoption Request
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that submitting an adoption request for a valid available animal
+     * exits successfully and prints the generated request UUID.
+     * Two animals are admitted so the request targets a specific one.
+     */
     @Test
     void submit_validPair_printsRequestId() throws Exception {
         String shelterId = registerShelter();
-        String animalId  = admitDog(shelterId);
-        String adopterId = registerAdopter();
-        RunResult r = run("adopt", "submit",
-                "--adopter", adopterId, "--animal", animalId);
+        admitDog(shelterId, "Bystander");
+        String animalId = admitDog(shelterId, "Rex");
+        String adopterId = registerAdopter("Alice");
+        RunResult r = run("adopt", "submit", "--adopter", adopterId, "--animal", animalId);
         assertSuccess(r);
         assertOutputContains(r, "id=");
     }
 
+    /**
+     * Verifies that submitting an adoption request for a non-existent animal ID prints an error.
+     * Two adopters are registered to confirm the guard applies regardless of adopter count.
+     */
     @Test
-    void approve_validRequest_printsConfirmationAndAnimalIsAdopted() throws Exception {
+    void submit_nonExistentAnimal_printsError() throws Exception {
+        registerAdopter("Alice");
+        String adopterId = registerAdopter("Bob");
+        RunResult r = run("adopt", "submit",
+                "--adopter", adopterId,
+                "--animal", "00000000-0000-0000-0000-000000000000");
+        assertOutputContains(r, "Error");
+    }
+
+    /**
+     * Verifies that submitting an adoption request for an already-adopted animal prints an error.
+     * A first request is approved to set the animal as adopted before the second submission.
+     */
+    @Test
+    void submit_alreadyAdoptedAnimal_printsError() throws Exception {
         String shelterId = registerShelter();
-        String animalId  = admitDog(shelterId);
-        String adopterId = registerAdopter();
+        String animalId = admitDog(shelterId, "Rex");
+        String adopter1 = registerAdopter("Alice");
+        String adopter2 = registerAdopter("Bob");
+        String requestId = submitAdoption(adopter1, animalId);
+        run("adopt", "approve", "--request", requestId);
+        RunResult r = run("adopt", "submit", "--adopter", adopter2, "--animal", animalId);
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-05.2: Approve an Adoption Request
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that approving a pending adoption request prints a confirmation and
+     * marks the animal as adopted. Two animals are in the shelter so the list confirms
+     * only the adopted animal changes status.
+     */
+    @Test
+    void approve_validRequest_animalMarkedAdopted() throws Exception {
+        String shelterId = registerShelter();
+        admitDog(shelterId, "FreeAnimal");
+        String animalId = admitDog(shelterId, "Rex");
+        String adopterId = registerAdopter("Alice");
         String requestId = submitAdoption(adopterId, animalId);
         RunResult r = run("adopt", "approve", "--request", requestId);
         assertSuccess(r);
         assertOutputContains(r, "Approved adoption request");
-        RunResult list = run("animal", "list", "--shelter", shelterId);
+        RunResult list = run("animal", "list");
         assertOutputContains(list, "adopted");
     }
 
+    /**
+     * Verifies that approving an already-approved request prints an error.
+     * The state-transition guard must reject the second approval attempt.
+     */
     @Test
-    void reject_validRequest_printsConfirmation() throws Exception {
+    void approve_alreadyApproved_printsError() throws Exception {
         String shelterId = registerShelter();
-        String animalId  = admitDog(shelterId);
-        String adopterId = registerAdopter();
+        String animalId = admitDog(shelterId, "Rex");
+        String adopterId = registerAdopter("Alice");
         String requestId = submitAdoption(adopterId, animalId);
-        RunResult r = run("adopt", "reject", "--request", requestId);
-        assertSuccess(r);
-        assertOutputContains(r, "Rejected adoption request");
+        run("adopt", "approve", "--request", requestId);
+        RunResult r = run("adopt", "approve", "--request", requestId);
+        assertOutputContains(r, "Error");
     }
 
-    @Test
-    void cancel_validRequest_printsConfirmation() throws Exception {
-        String shelterId = registerShelter();
-        String animalId  = admitDog(shelterId);
-        String adopterId = registerAdopter();
-        String requestId = submitAdoption(adopterId, animalId);
-        RunResult r = run("adopt", "cancel", "--request", requestId);
-        assertSuccess(r);
-        assertOutputContains(r, "Cancelled adoption request");
-    }
-
+    /**
+     * Verifies that attempting to approve a non-existent request ID prints an error.
+     * A shelter and animal are created to rule out false positives from missing entities.
+     */
     @Test
     void approve_nonExistentRequest_printsError() throws Exception {
+        registerShelter();
         RunResult r = run("adopt", "approve",
                 "--request", "00000000-0000-0000-0000-000000000000");
         assertOutputContains(r, "Error");
     }
 
+    // -------------------------------------------------------------------------
+    // UC-05.3: Reject an Adoption Request
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that rejecting a pending adoption request prints a confirmation and
+     * the animal remains available. Two adopters submit for the same animal so the test
+     * can confirm the second request is unaffected by the rejection of the first.
+     */
     @Test
-    void submit_alreadyAdoptedAnimal_printsError() throws Exception {
+    void reject_validRequest_printsConfirmation() throws Exception {
         String shelterId = registerShelter();
-        String animalId  = admitDog(shelterId);
-        String adopterId = registerAdopter();
+        String animalId = admitDog(shelterId, "Rex");
+        String adopter1 = registerAdopter("Alice");
+        String adopter2 = registerAdopter("Bob");
+        String requestId = submitAdoption(adopter1, animalId);
+        submitAdoption(adopter2, animalId);
+        RunResult r = run("adopt", "reject", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rejected adoption request");
+    }
+
+    /**
+     * Verifies that rejecting an already-rejected request prints an error.
+     * The state-transition guard must prevent a second rejection attempt.
+     */
+    @Test
+    void reject_alreadyRejected_printsError() throws Exception {
+        String shelterId = registerShelter();
+        String animalId = admitDog(shelterId, "Rex");
+        String adopterId = registerAdopter("Alice");
         String requestId = submitAdoption(adopterId, animalId);
-        run("adopt", "approve", "--request", requestId);
-        RunResult r = run("adopt", "submit",
-                "--adopter", adopterId, "--animal", animalId);
+        run("adopt", "reject", "--request", requestId);
+        RunResult r = run("adopt", "reject", "--request", requestId);
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-05.4: Cancel an Adoption Request
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that cancelling a pending adoption request prints a confirmation.
+     * Two adoption requests are created so the cancel targets one specifically
+     * and the other remains unaffected.
+     */
+    @Test
+    void cancel_validRequest_printsConfirmation() throws Exception {
+        String shelterId = registerShelter();
+        String animalId1 = admitDog(shelterId, "Rex");
+        String animalId2 = admitDog(shelterId, "Max");
+        String adopterId = registerAdopter("Alice");
+        String requestId = submitAdoption(adopterId, animalId1);
+        submitAdoption(adopterId, animalId2);
+        RunResult r = run("adopt", "cancel", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Cancelled adoption request");
+    }
+
+    /**
+     * Verifies that cancelling an already-cancelled request prints an error.
+     * The state-transition guard must reject the second cancellation attempt.
+     */
+    @Test
+    void cancel_alreadyCancelled_printsError() throws Exception {
+        String shelterId = registerShelter();
+        String animalId = admitDog(shelterId, "Rex");
+        String adopterId = registerAdopter("Alice");
+        String requestId = submitAdoption(adopterId, animalId);
+        run("adopt", "cancel", "--request", requestId);
+        RunResult r = run("adopt", "cancel", "--request", requestId);
         assertOutputContains(r, "Error");
     }
 }

--- a/src/test/java/shelter/integration/AdoptionIntegrationTest.java
+++ b/src/test/java/shelter/integration/AdoptionIntegrationTest.java
@@ -1,0 +1,103 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter adopt} command group.
+ * Tests the full adoption lifecycle: submit → approve/reject/cancel, plus error paths.
+ */
+class AdoptionIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter() throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        return extractId(r.stdout());
+    }
+
+    private String admitDog(String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    private String registerAdopter() throws Exception {
+        RunResult r = run("adopter", "register",
+                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        return extractId(r.stdout());
+    }
+
+    private String submitAdoption(String adopterId, String animalId) throws Exception {
+        RunResult r = run("adopt", "submit",
+                "--adopter", adopterId, "--animal", animalId);
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void submit_validPair_printsRequestId() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        String adopterId = registerAdopter();
+        RunResult r = run("adopt", "submit",
+                "--adopter", adopterId, "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void approve_validRequest_printsConfirmationAndAnimalIsAdopted() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        String adopterId = registerAdopter();
+        String requestId = submitAdoption(adopterId, animalId);
+        RunResult r = run("adopt", "approve", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Approved adoption request");
+        RunResult list = run("animal", "list", "--shelter", shelterId);
+        assertOutputContains(list, "adopted");
+    }
+
+    @Test
+    void reject_validRequest_printsConfirmation() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        String adopterId = registerAdopter();
+        String requestId = submitAdoption(adopterId, animalId);
+        RunResult r = run("adopt", "reject", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rejected adoption request");
+    }
+
+    @Test
+    void cancel_validRequest_printsConfirmation() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        String adopterId = registerAdopter();
+        String requestId = submitAdoption(adopterId, animalId);
+        RunResult r = run("adopt", "cancel", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Cancelled adoption request");
+    }
+
+    @Test
+    void approve_nonExistentRequest_printsError() throws Exception {
+        RunResult r = run("adopt", "approve",
+                "--request", "00000000-0000-0000-0000-000000000000");
+        assertOutputContains(r, "Error");
+    }
+
+    @Test
+    void submit_alreadyAdoptedAnimal_printsError() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        String adopterId = registerAdopter();
+        String requestId = submitAdoption(adopterId, animalId);
+        run("adopt", "approve", "--request", requestId);
+        RunResult r = run("adopt", "submit",
+                "--adopter", adopterId, "--animal", animalId);
+        assertOutputContains(r, "Error");
+    }
+}

--- a/src/test/java/shelter/integration/AnimalIntegrationTest.java
+++ b/src/test/java/shelter/integration/AnimalIntegrationTest.java
@@ -300,4 +300,79 @@ class AnimalIntegrationTest extends CliIntegrationTest {
                 "--id", "00000000-0000-0000-0000-000000000000");
         assertOutputContains(r, "Error");
     }
+
+    // -------------------------------------------------------------------------
+    // Shelter column in animal list
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that the animal list output always includes a Shelter column header
+     * and that the column shows the correct shelter name for each animal.
+     * Two animals are admitted to shelters with different names; both shelter names
+     * must appear in the unfiltered list output alongside the correct animal.
+     */
+    @Test
+    void list_allAnimals_showsShelterNameColumn() throws Exception {
+        String shelterA = registerShelter("Happy Paws", 10);
+        String shelterB = registerShelter("Green Field", 10);
+        run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "2", "--activity", "HIGH", "--shelter", shelterA);
+        run("animal", "admit",
+                "--species", "cat", "--name", "Misty", "--breed", "Mix",
+                "--age", "3", "--activity", "LOW", "--shelter", shelterB);
+
+        RunResult r = run("animal", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Shelter");
+        assertOutputContains(r, "Happy Paws");
+        assertOutputContains(r, "Green Field");
+    }
+
+    /**
+     * Verifies that filtering by shelter still shows the correct shelter name in the output.
+     * Only animals belonging to the specified shelter should appear, and their Shelter
+     * column must match the shelter name rather than the raw ID.
+     */
+    @Test
+    void list_byShelter_showsCorrectShelterName() throws Exception {
+        String shelterA = registerShelter("Cozy Corner", 10);
+        String shelterB = registerShelter("Open Meadow", 10);
+        run("animal", "admit",
+                "--species", "rabbit", "--name", "Bun", "--breed", "Dutch",
+                "--age", "1", "--activity", "MEDIUM", "--shelter", shelterA);
+        run("animal", "admit",
+                "--species", "dog", "--name", "Bolt", "--breed", "Mix",
+                "--age", "4", "--activity", "HIGH", "--shelter", shelterB);
+
+        RunResult r = run("animal", "list", "--shelter", shelterA);
+        assertSuccess(r);
+        assertOutputContains(r, "Cozy Corner");
+        assertOutputDoesNotContain(r, "Open Meadow");
+        assertOutputDoesNotContain(r, "Bolt");
+    }
+
+    /**
+     * Verifies that updating the neutered status of a dog changes the field from false to true.
+     * A second animal is admitted to confirm the update is scoped only to the target animal.
+     */
+    @Test
+    void update_neutered_changesNeuteredStatus() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "cat", "--name", "Bystander", "--breed", "Mix",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        RunResult admit = run("animal", "admit",
+                "--species", "dog", "--name", "Bruno", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        String animalId = extractId(admit.stdout());
+
+        RunResult r = run("animal", "update", "--id", animalId, "--neutered", "true");
+        assertSuccess(r);
+        assertOutputContains(r, "Updated animal");
+
+        RunResult list = run("animal", "list", "--shelter", shelterId);
+        assertSuccess(list);
+        assertOutputContains(list, "true");
+    }
 }

--- a/src/test/java/shelter/integration/AnimalIntegrationTest.java
+++ b/src/test/java/shelter/integration/AnimalIntegrationTest.java
@@ -1,0 +1,96 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter animal} command group.
+ * Covers Dog, Cat, Rabbit, and Other species, plus list filtering and capacity enforcement.
+ */
+class AnimalIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter(String name, int capacity) throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", name, "--location", "Boston", "--capacity", String.valueOf(capacity));
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void admit_dog_printsIdAndSpecies() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Labrador",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rex");
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void admit_cat_printsIdAndSpecies() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        RunResult r = run("animal", "admit",
+                "--species", "cat", "--name", "Whiskers", "--breed", "Siamese",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Whiskers");
+    }
+
+    @Test
+    void admit_rabbit_printsIdAndSpecies() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        RunResult r = run("animal", "admit",
+                "--species", "rabbit", "--name", "Fluffy", "--breed", "Holland Lop",
+                "--age", "1", "--activity", "MEDIUM", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Fluffy");
+    }
+
+    @Test
+    void admit_other_speciesNamePreservedOnList() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "other", "--species-name", "fish",
+                "--name", "Nemo", "--breed", "Clownfish",
+                "--age", "1", "--activity", "LOW", "--shelter", shelterId);
+        RunResult r = run("animal", "list", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Nemo");
+    }
+
+    @Test
+    void list_byShelter_onlyShowsAnimalsInThatShelter() throws Exception {
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
+        run("animal", "admit",
+                "--species", "dog", "--name", "InA", "--breed", "Breed",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterA);
+        run("animal", "admit",
+                "--species", "dog", "--name", "InB", "--breed", "Breed",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterB);
+        RunResult r = run("animal", "list", "--shelter", shelterA);
+        assertOutputContains(r, "InA");
+        assertOutputDoesNotContain(r, "InB");
+    }
+
+    @Test
+    void admit_exceedsCapacity_printsError() throws Exception {
+        String shelterId = registerShelter("Tiny", 1);
+        run("animal", "admit",
+                "--species", "dog", "--name", "First", "--breed", "Breed",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Second", "--breed", "Breed",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        assertOutputContains(r, "Error");
+    }
+
+    @Test
+    void list_noAnimals_printsEmptyMessage() throws Exception {
+        String shelterId = registerShelter("Empty", 10);
+        RunResult r = run("animal", "list", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "No animals found.");
+    }
+}

--- a/src/test/java/shelter/integration/AnimalIntegrationTest.java
+++ b/src/test/java/shelter/integration/AnimalIntegrationTest.java
@@ -6,18 +6,30 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the {@code shelter animal} command group.
- * Covers Dog, Cat, Rabbit, and Other species, plus list filtering and capacity enforcement.
+ * Covers UC-02.1 through UC-02.4: admit (Dog, Cat, Rabbit, Other), list with and without
+ * shelter filter, update, and remove operations, including capacity overflow, unknown shelter,
+ * not-found, and pending-adoption error cases.
  */
 class AnimalIntegrationTest extends CliIntegrationTest {
 
+    /** Registers a shelter and returns its generated ID. */
     private String registerShelter(String name, int capacity) throws Exception {
         RunResult r = run("shelter", "register",
                 "--name", name, "--location", "Boston", "--capacity", String.valueOf(capacity));
         return extractId(r.stdout());
     }
 
+    // -------------------------------------------------------------------------
+    // UC-02.1: Admit a New Animal
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that admitting a Dog with valid arguments exits successfully and prints
+     * the animal name and generated UUID. A Cat is admitted to the same shelter
+     * so both records coexist without interference.
+     */
     @Test
-    void admit_dog_printsIdAndSpecies() throws Exception {
+    void admit_dog_printsIdAndName() throws Exception {
         String shelterId = registerShelter("Paws", 10);
         RunResult r = run("animal", "admit",
                 "--species", "dog", "--name", "Rex", "--breed", "Labrador",
@@ -25,31 +37,59 @@ class AnimalIntegrationTest extends CliIntegrationTest {
         assertSuccess(r);
         assertOutputContains(r, "Rex");
         assertOutputContains(r, "id=");
+
+        run("animal", "admit",
+                "--species", "cat", "--name", "Whiskers", "--breed", "Siamese",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
     }
 
+    /**
+     * Verifies that admitting a Cat exits successfully and the name appears in the confirmation.
+     * A Dog is also admitted to the same shelter to confirm species routing works for both.
+     */
     @Test
-    void admit_cat_printsIdAndSpecies() throws Exception {
+    void admit_cat_printsIdAndName() throws Exception {
         String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         RunResult r = run("animal", "admit",
                 "--species", "cat", "--name", "Whiskers", "--breed", "Siamese",
                 "--age", "2", "--activity", "LOW", "--shelter", shelterId);
         assertSuccess(r);
         assertOutputContains(r, "Whiskers");
+        assertOutputContains(r, "id=");
     }
 
+    /**
+     * Verifies that admitting a Rabbit exits successfully and the name appears in the confirmation.
+     * A Dog is also admitted to confirm the species discriminator does not corrupt other records.
+     */
     @Test
-    void admit_rabbit_printsIdAndSpecies() throws Exception {
+    void admit_rabbit_printsIdAndName() throws Exception {
         String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         RunResult r = run("animal", "admit",
                 "--species", "rabbit", "--name", "Fluffy", "--breed", "Holland Lop",
                 "--age", "1", "--activity", "MEDIUM", "--shelter", shelterId);
         assertSuccess(r);
         assertOutputContains(r, "Fluffy");
+        assertOutputContains(r, "id=");
     }
 
+    /**
+     * Verifies that admitting an Other-species animal with a free-form species name
+     * stores the name correctly and both it and a co-resident Dog appear in the list.
+     * This exercises the species discriminator round-trip for non-enum species.
+     */
     @Test
     void admit_other_speciesNamePreservedOnList() throws Exception {
         String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         run("animal", "admit",
                 "--species", "other", "--species-name", "fish",
                 "--name", "Nemo", "--breed", "Clownfish",
@@ -57,40 +97,207 @@ class AnimalIntegrationTest extends CliIntegrationTest {
         RunResult r = run("animal", "list", "--shelter", shelterId);
         assertSuccess(r);
         assertOutputContains(r, "Nemo");
+        assertOutputContains(r, "Rex");
     }
 
+    /**
+     * Verifies that admitting an animal to a non-existent shelter ID prints an error.
+     * Two bogus shelter IDs are attempted to confirm the guard applies unconditionally.
+     */
+    @Test
+    void admit_unknownShelterId_printsError() throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Ghost", "--breed", "Lab",
+                "--age", "2", "--activity", "LOW",
+                "--shelter", "00000000-0000-0000-0000-000000000000");
+        assertOutputContains(r, "Error");
+    }
+
+    /**
+     * Verifies that admitting a second animal to a shelter that has reached capacity prints an error.
+     * The shelter is pre-filled with one animal so the second admission triggers the capacity guard.
+     */
+    @Test
+    void admit_exceedsCapacity_printsError() throws Exception {
+        String shelterId = registerShelter("Tiny", 1);
+        run("animal", "admit",
+                "--species", "dog", "--name", "First", "--breed", "Lab",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Second", "--breed", "Lab",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-02.2: View Animals
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that listing with a shelter filter returns only animals in that shelter.
+     * Two shelters each contain a distinctly named animal; the list for Shelter A must
+     * include its animal and exclude Shelter B's animal.
+     */
     @Test
     void list_byShelter_onlyShowsAnimalsInThatShelter() throws Exception {
         String shelterA = registerShelter("Shelter A", 10);
         String shelterB = registerShelter("Shelter B", 10);
         run("animal", "admit",
-                "--species", "dog", "--name", "InA", "--breed", "Breed",
+                "--species", "dog", "--name", "InA", "--breed", "Lab",
                 "--age", "2", "--activity", "LOW", "--shelter", shelterA);
         run("animal", "admit",
-                "--species", "dog", "--name", "InB", "--breed", "Breed",
+                "--species", "dog", "--name", "InB", "--breed", "Lab",
                 "--age", "2", "--activity", "LOW", "--shelter", shelterB);
         RunResult r = run("animal", "list", "--shelter", shelterA);
         assertOutputContains(r, "InA");
         assertOutputDoesNotContain(r, "InB");
     }
 
+    /**
+     * Verifies that listing without a shelter filter shows animals from all shelters.
+     * One animal is admitted to each of two shelters; both must appear in the unfiltered list.
+     */
     @Test
-    void admit_exceedsCapacity_printsError() throws Exception {
-        String shelterId = registerShelter("Tiny", 1);
+    void list_allAnimals_multiShelter_showsAll() throws Exception {
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
         run("animal", "admit",
-                "--species", "dog", "--name", "First", "--breed", "Breed",
-                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
-        RunResult r = run("animal", "admit",
-                "--species", "dog", "--name", "Second", "--breed", "Breed",
-                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
-        assertOutputContains(r, "Error");
+                "--species", "dog", "--name", "Alpha", "--breed", "Lab",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterA);
+        run("animal", "admit",
+                "--species", "cat", "--name", "Beta", "--breed", "Mix",
+                "--age", "3", "--activity", "MEDIUM", "--shelter", shelterB);
+        RunResult r = run("animal", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Alpha");
+        assertOutputContains(r, "Beta");
     }
 
+    /**
+     * Verifies that listing animals in an empty shelter prints an empty-list message
+     * rather than crashing or printing a blank line.
+     */
     @Test
     void list_noAnimals_printsEmptyMessage() throws Exception {
         String shelterId = registerShelter("Empty", 10);
         RunResult r = run("animal", "list", "--shelter", shelterId);
         assertSuccess(r);
         assertOutputContains(r, "No animals found.");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-02.3: Update Animal Information
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that updating an existing animal's name succeeds and the confirmation
+     * reflects the new name. A second animal is admitted to the same shelter to
+     * confirm only the targeted animal is renamed.
+     */
+    @Test
+    void update_name_printsUpdatedName() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "cat", "--name", "Bystander", "--breed", "Mix",
+                "--age", "4", "--activity", "LOW", "--shelter", shelterId);
+        RunResult admit = run("animal", "admit",
+                "--species", "dog", "--name", "Old Name", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        String animalId = extractId(admit.stdout());
+        RunResult r = run("animal", "update", "--id", animalId, "--name", "New Name");
+        assertSuccess(r);
+        assertOutputContains(r, "Updated animal");
+        assertOutputContains(r, "New Name");
+    }
+
+    /**
+     * Verifies that updating only the activity level leaves the animal name unchanged.
+     * A second animal is admitted so the list can confirm isolation between records.
+     */
+    @Test
+    void update_activityOnly_nameUnchanged() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "cat", "--name", "Other", "--breed", "Mix",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        RunResult admit = run("animal", "admit",
+                "--species", "dog", "--name", "Speedy", "--breed", "Lab",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        String animalId = extractId(admit.stdout());
+        RunResult r = run("animal", "update", "--id", animalId, "--activity", "HIGH");
+        assertSuccess(r);
+        assertOutputContains(r, "Speedy");
+    }
+
+    /**
+     * Verifies that attempting to update an animal with an unknown ID prints an error.
+     * This exercises the not-found guard in the application layer.
+     */
+    @Test
+    void update_nonExistentId_printsError() throws Exception {
+        RunResult r = run("animal", "update",
+                "--id", "00000000-0000-0000-0000-000000000000", "--name", "Ghost");
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-02.4: Remove an Animal
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that removing an animal succeeds and it no longer appears in the shelter list.
+     * A second animal stays in the shelter to confirm only the targeted animal is absent.
+     */
+    @Test
+    void remove_existingAnimal_disappearsFromList() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "cat", "--name", "Survivor", "--breed", "Mix",
+                "--age", "3", "--activity", "LOW", "--shelter", shelterId);
+        RunResult admit = run("animal", "admit",
+                "--species", "dog", "--name", "Doomed", "--breed", "Lab",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        String animalId = extractId(admit.stdout());
+        RunResult r = run("animal", "remove", "--id", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "Removed animal");
+        RunResult list = run("animal", "list", "--shelter", shelterId);
+        assertOutputDoesNotContain(list, "Doomed");
+        assertOutputContains(list, "Survivor");
+    }
+
+    /**
+     * Verifies that attempting to remove an animal that has a pending adoption request
+     * prints an error. An adopter submits a request first, putting the animal in a blocked state.
+     * A second animal is admitted to confirm the block is scoped to the request target only.
+     */
+    @Test
+    void remove_animalWithPendingAdoption_printsError() throws Exception {
+        String shelterId = registerShelter("Paws", 10);
+        run("animal", "admit",
+                "--species", "cat", "--name", "Free", "--breed", "Mix",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        RunResult animalResult = run("animal", "admit",
+                "--species", "dog", "--name", "Blocked", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        String animalId = extractId(animalResult.stdout());
+        RunResult adopterResult = run("adopter", "register",
+                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        String adopterId = extractId(adopterResult.stdout());
+        run("adopt", "submit", "--adopter", adopterId, "--animal", animalId);
+        RunResult r = run("animal", "remove", "--id", animalId);
+        assertOutputContains(r, "Error");
+    }
+
+    /**
+     * Verifies that attempting to remove an animal with an unknown ID prints an error.
+     * This tests the not-found guard without any animals registered in the shelter.
+     */
+    @Test
+    void remove_nonExistentId_printsError() throws Exception {
+        RunResult r = run("animal", "remove",
+                "--id", "00000000-0000-0000-0000-000000000000");
+        assertOutputContains(r, "Error");
     }
 }

--- a/src/test/java/shelter/integration/AuditIntegrationTest.java
+++ b/src/test/java/shelter/integration/AuditIntegrationTest.java
@@ -6,10 +6,16 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the {@code shelter audit} command group.
- * Verifies that mutations are recorded in the audit log and visible via CLI.
+ * Covers UC-08.1: viewing the audit log, including the empty-log case and multi-operation coverage.
+ * The audit log is persistent across CLI invocations, so each test verifies that all
+ * mutations performed in that session appear in the log retrieved at the end.
  */
 class AuditIntegrationTest extends CliIntegrationTest {
 
+    /**
+     * Verifies that retrieving the audit log when no operations have been performed
+     * exits with code 0 and prints the empty-log sentinel message.
+     */
     @Test
     void log_noActions_printsEmptyMessage() throws Exception {
         RunResult r = run("audit", "log");
@@ -17,14 +23,45 @@ class AuditIntegrationTest extends CliIntegrationTest {
         assertOutputContains(r, "Audit log is empty.");
     }
 
+    /**
+     * Verifies that registering two shelters and admitting an animal all produce audit entries.
+     * After these three operations the log must be non-empty and must not print the empty sentinel.
+     */
     @Test
-    void log_afterAdmitAndRegister_containsEntries() throws Exception {
+    void log_shelterAndAnimalOperations_containsEntries() throws Exception {
         RunResult sr = run("shelter", "register",
                 "--name", "Paws", "--location", "Boston", "--capacity", "10");
         String shelterId = extractId(sr.stdout());
+        run("shelter", "register",
+                "--name", "Happy Tails", "--location", "Cambridge", "--capacity", "5");
         run("animal", "admit",
                 "--species", "dog", "--name", "Rex", "--breed", "Lab",
                 "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        RunResult r = run("audit", "log");
+        assertSuccess(r);
+        assertOutputDoesNotContain(r, "Audit log is empty.");
+    }
+
+    /**
+     * Verifies that registering two adopters and submitting an adoption request all
+     * produce audit entries. After these operations the log must be non-empty, confirming
+     * the audit layer captures adopter and adoption events as well as shelter events.
+     */
+    @Test
+    void log_adopterAndAdoptionOperations_containsEntries() throws Exception {
+        RunResult shelterResult = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        String shelterId = extractId(shelterResult.stdout());
+        RunResult animalResult = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        String animalId = extractId(animalResult.stdout());
+        run("adopter", "register",
+                "--name", "Alice", "--space", "HOUSE_WITH_YARD", "--schedule", "HOME_MOST_OF_DAY");
+        RunResult adopterResult = run("adopter", "register",
+                "--name", "Bob", "--space", "APARTMENT", "--schedule", "AWAY_MOST_OF_DAY");
+        String adopterId = extractId(adopterResult.stdout());
+        run("adopt", "submit", "--adopter", adopterId, "--animal", animalId);
         RunResult r = run("audit", "log");
         assertSuccess(r);
         assertOutputDoesNotContain(r, "Audit log is empty.");

--- a/src/test/java/shelter/integration/AuditIntegrationTest.java
+++ b/src/test/java/shelter/integration/AuditIntegrationTest.java
@@ -1,0 +1,32 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter audit} command group.
+ * Verifies that mutations are recorded in the audit log and visible via CLI.
+ */
+class AuditIntegrationTest extends CliIntegrationTest {
+
+    @Test
+    void log_noActions_printsEmptyMessage() throws Exception {
+        RunResult r = run("audit", "log");
+        assertSuccess(r);
+        assertOutputContains(r, "Audit log is empty.");
+    }
+
+    @Test
+    void log_afterAdmitAndRegister_containsEntries() throws Exception {
+        RunResult sr = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        String shelterId = extractId(sr.stdout());
+        run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        RunResult r = run("audit", "log");
+        assertSuccess(r);
+        assertOutputDoesNotContain(r, "Audit log is empty.");
+    }
+}

--- a/src/test/java/shelter/integration/CliIntegrationTest.java
+++ b/src/test/java/shelter/integration/CliIntegrationTest.java
@@ -1,0 +1,117 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Abstract base class for CLI end-to-end integration tests.
+ * Spawns real {@code shelter} subprocesses with {@code SHELTER_HOME} pointed at a JUnit
+ * {@code @TempDir} so each test method runs against a completely isolated, ephemeral data
+ * directory. The binary is expected at {@code build/install/shelter/bin/shelter},
+ * which is produced by the Gradle {@code installDist} task.
+ */
+@Tag("integration")
+abstract class CliIntegrationTest {
+
+    private static final Path BINARY = Path.of(System.getProperty("user.dir"))
+            .resolve("build/install/shelter/bin/shelter");
+
+    /** Fresh isolated data directory injected by JUnit for every test method. */
+    @TempDir
+    Path shelterHome;
+
+    /**
+     * Launches the {@code shelter} binary with the given arguments and captures all output.
+     * {@code SHELTER_HOME} is set to the per-test {@code @TempDir}; the real {@code ~/shelter}
+     * directory is never touched.
+     *
+     * @param args subcommand tokens, e.g. {@code "shelter", "register", "--name", "Paws"}
+     * @return a {@link RunResult} containing exit code, stdout, and stderr
+     * @throws IOException          if the process cannot be started
+     * @throws InterruptedException if the thread is interrupted while waiting
+     */
+    RunResult run(String... args) throws IOException, InterruptedException {
+        String[] command = new String[args.length + 1];
+        command[0] = BINARY.toString();
+        System.arraycopy(args, 0, command, 1, args.length);
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.environment().put("SHELTER_HOME", shelterHome.toString());
+
+        Process process = pb.start();
+        String stdout = new String(process.getInputStream().readAllBytes());
+        String stderr  = new String(process.getErrorStream().readAllBytes());
+        boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+        assertTrue(finished, "shelter process timed out after 10 s");
+
+        return new RunResult(process.exitValue(), stdout, stderr);
+    }
+
+    /**
+     * Extracts a UUID that follows {@code id=} anywhere in the given output string.
+     * Matches CLI output patterns such as {@code "Registered shelter: Paws (id=abc-123)"}.
+     *
+     * @param output stdout string from a {@link #run} call
+     * @return the extracted UUID string
+     */
+    String extractId(String output) {
+        Matcher m = Pattern.compile("id=([a-f0-9\\-]{36})").matcher(output);
+        assertTrue(m.find(), "Expected id=<uuid> in output: " + output);
+        return m.group(1);
+    }
+
+    /**
+     * Asserts that the process exited with code 0.
+     * Includes stdout and stderr in the failure message for easier debugging.
+     *
+     * @param r the result to check
+     */
+    void assertSuccess(RunResult r) {
+        assertEquals(0, r.exitCode(),
+                "Expected exit 0. stderr: " + r.stderr() + " stdout: " + r.stdout());
+    }
+
+    /**
+     * Asserts that the combined stdout and stderr contain the given fragment.
+     * Prints both streams in the failure message so the actual output is visible.
+     *
+     * @param r        the result to inspect
+     * @param fragment the substring that must appear
+     */
+    void assertOutputContains(RunResult r, String fragment) {
+        assertTrue((r.stdout() + r.stderr()).contains(fragment),
+                "Expected output to contain \"" + fragment + "\"\n"
+                        + "stdout: " + r.stdout() + "\nstderr: " + r.stderr());
+    }
+
+    /**
+     * Asserts that neither stdout nor stderr contains the given fragment.
+     * Useful for verifying that a value is absent after a delete or an incorrect default is not applied.
+     *
+     * @param r        the result to inspect
+     * @param fragment the substring that must be absent
+     */
+    void assertOutputDoesNotContain(RunResult r, String fragment) {
+        assertFalse((r.stdout() + r.stderr()).contains(fragment),
+                "Expected output NOT to contain \"" + fragment + "\"\n"
+                        + "stdout: " + r.stdout() + "\nstderr: " + r.stderr());
+    }
+
+    /**
+     * Immutable result of one {@code shelter} CLI invocation.
+     * Contains exit code, full stdout, and full stderr captured from the subprocess.
+     *
+     * @param exitCode the process exit code (0 = success)
+     * @param stdout   everything written to standard output
+     * @param stderr   everything written to standard error
+     */
+    record RunResult(int exitCode, String stdout, String stderr) {}
+}

--- a/src/test/java/shelter/integration/CrossSessionIntegrationTest.java
+++ b/src/test/java/shelter/integration/CrossSessionIntegrationTest.java
@@ -5,26 +5,42 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Integration tests verifying that data persists across separate shelter processes.
- * Each test runs two independent subprocesses against the same TempDir, simulating
- * a real shutdown-and-restart cycle.
+ * Integration tests verifying that data persists correctly across separate process invocations.
+ * Each process runs with the same {@code SHELTER_HOME} directory but no shared in-memory state,
+ * so these tests confirm the CSV persistence layer works end-to-end across shutdown-restart cycles.
  */
 class CrossSessionIntegrationTest extends CliIntegrationTest {
 
+    /**
+     * Verifies that two shelters registered in separate process invocations both appear
+     * in a third listing invocation. This confirms the CSV persistence layer accumulates
+     * entries across multiple writes before any read is performed.
+     */
     @Test
-    void shelterRegistered_inProcess1_visibleInProcess2() throws Exception {
+    void multipleShelters_persistAcrossSessions() throws Exception {
         run("shelter", "register",
-                "--name", "Persistent Paws", "--location", "Boston", "--capacity", "10");
+                "--name", "Alpha", "--location", "Boston", "--capacity", "10");
+        run("shelter", "register",
+                "--name", "Beta", "--location", "Cambridge", "--capacity", "5");
         RunResult r = run("shelter", "list");
         assertSuccess(r);
-        assertOutputContains(r, "Persistent Paws");
+        assertOutputContains(r, "Alpha");
+        assertOutputContains(r, "Beta");
     }
 
+    /**
+     * Verifies that an {@code Other}-species animal's free-form species name survives a full
+     * save-and-reload cycle across separate processes. A Dog is also admitted so the list
+     * can confirm the species discriminator correctly isolates the two records on reload.
+     */
     @Test
-    void otherAnimal_admittedInProcess1_speciesNamePreservedInProcess2() throws Exception {
+    void otherAnimal_speciesNamePersistsAcrossSessions() throws Exception {
         RunResult sr = run("shelter", "register",
                 "--name", "Paws", "--location", "Boston", "--capacity", "10");
         String shelterId = extractId(sr.stdout());
+        run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         run("animal", "admit",
                 "--species", "other", "--species-name", "fish",
                 "--name", "Nemo", "--breed", "Clownfish",
@@ -32,5 +48,42 @@ class CrossSessionIntegrationTest extends CliIntegrationTest {
         RunResult r = run("animal", "list", "--shelter", shelterId);
         assertSuccess(r);
         assertOutputContains(r, "Nemo");
+        assertOutputContains(r, "Rex");
+    }
+
+    /**
+     * Verifies that an update made in one process invocation is reflected when data is loaded
+     * in a subsequent process. Two shelters are registered; only one is updated, and the list
+     * must show the new name while the other shelter's name is unchanged.
+     */
+    @Test
+    void updatePersists_acrossSession() throws Exception {
+        run("shelter", "register",
+                "--name", "Unchanged", "--location", "Cambridge", "--capacity", "5");
+        RunResult reg = run("shelter", "register",
+                "--name", "Old Name", "--location", "Boston", "--capacity", "10");
+        String id = extractId(reg.stdout());
+        run("shelter", "update", "--id", id, "--name", "New Name");
+        RunResult list = run("shelter", "list");
+        assertOutputContains(list, "New Name");
+        assertOutputDoesNotContain(list, "Old Name");
+        assertOutputContains(list, "Unchanged");
+    }
+
+    /**
+     * Verifies that a removal made in one process invocation takes effect in a subsequent process.
+     * Two shelters are registered; one is removed, and the list must show only the remaining shelter.
+     */
+    @Test
+    void removePersists_acrossSession() throws Exception {
+        run("shelter", "register",
+                "--name", "Stays", "--location", "Cambridge", "--capacity", "5");
+        RunResult reg = run("shelter", "register",
+                "--name", "To Remove", "--location", "Boston", "--capacity", "10");
+        String id = extractId(reg.stdout());
+        run("shelter", "remove", "--id", id);
+        RunResult list = run("shelter", "list");
+        assertOutputDoesNotContain(list, "To Remove");
+        assertOutputContains(list, "Stays");
     }
 }

--- a/src/test/java/shelter/integration/CrossSessionIntegrationTest.java
+++ b/src/test/java/shelter/integration/CrossSessionIntegrationTest.java
@@ -1,0 +1,36 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests verifying that data persists across separate shelter processes.
+ * Each test runs two independent subprocesses against the same TempDir, simulating
+ * a real shutdown-and-restart cycle.
+ */
+class CrossSessionIntegrationTest extends CliIntegrationTest {
+
+    @Test
+    void shelterRegistered_inProcess1_visibleInProcess2() throws Exception {
+        run("shelter", "register",
+                "--name", "Persistent Paws", "--location", "Boston", "--capacity", "10");
+        RunResult r = run("shelter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Persistent Paws");
+    }
+
+    @Test
+    void otherAnimal_admittedInProcess1_speciesNamePreservedInProcess2() throws Exception {
+        RunResult sr = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        String shelterId = extractId(sr.stdout());
+        run("animal", "admit",
+                "--species", "other", "--species-name", "fish",
+                "--name", "Nemo", "--breed", "Clownfish",
+                "--age", "1", "--activity", "LOW", "--shelter", shelterId);
+        RunResult r = run("animal", "list", "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Nemo");
+    }
+}

--- a/src/test/java/shelter/integration/MatchIntegrationTest.java
+++ b/src/test/java/shelter/integration/MatchIntegrationTest.java
@@ -1,0 +1,78 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter match} command group.
+ * Verifies ranked output and that null age preferences do not penalise the score.
+ */
+class MatchIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter() throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        return extractId(r.stdout());
+    }
+
+    private String admitDog(String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void matchAnimal_returnsRankedList() throws Exception {
+        String shelterId = registerShelter();
+        admitDog(shelterId);
+        RunResult ar = run("adopter", "register",
+                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY", "--species", "DOG");
+        String adopterId = extractId(ar.stdout());
+        RunResult r = run("match", "animal",
+                "--adopter", adopterId, "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rex");
+    }
+
+    @Test
+    void matchAnimal_noAnimalsInShelter_printsEmptyMessage() throws Exception {
+        String shelterId = registerShelter();
+        RunResult ar = run("adopter", "register",
+                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        String adopterId = extractId(ar.stdout());
+        RunResult r = run("match", "animal",
+                "--adopter", adopterId, "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "No available animals");
+    }
+
+    @Test
+    void matchAdopter_returnsRankedList() throws Exception {
+        String shelterId = registerShelter();
+        String animalId = admitDog(shelterId);
+        run("adopter", "register",
+                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        RunResult r = run("match", "adopter", "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "Alice");
+    }
+
+    @Test
+    void matchAnimal_adopterWithNoAgePrefs_animalAppearsInResults() throws Exception {
+        String shelterId = registerShelter();
+        admitDog(shelterId);
+        RunResult ar = run("adopter", "register",
+                "--name", "NoAge", "--space", "HOUSE_WITH_YARD",
+                "--schedule", "HOME_MOST_OF_DAY");
+        String adopterId = extractId(ar.stdout());
+        RunResult r = run("match", "animal",
+                "--adopter", adopterId, "--shelter", shelterId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rex");
+    }
+}

--- a/src/test/java/shelter/integration/MatchIntegrationTest.java
+++ b/src/test/java/shelter/integration/MatchIntegrationTest.java
@@ -6,73 +6,145 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the {@code shelter match} command group.
- * Verifies ranked output and that null age preferences do not penalise the score.
+ * Covers UC-04.1 (match animals for an adopter) and UC-04.2 (match adopters for an animal),
+ * including empty result sets, multiple scored entities, and the already-adopted error case.
  */
 class MatchIntegrationTest extends CliIntegrationTest {
 
+    /** Registers a shelter with ample capacity and returns its ID. */
     private String registerShelter() throws Exception {
         RunResult r = run("shelter", "register",
-                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+                "--name", "Paws", "--location", "Boston", "--capacity", "20");
         return extractId(r.stdout());
     }
 
-    private String admitDog(String shelterId) throws Exception {
+    /** Admits a dog with the given name to the given shelter and returns its ID. */
+    private String admitDog(String name, String shelterId) throws Exception {
         RunResult r = run("animal", "admit",
-                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--species", "dog", "--name", name, "--breed", "Lab",
                 "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         return extractId(r.stdout());
     }
 
-    @Test
-    void matchAnimal_returnsRankedList() throws Exception {
-        String shelterId = registerShelter();
-        admitDog(shelterId);
-        RunResult ar = run("adopter", "register",
-                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
+    /** Registers a DOG-preferring adopter with the given name and returns its ID. */
+    private String registerAdopter(String name) throws Exception {
+        RunResult r = run("adopter", "register",
+                "--name", name, "--space", "HOUSE_WITH_YARD",
                 "--schedule", "HOME_MOST_OF_DAY", "--species", "DOG");
-        String adopterId = extractId(ar.stdout());
+        return extractId(r.stdout());
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-04.1: Match Animals for an Adopter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that matching animals for an adopter when two available animals are in the shelter
+     * returns scored results containing both animal names, confirming the ranker sees all candidates.
+     */
+    @Test
+    void matchAnimal_multipleAnimals_returnsRankedList() throws Exception {
+        String shelterId = registerShelter();
+        admitDog("Rex", shelterId);
+        admitDog("Max", shelterId);
+        String adopterId = registerAdopter("Alice");
         RunResult r = run("match", "animal",
                 "--adopter", adopterId, "--shelter", shelterId);
         assertSuccess(r);
         assertOutputContains(r, "Rex");
+        assertOutputContains(r, "Max");
     }
 
+    /**
+     * Verifies that matching animals for an adopter when the shelter is empty prints an
+     * empty-result message rather than crashing. Two adopters are registered so the
+     * empty state is confirmed against an existing adopter.
+     */
     @Test
-    void matchAnimal_noAnimalsInShelter_printsEmptyMessage() throws Exception {
+    void matchAnimal_noAnimals_printsEmptyMessage() throws Exception {
         String shelterId = registerShelter();
-        RunResult ar = run("adopter", "register",
-                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
-                "--schedule", "HOME_MOST_OF_DAY");
-        String adopterId = extractId(ar.stdout());
+        registerAdopter("Alice");
+        String adopterId = registerAdopter("Bob");
         RunResult r = run("match", "animal",
                 "--adopter", adopterId, "--shelter", shelterId);
         assertSuccess(r);
         assertOutputContains(r, "No available animals");
     }
 
+    /**
+     * Regression: verifies that an adopter registered without {@code --min-age} or
+     * {@code --max-age} does not apply a default max-age of 20, which would incorrectly
+     * exclude older animals. Both a young and a senior dog must appear in the results.
+     */
     @Test
-    void matchAdopter_returnsRankedList() throws Exception {
+    void matchAnimal_nullAgePrefs_doesNotExcludeOlderAnimals() throws Exception {
         String shelterId = registerShelter();
-        String animalId = admitDog(shelterId);
-        run("adopter", "register",
-                "--name", "Alice", "--space", "HOUSE_WITH_YARD",
+        admitDog("Young", shelterId);
+        run("animal", "admit",
+                "--species", "dog", "--name", "Senior", "--breed", "Lab",
+                "--age", "10", "--activity", "HIGH", "--shelter", shelterId);
+        RunResult adopterResult = run("adopter", "register",
+                "--name", "NoAgePrefs", "--space", "HOUSE_WITH_YARD",
                 "--schedule", "HOME_MOST_OF_DAY");
-        RunResult r = run("match", "adopter", "--animal", animalId);
-        assertSuccess(r);
-        assertOutputContains(r, "Alice");
-    }
-
-    @Test
-    void matchAnimal_adopterWithNoAgePrefs_animalAppearsInResults() throws Exception {
-        String shelterId = registerShelter();
-        admitDog(shelterId);
-        RunResult ar = run("adopter", "register",
-                "--name", "NoAge", "--space", "HOUSE_WITH_YARD",
-                "--schedule", "HOME_MOST_OF_DAY");
-        String adopterId = extractId(ar.stdout());
+        String adopterId = extractId(adopterResult.stdout());
         RunResult r = run("match", "animal",
                 "--adopter", adopterId, "--shelter", shelterId);
         assertSuccess(r);
-        assertOutputContains(r, "Rex");
+        assertOutputContains(r, "Young");
+        assertOutputContains(r, "Senior");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-04.2: Match Adopters for an Animal
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that matching adopters for an available animal when two adopters are registered
+     * returns scored results containing both adopter names.
+     */
+    @Test
+    void matchAdopter_multipleAdopters_returnsRankedList() throws Exception {
+        String shelterId = registerShelter();
+        String animalId = admitDog("Rex", shelterId);
+        registerAdopter("Alice");
+        registerAdopter("Bob");
+        RunResult r = run("match", "adopter", "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "Alice");
+        assertOutputContains(r, "Bob");
+    }
+
+    /**
+     * Verifies that matching adopters when no adopters are registered returns an empty-result
+     * message rather than crashing. Two animals are in the shelter so the empty state is
+     * confirmed against an existing animal.
+     */
+    @Test
+    void matchAdopter_noAdopters_printsEmptyMessage() throws Exception {
+        String shelterId = registerShelter();
+        admitDog("Rex", shelterId);
+        String animalId = admitDog("Max", shelterId);
+        RunResult r = run("match", "adopter", "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "No adopters registered.");
+    }
+
+    /**
+     * Verifies that attempting to match adopters for an already-adopted animal prints an error.
+     * A first adopter approves the animal, then a second adopter attempts a match.
+     */
+    @Test
+    void matchAdopter_adoptedAnimal_printsError() throws Exception {
+        String shelterId = registerShelter();
+        String animalId = admitDog("Rex", shelterId);
+        admitDog("Free", shelterId);
+        String adopterId = registerAdopter("Alice");
+        registerAdopter("Bob");
+        RunResult submitResult = run("adopt", "submit",
+                "--adopter", adopterId, "--animal", animalId);
+        String requestId = extractId(submitResult.stdout());
+        run("adopt", "approve", "--request", requestId);
+        RunResult r = run("match", "adopter", "--animal", animalId);
+        assertOutputContains(r, "Error");
     }
 }

--- a/src/test/java/shelter/integration/ShelterIntegrationTest.java
+++ b/src/test/java/shelter/integration/ShelterIntegrationTest.java
@@ -1,0 +1,44 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter shelter} command group.
+ * Each test runs against a fresh TempDir; no shared state between methods.
+ */
+class ShelterIntegrationTest extends CliIntegrationTest {
+
+    @Test
+    void register_validArgs_printsNameAndId() throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", "Happy Paws", "--location", "Boston", "--capacity", "20");
+        assertSuccess(r);
+        assertOutputContains(r, "Happy Paws");
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void list_noShelters_printsEmptyMessage() throws Exception {
+        RunResult r = run("shelter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "No shelters registered.");
+    }
+
+    @Test
+    void list_afterRegister_showsRegisteredShelter() throws Exception {
+        run("shelter", "register",
+                "--name", "Happy Paws", "--location", "Boston", "--capacity", "20");
+        RunResult r = run("shelter", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Happy Paws");
+        assertOutputContains(r, "Boston");
+    }
+
+    @Test
+    void register_missingRequiredOption_exitNonZero() throws Exception {
+        RunResult r = run("shelter", "register", "--name", "Incomplete");
+        assertNotEquals(0, r.exitCode());
+    }
+}

--- a/src/test/java/shelter/integration/ShelterIntegrationTest.java
+++ b/src/test/java/shelter/integration/ShelterIntegrationTest.java
@@ -6,19 +6,67 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the {@code shelter shelter} command group.
- * Each test runs against a fresh TempDir; no shared state between methods.
+ * Covers UC-01.1 through UC-01.4: register, list, update, and remove shelters,
+ * including duplicate-name, not-found, and non-empty-shelter error cases.
+ * Each test method runs against a fresh {@code @TempDir}; no shared state between methods.
  */
 class ShelterIntegrationTest extends CliIntegrationTest {
 
+    // -------------------------------------------------------------------------
+    // UC-01.1: Register a New Shelter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that registering a shelter with valid name, location, and capacity
+     * exits with code 0 and prints the shelter name and its generated UUID.
+     * A second shelter is registered in the same test to confirm both succeed independently.
+     */
     @Test
     void register_validArgs_printsNameAndId() throws Exception {
-        RunResult r = run("shelter", "register",
+        RunResult r1 = run("shelter", "register",
                 "--name", "Happy Paws", "--location", "Boston", "--capacity", "20");
-        assertSuccess(r);
-        assertOutputContains(r, "Happy Paws");
-        assertOutputContains(r, "id=");
+        assertSuccess(r1);
+        assertOutputContains(r1, "Happy Paws");
+        assertOutputContains(r1, "id=");
+
+        RunResult r2 = run("shelter", "register",
+                "--name", "Second Shelter", "--location", "Cambridge", "--capacity", "10");
+        assertSuccess(r2);
+        assertOutputContains(r2, "Second Shelter");
+        assertOutputContains(r2, "id=");
     }
 
+    /**
+     * Verifies that registering two shelters with the same name and location
+     * prints an error on the second attempt instead of creating a duplicate entry.
+     */
+    @Test
+    void register_duplicateNameAndLocation_printsError() throws Exception {
+        run("shelter", "register",
+                "--name", "Dup", "--location", "Boston", "--capacity", "10");
+        RunResult r = run("shelter", "register",
+                "--name", "Dup", "--location", "Boston", "--capacity", "5");
+        assertOutputContains(r, "Error");
+    }
+
+    /**
+     * Verifies that omitting a required option ({@code --location} here) causes Picocli
+     * to exit with a non-zero code before any business logic executes.
+     */
+    @Test
+    void register_missingRequiredOption_exitNonZero() throws Exception {
+        RunResult r = run("shelter", "register", "--name", "Incomplete");
+        assertNotEquals(0, r.exitCode());
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-01.2: View All Shelters
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that listing shelters when none have been registered prints an empty-list
+     * message rather than crashing or returning blank output.
+     */
     @Test
     void list_noShelters_printsEmptyMessage() throws Exception {
         RunResult r = run("shelter", "list");
@@ -26,19 +74,120 @@ class ShelterIntegrationTest extends CliIntegrationTest {
         assertOutputContains(r, "No shelters registered.");
     }
 
+    /**
+     * Verifies that two shelters registered with distinct names and locations
+     * both appear in the list output, confirming the command aggregates all entries.
+     */
     @Test
-    void list_afterRegister_showsRegisteredShelter() throws Exception {
+    void list_multipleShelters_showsAll() throws Exception {
         run("shelter", "register",
-                "--name", "Happy Paws", "--location", "Boston", "--capacity", "20");
+                "--name", "Alpha", "--location", "Boston", "--capacity", "10");
+        run("shelter", "register",
+                "--name", "Beta", "--location", "Cambridge", "--capacity", "5");
         RunResult r = run("shelter", "list");
         assertSuccess(r);
-        assertOutputContains(r, "Happy Paws");
-        assertOutputContains(r, "Boston");
+        assertOutputContains(r, "Alpha");
+        assertOutputContains(r, "Beta");
     }
 
+    // -------------------------------------------------------------------------
+    // UC-01.3: Update Shelter Information
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that updating an existing shelter's name succeeds and the confirmation
+     * message reflects the new name. A second shelter is registered in the same test
+     * to confirm only the targeted shelter is renamed.
+     */
     @Test
-    void register_missingRequiredOption_exitNonZero() throws Exception {
-        RunResult r = run("shelter", "register", "--name", "Incomplete");
-        assertNotEquals(0, r.exitCode());
+    void update_existingShelter_printsUpdatedName() throws Exception {
+        run("shelter", "register",
+                "--name", "Bystander", "--location", "Cambridge", "--capacity", "5");
+        RunResult reg = run("shelter", "register",
+                "--name", "Old Name", "--location", "Boston", "--capacity", "10");
+        String id = extractId(reg.stdout());
+        RunResult r = run("shelter", "update", "--id", id, "--name", "New Name");
+        assertSuccess(r);
+        assertOutputContains(r, "Updated shelter");
+        assertOutputContains(r, "New Name");
+    }
+
+    /**
+     * Verifies that updating both name and capacity in a single command succeeds and
+     * the updated name appears in the list. Two shelters are registered to confirm
+     * only the targeted shelter's fields change.
+     */
+    @Test
+    void update_multipleFields_newNameAppearsInList() throws Exception {
+        run("shelter", "register",
+                "--name", "Unchanged", "--location", "Cambridge", "--capacity", "5");
+        RunResult reg = run("shelter", "register",
+                "--name", "Target", "--location", "Boston", "--capacity", "10");
+        String id = extractId(reg.stdout());
+        run("shelter", "update", "--id", id, "--name", "Renamed", "--capacity", "15");
+        RunResult list = run("shelter", "list");
+        assertOutputContains(list, "Renamed");
+        assertOutputContains(list, "Unchanged");
+    }
+
+    /**
+     * Verifies that attempting to update a shelter with an unknown ID prints an error.
+     * This exercises the not-found guard in the application layer.
+     */
+    @Test
+    void update_nonExistentId_printsError() throws Exception {
+        RunResult r = run("shelter", "update",
+                "--id", "00000000-0000-0000-0000-000000000000", "--name", "Ghost");
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-01.4: Remove a Shelter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that removing an empty shelter succeeds and it no longer appears in the list.
+     * A second shelter is registered so the list confirms only the targeted shelter is removed.
+     */
+    @Test
+    void remove_emptyShelter_disappearsFromList() throws Exception {
+        run("shelter", "register",
+                "--name", "Stays", "--location", "Cambridge", "--capacity", "5");
+        RunResult reg = run("shelter", "register",
+                "--name", "To Remove", "--location", "Boston", "--capacity", "10");
+        String id = extractId(reg.stdout());
+        RunResult r = run("shelter", "remove", "--id", id);
+        assertSuccess(r);
+        assertOutputContains(r, "Removed shelter");
+        RunResult list = run("shelter", "list");
+        assertOutputDoesNotContain(list, "To Remove");
+        assertOutputContains(list, "Stays");
+    }
+
+    /**
+     * Verifies that attempting to remove a shelter that still contains animals prints an error.
+     * An animal is admitted first so the shelter is non-empty, which must block removal.
+     */
+    @Test
+    void remove_shelterWithAnimals_printsError() throws Exception {
+        RunResult reg = run("shelter", "register",
+                "--name", "Full", "--location", "Boston", "--capacity", "10");
+        String shelterId = extractId(reg.stdout());
+        run("animal", "admit",
+                "--species", "dog", "--name", "Blocker", "--breed", "Lab",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        RunResult r = run("shelter", "remove", "--id", shelterId);
+        assertOutputContains(r, "Error");
+    }
+
+    /**
+     * Verifies that attempting to remove a shelter with an unknown ID prints an error.
+     * This tests the not-found guard without any registered shelters present.
+     */
+    @Test
+    void remove_nonExistentId_printsError() throws Exception {
+        RunResult r = run("shelter", "remove",
+                "--id", "00000000-0000-0000-0000-000000000000");
+        assertOutputContains(r, "Error");
     }
 }

--- a/src/test/java/shelter/integration/TransferIntegrationTest.java
+++ b/src/test/java/shelter/integration/TransferIntegrationTest.java
@@ -6,59 +6,177 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the {@code shelter transfer} command group.
- * Verifies request, approve (animal moves shelter), and reject flows.
+ * Covers UC-06.1 through UC-06.4: request, approve, reject, and cancel transfer requests,
+ * including destination-at-capacity and cancel-after-approve error cases.
  */
 class TransferIntegrationTest extends CliIntegrationTest {
 
-    private String registerShelter(String name) throws Exception {
+    /** Registers a shelter with the given name and capacity and returns its ID. */
+    private String registerShelter(String name, int capacity) throws Exception {
         RunResult r = run("shelter", "register",
-                "--name", name, "--location", "Boston", "--capacity", "10");
+                "--name", name, "--location", "Boston", "--capacity", String.valueOf(capacity));
         return extractId(r.stdout());
     }
 
-    private String admitDog(String shelterId) throws Exception {
+    /** Admits a dog with the given name to the given shelter and returns its ID. */
+    private String admitDog(String name, String shelterId) throws Exception {
         RunResult r = run("animal", "admit",
-                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--species", "dog", "--name", name, "--breed", "Lab",
                 "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         return extractId(r.stdout());
     }
 
+    // -------------------------------------------------------------------------
+    // UC-06.1: Request an Animal Transfer
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that creating a transfer request for an available animal between two shelters
+     * exits successfully and prints the generated request UUID.
+     * Two animals are admitted to the source shelter so the request targets one specifically.
+     */
     @Test
     void request_validTransfer_printsRequestId() throws Exception {
-        String shelterA = registerShelter("Shelter A");
-        String shelterB = registerShelter("Shelter B");
-        String animalId = admitDog(shelterA);
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
+        admitDog("Stays", shelterA);
+        String animalId = admitDog("Rex", shelterA);
         RunResult r = run("transfer", "request",
                 "--animal", animalId, "--from", shelterA, "--to", shelterB);
         assertSuccess(r);
         assertOutputContains(r, "id=");
     }
 
+    /**
+     * Verifies that two animals can each have independent transfer requests created in the same session.
+     * Both confirmations must print a request UUID, confirming independent request creation.
+     */
+    @Test
+    void request_twoAnimals_bothRequestsCreated() throws Exception {
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
+        String animal1 = admitDog("Alpha", shelterA);
+        String animal2 = admitDog("Beta", shelterA);
+        RunResult r1 = run("transfer", "request",
+                "--animal", animal1, "--from", shelterA, "--to", shelterB);
+        RunResult r2 = run("transfer", "request",
+                "--animal", animal2, "--from", shelterA, "--to", shelterB);
+        assertSuccess(r1);
+        assertSuccess(r2);
+        assertOutputContains(r1, "id=");
+        assertOutputContains(r2, "id=");
+    }
+
+    /**
+     * Verifies that requesting a transfer when the destination shelter is at capacity prints an error.
+     * Shelter B is filled to its one-animal limit before the transfer attempt is made.
+     */
+    @Test
+    void request_destinationAtCapacity_printsError() throws Exception {
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 1);
+        String animalForA = admitDog("FromA", shelterA);
+        admitDog("FillerInB", shelterB);
+        RunResult r = run("transfer", "request",
+                "--animal", animalForA, "--from", shelterA, "--to", shelterB);
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-06.2: Approve a Transfer Request
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that approving a transfer request moves the targeted animal to the destination shelter.
+     * A second animal stays in the source shelter to confirm only the transferred animal relocates.
+     */
     @Test
     void approve_validTransfer_animalAppearsInNewShelter() throws Exception {
-        String shelterA = registerShelter("Shelter A");
-        String shelterB = registerShelter("Shelter B");
-        String animalId = admitDog(shelterA);
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
+        admitDog("Stays", shelterA);
+        String transferId = admitDog("Rex", shelterA);
         RunResult requestResult = run("transfer", "request",
-                "--animal", animalId, "--from", shelterA, "--to", shelterB);
+                "--animal", transferId, "--from", shelterA, "--to", shelterB);
         String requestId = extractId(requestResult.stdout());
         RunResult r = run("transfer", "approve", "--request", requestId);
         assertSuccess(r);
         assertOutputContains(r, "Approved transfer request");
-        RunResult list = run("animal", "list", "--shelter", shelterB);
-        assertOutputContains(list, "Rex");
+        RunResult listB = run("animal", "list", "--shelter", shelterB);
+        assertOutputContains(listB, "Rex");
+        RunResult listA = run("animal", "list", "--shelter", shelterA);
+        assertOutputContains(listA, "Stays");
+        assertOutputDoesNotContain(listA, "Rex");
     }
 
+    // -------------------------------------------------------------------------
+    // UC-06.3: Reject a Transfer Request
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that rejecting a transfer request prints a confirmation and leaves both animals
+     * in their original shelters. Two transfer requests are created; only the targeted one is rejected.
+     */
     @Test
-    void reject_validTransfer_printsConfirmation() throws Exception {
-        String shelterA = registerShelter("Shelter A");
-        String shelterB = registerShelter("Shelter B");
-        String animalId = admitDog(shelterA);
+    void reject_validTransfer_animalRemainsInSource() throws Exception {
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
+        String animal1 = admitDog("Rex", shelterA);
+        String animal2 = admitDog("Max", shelterA);
         RunResult requestResult = run("transfer", "request",
-                "--animal", animalId, "--from", shelterA, "--to", shelterB);
+                "--animal", animal1, "--from", shelterA, "--to", shelterB);
         String requestId = extractId(requestResult.stdout());
+        run("transfer", "request",
+                "--animal", animal2, "--from", shelterA, "--to", shelterB);
         RunResult r = run("transfer", "reject", "--request", requestId);
         assertSuccess(r);
         assertOutputContains(r, "Rejected transfer request");
+        RunResult listA = run("animal", "list", "--shelter", shelterA);
+        assertOutputContains(listA, "Rex");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-06.4: Cancel a Transfer Request
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that cancelling a pending transfer request prints a confirmation.
+     * Two animals each have their own transfer request; only one is cancelled to confirm
+     * the cancel targets a specific request.
+     */
+    @Test
+    void cancel_pendingTransfer_printsConfirmation() throws Exception {
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
+        String animal1 = admitDog("Rex", shelterA);
+        String animal2 = admitDog("Max", shelterA);
+        RunResult requestResult = run("transfer", "request",
+                "--animal", animal1, "--from", shelterA, "--to", shelterB);
+        String requestId = extractId(requestResult.stdout());
+        run("transfer", "request",
+                "--animal", animal2, "--from", shelterA, "--to", shelterB);
+        RunResult r = run("transfer", "cancel", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Cancelled transfer request");
+    }
+
+    /**
+     * Verifies that attempting to cancel an already-approved transfer request prints an error.
+     * The state-transition guard must reject a cancel on a non-pending request.
+     */
+    @Test
+    void cancel_alreadyApproved_printsError() throws Exception {
+        String shelterA = registerShelter("Shelter A", 10);
+        String shelterB = registerShelter("Shelter B", 10);
+        String animal1 = admitDog("Rex", shelterA);
+        String animal2 = admitDog("Max", shelterA);
+        RunResult requestResult = run("transfer", "request",
+                "--animal", animal1, "--from", shelterA, "--to", shelterB);
+        String requestId = extractId(requestResult.stdout());
+        run("transfer", "request",
+                "--animal", animal2, "--from", shelterA, "--to", shelterB);
+        run("transfer", "approve", "--request", requestId);
+        RunResult r = run("transfer", "cancel", "--request", requestId);
+        assertOutputContains(r, "Error");
     }
 }

--- a/src/test/java/shelter/integration/TransferIntegrationTest.java
+++ b/src/test/java/shelter/integration/TransferIntegrationTest.java
@@ -1,0 +1,64 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter transfer} command group.
+ * Verifies request, approve (animal moves shelter), and reject flows.
+ */
+class TransferIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter(String name) throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", name, "--location", "Boston", "--capacity", "10");
+        return extractId(r.stdout());
+    }
+
+    private String admitDog(String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void request_validTransfer_printsRequestId() throws Exception {
+        String shelterA = registerShelter("Shelter A");
+        String shelterB = registerShelter("Shelter B");
+        String animalId = admitDog(shelterA);
+        RunResult r = run("transfer", "request",
+                "--animal", animalId, "--from", shelterA, "--to", shelterB);
+        assertSuccess(r);
+        assertOutputContains(r, "id=");
+    }
+
+    @Test
+    void approve_validTransfer_animalAppearsInNewShelter() throws Exception {
+        String shelterA = registerShelter("Shelter A");
+        String shelterB = registerShelter("Shelter B");
+        String animalId = admitDog(shelterA);
+        RunResult requestResult = run("transfer", "request",
+                "--animal", animalId, "--from", shelterA, "--to", shelterB);
+        String requestId = extractId(requestResult.stdout());
+        RunResult r = run("transfer", "approve", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Approved transfer request");
+        RunResult list = run("animal", "list", "--shelter", shelterB);
+        assertOutputContains(list, "Rex");
+    }
+
+    @Test
+    void reject_validTransfer_printsConfirmation() throws Exception {
+        String shelterA = registerShelter("Shelter A");
+        String shelterB = registerShelter("Shelter B");
+        String animalId = admitDog(shelterA);
+        RunResult requestResult = run("transfer", "request",
+                "--animal", animalId, "--from", shelterA, "--to", shelterB);
+        String requestId = extractId(requestResult.stdout());
+        RunResult r = run("transfer", "reject", "--request", requestId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rejected transfer request");
+    }
+}

--- a/src/test/java/shelter/integration/VaccineIntegrationTest.java
+++ b/src/test/java/shelter/integration/VaccineIntegrationTest.java
@@ -1,0 +1,79 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the {@code shelter vaccine} command group.
+ * Covers vaccine type CRUD, recording vaccinations, and overdue checks.
+ */
+class VaccineIntegrationTest extends CliIntegrationTest {
+
+    private String registerShelter() throws Exception {
+        RunResult r = run("shelter", "register",
+                "--name", "Paws", "--location", "Boston", "--capacity", "10");
+        return extractId(r.stdout());
+    }
+
+    private String admitDog(String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    @Test
+    void vaccineType_addAndList_showsType() throws Exception {
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365");
+        RunResult r = run("vaccine", "type", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "Rabies");
+    }
+
+    @Test
+    void record_validVaccination_printsConfirmation() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365");
+        RunResult r = run("vaccine", "record",
+                "--animal", animalId,
+                "--type", "Rabies",
+                "--date", LocalDate.now().toString());
+        assertSuccess(r);
+        assertOutputContains(r, "Recorded vaccination");
+    }
+
+    @Test
+    void overdue_recentVaccination_notOverdue() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365");
+        run("vaccine", "record",
+                "--animal", animalId,
+                "--type", "Rabies",
+                "--date", LocalDate.now().toString());
+        RunResult r = run("vaccine", "overdue", "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "All vaccinations are current");
+    }
+
+    @Test
+    void overdue_expiredVaccination_printsOverdueEntry() throws Exception {
+        String shelterId = registerShelter();
+        String animalId  = admitDog(shelterId);
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365");
+        String pastDate = LocalDate.now().minusYears(2).toString();
+        run("vaccine", "record",
+                "--animal", animalId, "--type", "Rabies", "--date", pastDate);
+        RunResult r = run("vaccine", "overdue", "--animal", animalId);
+        assertSuccess(r);
+        assertOutputContains(r, "Rabies");
+    }
+}

--- a/src/test/java/shelter/integration/VaccineIntegrationTest.java
+++ b/src/test/java/shelter/integration/VaccineIntegrationTest.java
@@ -8,72 +8,265 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the {@code shelter vaccine} command group.
- * Covers vaccine type CRUD, recording vaccinations, and overdue checks.
+ * Covers UC-07.1 through UC-07.6: add vaccine type, record vaccination, check overdue,
+ * update and remove vaccine types, including duplicate-name, species-mismatch,
+ * unknown-type, and not-found error cases.
  */
 class VaccineIntegrationTest extends CliIntegrationTest {
 
+    /** Registers a shelter with ample capacity and returns its ID. */
     private String registerShelter() throws Exception {
         RunResult r = run("shelter", "register",
                 "--name", "Paws", "--location", "Boston", "--capacity", "10");
         return extractId(r.stdout());
     }
 
-    private String admitDog(String shelterId) throws Exception {
+    /** Admits a dog with the given name to the given shelter and returns its ID. */
+    private String admitDog(String name, String shelterId) throws Exception {
         RunResult r = run("animal", "admit",
-                "--species", "dog", "--name", "Rex", "--breed", "Lab",
+                "--species", "dog", "--name", name, "--breed", "Lab",
                 "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         return extractId(r.stdout());
     }
 
+    /** Admits a cat with the given name to the given shelter and returns its ID. */
+    private String admitCat(String name, String shelterId) throws Exception {
+        RunResult r = run("animal", "admit",
+                "--species", "cat", "--name", name, "--breed", "Mix",
+                "--age", "2", "--activity", "LOW", "--shelter", shelterId);
+        return extractId(r.stdout());
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-07.3: Add a Vaccine Type / UC-07.6: View All Vaccine Types
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that adding two vaccine types (DOG and CAT species) and then listing them
+     * shows both entries. This confirms the add-then-list path across different species.
+     */
     @Test
-    void vaccineType_addAndList_showsType() throws Exception {
+    void vaccineType_addAndList_showsBothTypes() throws Exception {
         run("vaccine", "type", "add",
                 "--name", "Rabies", "--species", "DOG", "--days", "365");
+        run("vaccine", "type", "add",
+                "--name", "FeLV", "--species", "CAT", "--days", "365");
         RunResult r = run("vaccine", "type", "list");
         assertSuccess(r);
         assertOutputContains(r, "Rabies");
+        assertOutputContains(r, "FeLV");
     }
 
+    /**
+     * Verifies that adding two vaccine types with the same name prints an error on the
+     * second attempt. The duplicate-name guard must reject the conflicting entry.
+     */
+    @Test
+    void vaccineType_duplicateName_printsError() throws Exception {
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365");
+        RunResult r = run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "CAT", "--days", "180");
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-07.1: Record a Vaccination
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that recording a vaccination for a valid animal and applicable vaccine type
+     * exits successfully and prints a confirmation. A Dog and a Cat are both admitted;
+     * the DOG-species vaccine is applied only to the Dog.
+     */
     @Test
     void record_validVaccination_printsConfirmation() throws Exception {
         String shelterId = registerShelter();
-        String animalId  = admitDog(shelterId);
+        String dogId = admitDog("Rex", shelterId);
+        admitCat("Whiskers", shelterId);
         run("vaccine", "type", "add",
                 "--name", "Rabies", "--species", "DOG", "--days", "365");
         RunResult r = run("vaccine", "record",
-                "--animal", animalId,
+                "--animal", dogId,
                 "--type", "Rabies",
                 "--date", LocalDate.now().toString());
         assertSuccess(r);
         assertOutputContains(r, "Recorded vaccination");
     }
 
+    /**
+     * Verifies that recording a vaccination with an unknown vaccine type name prints an error.
+     * Two animals are admitted to confirm the guard applies regardless of shelter population.
+     */
     @Test
-    void overdue_recentVaccination_notOverdue() throws Exception {
+    void record_unknownVaccineType_printsError() throws Exception {
         String shelterId = registerShelter();
-        String animalId  = admitDog(shelterId);
+        String dogId = admitDog("Rex", shelterId);
+        admitDog("Max", shelterId);
+        RunResult r = run("vaccine", "record",
+                "--animal", dogId,
+                "--type", "NoSuchVaccine",
+                "--date", LocalDate.now().toString());
+        assertOutputContains(r, "Error");
+    }
+
+    /**
+     * Verifies that applying a DOG-species vaccine to a Cat prints a species-mismatch error.
+     * Both a Dog and a Cat are admitted; the error must apply only to the Cat record.
+     */
+    @Test
+    void record_wrongSpecies_printsError() throws Exception {
+        String shelterId = registerShelter();
+        admitDog("Rex", shelterId);
+        String catId = admitCat("Whiskers", shelterId);
+        run("vaccine", "type", "add",
+                "--name", "DogOnly", "--species", "DOG", "--days", "365");
+        RunResult r = run("vaccine", "record",
+                "--animal", catId,
+                "--type", "DogOnly",
+                "--date", LocalDate.now().toString());
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-07.2: Check Overdue Vaccinations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that two vaccinations recorded today are not shown as overdue.
+     * Both Rabies and Bordetella are administered to the same dog on today's date.
+     */
+    @Test
+    void overdue_recentVaccinations_notOverdue() throws Exception {
+        String shelterId = registerShelter();
+        String dogId = admitDog("Rex", shelterId);
+        admitDog("Max", shelterId);
         run("vaccine", "type", "add",
                 "--name", "Rabies", "--species", "DOG", "--days", "365");
+        run("vaccine", "type", "add",
+                "--name", "Bordetella", "--species", "DOG", "--days", "365");
         run("vaccine", "record",
-                "--animal", animalId,
-                "--type", "Rabies",
+                "--animal", dogId, "--type", "Rabies",
                 "--date", LocalDate.now().toString());
-        RunResult r = run("vaccine", "overdue", "--animal", animalId);
+        run("vaccine", "record",
+                "--animal", dogId, "--type", "Bordetella",
+                "--date", LocalDate.now().toString());
+        RunResult r = run("vaccine", "overdue", "--animal", dogId);
         assertSuccess(r);
         assertOutputContains(r, "All vaccinations are current");
     }
 
+    /**
+     * Verifies that two vaccinations administered two years ago both appear in the overdue list.
+     * Both vaccine types have a 365-day validity; administering them two years in the past
+     * guarantees they exceed their validity windows.
+     */
     @Test
-    void overdue_expiredVaccination_printsOverdueEntry() throws Exception {
+    void overdue_multipleExpiredVaccinations_showsAllOverdue() throws Exception {
         String shelterId = registerShelter();
-        String animalId  = admitDog(shelterId);
+        String dogId = admitDog("Rex", shelterId);
+        admitDog("Max", shelterId);
         run("vaccine", "type", "add",
                 "--name", "Rabies", "--species", "DOG", "--days", "365");
+        run("vaccine", "type", "add",
+                "--name", "Bordetella", "--species", "DOG", "--days", "365");
         String pastDate = LocalDate.now().minusYears(2).toString();
-        run("vaccine", "record",
-                "--animal", animalId, "--type", "Rabies", "--date", pastDate);
-        RunResult r = run("vaccine", "overdue", "--animal", animalId);
+        run("vaccine", "record", "--animal", dogId, "--type", "Rabies", "--date", pastDate);
+        run("vaccine", "record", "--animal", dogId, "--type", "Bordetella", "--date", pastDate);
+        RunResult r = run("vaccine", "overdue", "--animal", dogId);
         assertSuccess(r);
         assertOutputContains(r, "Rabies");
+        assertOutputContains(r, "Bordetella");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-07.4: Update a Vaccine Type
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that updating a vaccine type's name succeeds, the confirmation reflects the
+     * new name, and the list shows the renamed entry while the old name is absent.
+     * A second vaccine type is registered to confirm only the targeted entry is renamed.
+     */
+    @Test
+    void vaccineType_update_printsUpdatedName() throws Exception {
+        run("vaccine", "type", "add",
+                "--name", "OtherVaccine", "--species", "CAT", "--days", "180");
+        RunResult add = run("vaccine", "type", "add",
+                "--name", "OldVaccine", "--species", "DOG", "--days", "180");
+        String typeId = extractId(add.stdout());
+        RunResult r = run("vaccine", "type", "update",
+                "--id", typeId, "--name", "NewVaccine");
+        assertSuccess(r);
+        assertOutputContains(r, "Updated vaccine type");
+        assertOutputContains(r, "NewVaccine");
+        RunResult list = run("vaccine", "type", "list");
+        assertOutputContains(list, "NewVaccine");
+        assertOutputDoesNotContain(list, "OldVaccine");
+    }
+
+    /**
+     * Verifies that renaming a vaccine type to a name already used by another type prints an error.
+     * The duplicate-name guard must prevent the conflicting rename.
+     */
+    @Test
+    void vaccineType_updateDuplicateName_printsError() throws Exception {
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365");
+        RunResult add = run("vaccine", "type", "add",
+                "--name", "Bordetella", "--species", "DOG", "--days", "180");
+        String typeId = extractId(add.stdout());
+        RunResult r = run("vaccine", "type", "update",
+                "--id", typeId, "--name", "Rabies");
+        assertOutputContains(r, "Error");
+    }
+
+    /**
+     * Verifies that attempting to update a vaccine type with an unknown ID prints an error.
+     * A valid vaccine type is registered to rule out false positives from an empty catalog.
+     */
+    @Test
+    void vaccineType_updateNonExistentId_printsError() throws Exception {
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365");
+        RunResult r = run("vaccine", "type", "update",
+                "--id", "00000000-0000-0000-0000-000000000000", "--name", "Ghost");
+        assertOutputContains(r, "Error");
+    }
+
+    // -------------------------------------------------------------------------
+    // UC-07.5: Remove a Vaccine Type
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that removing a vaccine type succeeds and it no longer appears in the catalog.
+     * A second vaccine type is registered to confirm it remains after the targeted removal.
+     */
+    @Test
+    void vaccineType_remove_disappearsFromList() throws Exception {
+        run("vaccine", "type", "add",
+                "--name", "Stays", "--species", "CAT", "--days", "180");
+        RunResult add = run("vaccine", "type", "add",
+                "--name", "TempVaccine", "--species", "DOG", "--days", "90");
+        String typeId = extractId(add.stdout());
+        RunResult r = run("vaccine", "type", "remove", "--id", typeId);
+        assertSuccess(r);
+        assertOutputContains(r, "Removed vaccine type");
+        RunResult list = run("vaccine", "type", "list");
+        assertOutputDoesNotContain(list, "TempVaccine");
+        assertOutputContains(list, "Stays");
+    }
+
+    /**
+     * Verifies that attempting to remove a vaccine type with an unknown ID prints an error.
+     * A valid vaccine type is registered to rule out false positives from an empty catalog.
+     */
+    @Test
+    void vaccineType_removeNonExistentId_printsError() throws Exception {
+        run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365");
+        RunResult r = run("vaccine", "type", "remove",
+                "--id", "00000000-0000-0000-0000-000000000000");
+        assertOutputContains(r, "Error");
     }
 }


### PR DESCRIPTION
## Overview

This is the final PR before the 2026-04-21 in-class demo. It bundles the last two sprints of work: a full CLI integration-test suite, the agent-driven demo tooling, and a series of polish fixes that surfaced while rehearsing the live demo with Claude Code as the AI agent.

The branch is 84 commits ahead of `main`. Substantive themes are grouped below. All items listed are merged into this branch and pass locally via `./gradlew test`.

---

## 1. CLI Integration Test Suite (UC-01 — UC-08)

A new `@Tag(\"integration\")` layer that spawns the real `shelter` binary via `ProcessBuilder` and verifies end-to-end behavior. Total: **78 integration tests** across 9 test classes.

- `CliIntegrationTest` base class — `run(...)` helper, stdout/stderr capture, `assertSuccess`, `assertOutputContains`, `extractId` (`src/test/java/shelter/integration/CliIntegrationTest.java`)
- Per-command-group test classes: `Shelter`, `Animal`, `Adopter`, `Adopt`, `Transfer`, `Match`, `Vaccine`, `Audit`, `CrossSession`
- Isolation strategy: each test points the CLI at a per-test `@TempDir` via the new `SHELTER_HOME` environment variable, so the real `~/shelter` directory is never touched
- Coverage spans every happy path, every documented error case, and CSV cross-session persistence
- `build.gradle`: `test` task depends on `installDist` automatically
- Plan documents: `docs/integration-test-plan.md`, `docs/integration-test-tasks.md`

Supporting product changes:
- `feat(cli): support SHELTER_HOME env var for test isolation` — `Main` resolves the work directory from the env var when present
- `fix(application): guard removeAnimal/removeAdopter against pending adoption requests` — closed a hole the integration tests caught

---

## 2. Demo Tooling for the AI Agent

The demo flow is: user speaks natural language → Claude Code interprets → Claude calls `shelter` CLI commands. To make this reliable, the runtime work directory now ships with its own context file and behavior contract for the agent.

**`WorkdirBootstrapper`** (`src/main/java/shelter/startup/WorkdirBootstrapper.java`) — generates `~/shelter/CLAUDE.md` on first launch with these agent rules:

1. **Language: English only** — agent must respond in English regardless of user's input language
2. **Ignore personal memory** — agent must not apply or cite `~/.claude/` memory during the demo
3. **Deletion requires confirmation** — every `remove` command must prompt before executing
4. **Approval-step commands: submit only, then wait** — `submit`/`request` calls must not auto-chain into `approve`/`reject`/`cancel`
5. **Always render results as tables with all fields** — agent must format every list/show output as a markdown table and never omit columns (even `N/A` or `any`)

Plus the full CLI command reference inline so the agent has a single source of truth.

**Demo helper script** (`scripts/init-demo.sh`):
- Removes any existing `~/shelter/`
- Runs `./gradlew installDist`
- Triggers `shelter --version` to regenerate `~/shelter/CLAUDE.md` and `data/`
- Drops the user into an interactive shell at `~/shelter` with `shelter` already on `PATH`

**Demo documents:**
- `docs/demo-script.md` — the 10-command happy-path script for the live presentation
- `docs/test-live.md` — the 9-phase / 25-step pre-demo dry-run covering every UC plus error cases
- `docs/demo-plan.md` — slide outline and timing for the 2026-04-21 in-class presentation

---

## 3. CLI Display Improvements

Both list commands now show **every field** so the agent can render complete tables:

- `feat(cli): animal list shows all columns including species-specific fields` — 12-column layout (ID / Species / Name / Breed / Age / Activity / Neutered / Indoor / Size / Fur / Shelter / Status); inapplicable species fields print `N/A` rather than being hidden
- `feat(cli): adopter list shows all preference fields` — 10-column layout; unset preferences print `any`
- `feat(animal): add AnimalView and listAnimalsWithShelterName for shelter-aware list` — introduces `shelter.application.model.AnimalView` so the CLI never crosses domains to resolve the shelter name; the application layer hands back `(Animal, shelterName)` pairs

---

## 4. CLI Functional Fixes

- `feat(animal): support --neutered update for dogs and cats` — `shelter animal update --neutered true|false` works via `instanceof` pattern matching in `AnimalApplicationServiceImpl`; rabbits and `other` silently ignore the flag
- Updated `AnimalApplicationService.updateAnimal` to a 4-arg signature and propagated to all unit tests
- New integration coverage: `update_neutered_changesNeuteredStatus`, `list_allAnimals_showsShelterNameColumn`, `list_byShelter_showsCorrectShelterName`

---

## 5. Documentation Sync

- `CLAUDE.md` (project) — column layouts for animal/adopter list, `--neutered` documented for `update`, agent-rules section relocated out of the project doc and into the runtime template
- All demo/live-test docs converted to a uniform format: `**N — heading**` → triple-backtick code block (Claude instruction) → ✅ plain-English expected result
- `docs/test-live.md` is a strict superset of `docs/demo-script.md` so the dry-run guarantees the live demo

---

## How to Verify

\`\`\`bash
# 1. Run the full test suite (unit + integration)
./gradlew test

# 2. Reset the demo environment and verify the bootstrap
./scripts/init-demo.sh
cat ~/shelter/CLAUDE.md          # confirm the 5 agent rules are present
shelter --version

# 3. Walk the happy path
#    Open docs/demo-script.md and run the 10 steps with Claude Code as the agent

# 4. Walk the full dry-run
#    Open docs/test-live.md and run all 9 phases / 25 steps
\`\`\`

## Test plan

- [ ] `./gradlew test` passes (unit + 78 integration tests)
- [ ] `scripts/init-demo.sh` produces a clean `~/shelter/` with the regenerated `CLAUDE.md`
- [ ] `docs/demo-script.md` end-to-end run with Claude Code agent — all 10 ✅ checks pass
- [ ] `docs/test-live.md` end-to-end run — all 25 ✅ checks pass and every error case prints a clear message without crashing
- [ ] `shelter audit log` after a full dry-run shows the complete operation history
- [ ] After restart (`shelter shelter list` in a fresh shell), all data persists from the previous session