### PR TITLE
feat: shelter print dashboard, demo scripts, and agent CLAUDE.md rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,198 @@
 # Multi-Shelter Animal Adoption Management System
 
-A Java-based system for managing animal adoption workflows across multiple shelters. Built as a final project for CS 5004 at Northeastern University, with a focus on object-oriented design principles.
+**This system is designed to be operated by an AI agent.**
+The user speaks in natural language. Claude Code interprets the intent and executes `shelter` CLI commands on their behalf.
 
-## Overview
+## What This System Is
 
-The system models the real-world workflow between animal shelters and prospective adopters. It supports animal management, adoption and transfer requests, vaccination tracking, smart animal-adopter matching via configurable strategies, and AI-assisted match explanations.
+Animal shelters have a coordination problem. Dozens of animals need homes. Dozens of prospective adopters have different lifestyles, living spaces, and preferences. Animals move between shelters. Vaccines expire. Requests get approved, rejected, cancelled. Someone needs to keep track of all of it.
 
-The project prioritizes a clean OOD architecture over a complex UI.
+This system manages that entire workflow — across multiple shelters, for any number of animals and adopters — through a single CLI tool called `shelter`. It is built as a Java OOD project, but it is designed to be *driven by an AI agent*: the operator speaks in natural language, and Claude Code translates that into the right sequence of commands.
+
+## What It Can Do
+
+| | |
+|---|---|
+| **Shelters** | Register multiple shelters with name, location, and capacity |
+| **Animals** | Admit dogs, cats, rabbits, or any other species; track breed, age, activity level, and species-specific traits |
+| **Adopters** | Register with lifestyle context (living space, schedule) and preferences (species, breed, age range, vaccination requirements) |
+| **Matching** | Score and rank animals for an adopter — or adopters for an animal — across six independent compatibility strategies; Claude generates a plain-language explanation of the result |
+| **Adoptions** | Full request lifecycle: submit → approve/reject → cancel; adopted animals are locked to their new owner |
+| **Transfers** | Move animals between shelters with the same approve/reject/cancel flow; capacity is enforced |
+| **Vaccinations** | Record vaccines by type and date; flag overdue animals; manage a per-species vaccine catalog |
+| **Audit** | Append-only log of every operation, with timestamp and actor |
+
+## How It Works
+
+A human says:
+
+> *"Find a good match for the golden retriever in shelter 2, then submit an adoption request from Alice."*
+
+Claude Code runs:
+
+```bash
+shelter shelter list                        # get shelter IDs
+shelter animal list --shelter <id>          # find the dog's ID
+shelter adopter list                        # find Alice's ID
+shelter match adopter --animal <animal-id>  # confirm Alice ranks well
+shelter adopt submit --adopter <alice-id> --animal <animal-id>
+```
+
+The `shelter` CLI is the only interface. All state is persisted to `~/shelter/data/` as CSV files. Every command is stateless — load, act, save.
+
+**IDs are never known in advance. Always `list` first.**
+
+## Command Overview
+
+| Area | What you can do |
+|---|---|
+| Shelters | Register, update, remove shelters; list all |
+| Animals | Admit animals (dog/cat/rabbit/other), update records, remove, list by shelter |
+| Adopters | Register with lifestyle + preferences, update, remove, list all |
+| Matching | Rank animals for an adopter; rank adopters for an animal |
+| Adoptions | Submit requests, approve/reject/cancel, view status |
+| Transfers | Request inter-shelter moves, approve/reject/cancel |
+| Vaccinations | Record vaccines, check overdue, manage vaccine type catalog |
+| Audit | View the full operation history |
+
+## CLI Reference
+
+### Shelter
+```bash
+shelter shelter list
+shelter shelter register --name <name> --location <location> --capacity <n>
+shelter shelter update --id <id> [--name <name>] [--location <location>] [--capacity <n>]
+shelter shelter remove --id <id>
+```
+
+### Animal
+```bash
+shelter animal list [--shelter <id>]
+shelter animal admit --species dog|cat|rabbit|other \
+  --name <name> --breed <breed> --age <years> \
+  --activity <LOW|MEDIUM|HIGH> --shelter <id> [species-specific flags]
+shelter animal update --id <id> [--name <name>] [--activity <...>] [--neutered <true|false>]
+shelter animal remove --id <id>
+```
+
+Species-specific flags for `admit`:
+- `dog` → `[--size <SMALL|MEDIUM|LARGE>] [--neutered]`
+- `cat` → `[--indoor] [--neutered]`
+- `rabbit` → `[--fur <SHORT|LONG>]`
+- `other` → `--species-name <e.g. fish>`
+
+### Adopter
+```bash
+shelter adopter list
+shelter adopter register --name <name> \
+  --space <APARTMENT|HOUSE_NO_YARD|HOUSE_WITH_YARD> \
+  --schedule <HOME_MOST_OF_DAY|AWAY_PART_OF_DAY|AWAY_MOST_OF_DAY> \
+  [--species <DOG|CAT|RABBIT|OTHER>] [--breed <breed>] [--activity <LOW|MEDIUM|HIGH>] \
+  [--requires-vaccinated <true|false>] [--min-age <n>] [--max-age <n>]
+shelter adopter update --id <id> [same optional flags]
+shelter adopter remove --id <id>
+```
+
+### Matching
+```bash
+shelter match animal  --adopter <id> --shelter <id>   # rank animals for an adopter
+shelter match adopter --animal <id>                    # rank adopters for an animal
+```
+
+### Adoption
+```bash
+shelter adopt submit  --adopter <id> --animal <id>
+shelter adopt approve --request <id>
+shelter adopt reject  --request <id>
+shelter adopt cancel  --request <id>
+```
+
+### Transfer
+```bash
+shelter transfer request --animal <id> --from <shelter-id> --to <shelter-id>
+shelter transfer approve --request <id>
+shelter transfer reject  --request <id>
+shelter transfer cancel  --request <id>
+```
+
+### Vaccination
+```bash
+shelter vaccine record  --animal <id> --type <vaccine-type-name> --date <yyyy-mm-dd>
+shelter vaccine overdue --animal <id>
+shelter vaccine type list
+shelter vaccine type add    --name <name> --species <DOG|CAT|RABBIT|OTHER> --days <n>
+shelter vaccine type update --id <id> [--name <name>] [--species <...>] [--days <n>]
+shelter vaccine type remove --id <id>
+```
+
+### Audit
+```bash
+shelter audit log
+```
+
 
 ## Architecture
 
-The system is organized into three layers:
+Five layers, each with a single responsibility:
 
 ```
-Strategy Layer  ←  interchangeable rules (MatchingStrategy, VaccinationStrategy, ...)
-Service Layer   ←  business workflows (AdoptionService, MatchingService, ...)
-Domain Layer    ←  core entities (Animal, Shelter, Adopter, AdoptionRequest, ...)
+Presentation Layer  ←  Picocli CLI (shelter animal admit ..., shelter adopt approve ...)
+Application Layer   ←  orchestrates use cases across multiple services
+Service Layer       ←  single-responsibility business operations
+Strategy Layer      ←  pluggable scoring rules (IMatchingStrategy and implementations)
+Domain Layer        ←  core entities (Animal, Shelter, Adopter, AdoptionRequest, ...)
 ```
 
-### Domain Layer
+**Matching** is powered by six composable strategies — `SpeciesPreferenceStrategy`, `BreedPreferenceStrategy`, `ActivityLevelStrategy`, `AgePreferenceStrategy`, `LifestyleCompatibilityStrategy`, `VaccinationPreferenceStrategy` — each independently scoreable and combinable. AI explanation runs *after* scoring and does not affect results.
 
-| Class | Description |
-|---|---|
-| `Animal` | Base class with subclasses `Dog`, `Cat`, `Rabbit` |
-| `Shelter` | Holds a collection of animals, manages capacity and location |
-| `Adopter` | Prospective adopter with preferences and lifestyle context |
-| `AdoptionRequest` | Links an adopter to a target animal, tracks request status |
-| `TransferRequest` | Models an inter-shelter animal transfer request |
-
-### Service Layer
-
-| Service | Description |
-|---|---|
-| `AdoptionService` | Manages adoption request lifecycle (submit, validate, approve, reject) |
-| `TransferService` | Handles inter-shelter transfers |
-| `MatchingService` | Scores and ranks animals for a given adopter using configurable strategies |
-| `VaccinationService` | Tracks vaccination records and schedules reminders |
-| `RequestNotificationService` | Dispatches status updates to adopters and shelter staff |
-| `ExplanationService` | Interface with `AIExplanationService` (external AI API) and `MockExplanationService` (for testing) |
-
-### Strategy Layer
-
-Encapsulates interchangeable rules consumed by the services:
-
-- **MatchingStrategy** → `BreedStrategy`, `ActivityStrategy`, `LifestyleStrategy`
-- New strategies can be added without modifying core services (Open/Closed Principle)
-
-## Key Features
-
-- Multi-shelter animal and capacity management
-- Adoption and inter-shelter transfer request workflows
-- Vaccination record tracking and follow-up reminders
-- Adopter-animal matching scored by composable strategy rules
-- AI-assisted natural-language explanation of match results (post-processing only, does not affect scores)
-- Event notifications on request status changes
+**Animals** support four species: `Dog`, `Cat`, `Rabbit`, and `Other` (free-form species name).
 
 ## Getting Started
 
-**Prerequisites**: Java 21+, Maven
+**Prerequisites:** Java 21+, Gradle (wrapper included)
 
 ```bash
 git clone https://github.com/guanyu-gerry-tao/management-system-for-multi-shelter-animal-adoption.git
 cd management-system-for-multi-shelter-animal-adoption
-mvn compile
-mvn test
+
+./gradlew installDist
+export PATH="$HOME/shelter/bin:$PATH"
+
+shelter --help
 ```
+
+Run all tests:
+```bash
+./gradlew test
+```
+
+Integration tests spawn real `shelter` subprocesses via `ProcessBuilder`, isolated with `SHELTER_HOME` pointing to a `@TempDir` — the real `~/shelter/` is never touched.
 
 ## Project Structure
 
 ```
-src/
-  main/java/
-    domain/       # Animal, Shelter, Adopter, AdoptionRequest, TransferRequest
-    service/      # AdoptionService, MatchingService, TransferService, ...
-    strategy/     # MatchingStrategy and implementations
-  test/java/      # JUnit unit tests
+src/main/java/shelter/
+  cli/          # Presentation layer — Picocli subcommands
+  application/  # Application layer — use-case orchestrators
+  service/      # Service layer — business operations
+  strategy/     # Strategy layer — matching scoring rules
+  domain/       # Domain layer — entities and value objects
+  repository/   # CSV-backed persistence
+  exception/    # Domain-specific exceptions
 docs/
-  proposal.md           # Machine-readable proposal with diagrams
-  proposal-for-pdf.md   # Human-readable proposal
-  diagram-class.mmd     # Class diagram (Mermaid source)
-  diagram-layer.mmd     # Layer architecture diagram
+  use-cases.md              # Use-case list with method signatures
+  integration-test-plan.md  # Integration test design
+  diagram-class.mmd         # Class diagram (Mermaid)
+  diagram-layer.mmd         # Layer architecture diagram
 ```
+
 
 ## Team
 
-| Name | GitHub | Email | Student ID |
-|---|---|---|---|
-| Guanyu (Gerry) Tao | [@guanyu-gerry-tao](https://github.com/guanyu-gerry-tao) | tao.gua@northeastern.edu | 002593169 |
-| Yiying (Irene) Xie | [@Bestpart-Irene](https://github.com/Bestpart-Irene) | xie.yiyi@northeastern.edu | 002591741 |
-| Yuxi (Molly) Ou | [@mollyouyuxi](https://github.com/mollyouyuxi) | ou.yux@northeastern.edu | 003163051 |
+| Name | GitHub | Email |
+|---|---|---|
+| Guanyu (Gerry) Tao | [@guanyu-gerry-tao](https://github.com/guanyu-gerry-tao) | tao.gua@northeastern.edu |
+| Yiying (Irene) Xie | [@Bestpart-Irene](https://github.com/Bestpart-Irene) | xie.yiyi@northeastern.edu |
+| Yuxi (Molly) Ou | [@mollyouyuxi](https://github.com/mollyouyuxi) | ou.yux@northeastern.edu |
+
+*CS 5004 Final Project · Northeastern University · Spring 2026*

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,91 +1,98 @@
-# Demo Script (Happy Path)
+# Demo Script (Happy Path, Compound Prompts)
 
-Quick demo covering all major features in ~10 commands.
-IDs returned at each step are used in later commands — note them as you go.
+Four prompts cover the whole system. Each one bundles several related CLI actions so the agent demonstrates natural-language → multi-command translation. The live dashboard (`shelter print --watch` writing `~/shelter/dashboard.md`, rendered by VS Code markdown preview) updates after every batch so the audience sees shelters, animals, adopters, requests, and vaccinations all appearing together.
 
-**Setup** (run before demo):
+**Setup** (from project root; full instructions in `docs/test-live.md`):
 ```bash
-./gradlew installDist
-export PATH="$PWD/build/install/shelter/bin:$PATH"
-rm -rf ~/shelter/data
+bash scripts/init-demo.sh         # wipes ~/shelter, builds, regenerates CLAUDE.md
+shelter print --watch &           # Pane A — watcher
+code ~/shelter/dashboard.md       # Pane B — Cmd+K V for markdown preview
+cd ~/shelter && claude            # Pane C — agent picks up ~/shelter/CLAUDE.md
 ```
+
+Warm-up (not counted): just say `hi` to the agent. It should introduce itself as the shelter management assistant without running any command.
 
 ---
 
-**1 — Register a shelter**
+**1 — Populate the system: shelters, animals, adopters**
 ```
-Register a shelter called "Boston Paws" in Boston with a capacity of 20.
+Register two shelters:
+- "Boston Paws" in Boston, capacity 20
+- "Cambridge Care" in Cambridge, capacity 10
+
+Admit four animals:
+- Buddy — Labrador, 3 years old, activity HIGH, size LARGE, into Boston Paws
+- Luna — Siamese cat, 2 years old, activity LOW, indoor, neutered, into Boston Paws
+- Fluffy — Dutch rabbit, 1 year old, activity MEDIUM, into Boston Paws
+- Max — Golden Retriever, 4 years old, activity MEDIUM, size LARGE, neutered, into Cambridge Care
+
+Register two adopters:
+
+Alice
+- Lives in a house with yard, home most of the day
+- Prefers Labradors, high activity level
+- Requires vaccinated animals
+- Age range 1 to 5
+
+Bob
+- Lives in an apartment, away part of the day
+- Prefers indoor cats, low activity
+- No vaccination requirement, no age limit
+
+Finally print the full system snapshot.
 ```
-✅ One confirmation line with the shelter name and a generated ID.
+✅ Nine confirmation lines (2 shelter + 4 animal + 2 adopter + 1 print call), then the snapshot with Shelters / Animals / Adopters populated and everything else `(none)`.
 
 ---
 
-**2 — Admit a dog**
+**2 — Match, adopt, vaccinate**
 ```
-Admit a 3-year-old Labrador named Buddy into Boston Paws, activity level HIGH, size LARGE.
+Find the best animal in Boston Paws for Alice, submit an adoption request for whichever scored highest, then approve it.
+
+Next, set up the vaccine catalog:
+- Rabies for dogs, valid 365 days
+- Feline FVRCP for cats, valid 365 days
+
+Record two vaccinations: Buddy received Rabies today, and Luna received Feline FVRCP today.
+
+Print the snapshot at the end.
 ```
-✅ One confirmation line showing Buddy's ID and the shelter ID.
+✅ A ranked match table (Buddy wins), a submit+approve pair, two vaccine-type additions, two vaccinations, then a snapshot showing Buddy as `adopted` and both Vaccine Types / Vaccinations sections populated.
 
 ---
 
-**3 — Admit a cat**
+**3 — Transfer workflow with a rejection, plus updates**
 ```
-Admit a 2-year-old Siamese cat named Luna into Boston Paws, activity LOW, she is indoor and neutered.
+Request a transfer for Luna from Boston Paws to Cambridge Care, then reject that request.
+
+Submit a fresh transfer request for Luna from Boston Paws to Cambridge Care, and approve it this time.
+
+Also make these updates while you're at it:
+- Rename Max to Rocky
+- Change Bob's preferred activity level to MEDIUM
+
+Print the snapshot at the end.
 ```
-✅ One confirmation line showing Luna's ID and the shelter ID.
+✅ Two transfer-request lifecycles (one rejected, one approved), two update confirmations, then a snapshot where Luna is in Cambridge Care, Transfer Requests shows a REJECTED row and an APPROVED row, and Max's row now reads Rocky.
 
 ---
 
-**4 — Register an adopter**
+**4 — Errors, then audit log wrap-up**
 ```
-Register an adopter named Alice — she lives in a house with yard, is home most of the day, prefers dogs, specifically Labradors, high activity level, requires vaccinated animals, age range 1 to 5.
+Try three operations that should fail — show me the error message for each:
+1. Submit an adoption request for Bob to adopt Buddy (Buddy is already adopted).
+2. Give Luna the Rabies vaccine (Rabies is for dogs only).
+3. Delete Cambridge Care (it still holds animals).
+
+After that, show me the audit log so we can review every action from this session.
 ```
-✅ One confirmation line with Alice's name and generated ID.
+✅ Three distinct error messages, system state unchanged, then the full audit log — a chronological table covering every registration / admit / match / adopt / vaccinate / transfer / update event performed so far.
 
 ---
 
-**5 — Smart matching**
-```
-Match animals in Boston Paws for Alice.
-```
-✅ A ranked table — Buddy should score the highest because species, breed, age, and activity all match Alice's preferences.
+## Tips for compound prompts
 
----
-
-**6 — Submit adoption request**
-```
-Alice wants to adopt Buddy, submit the request.
-```
-✅ One confirmation line showing the request ID, Alice's ID, and Buddy's ID.
-
----
-
-**7 — Approve adoption**
-```
-Approve that adoption request.
-```
-✅ One confirmation line showing the request is approved. Buddy's status is now adopted.
-
----
-
-**8 — Vaccination**
-```
-Add a vaccine type called Rabies for dogs, valid for 365 days. Then record that Buddy received it today.
-```
-✅ Two confirmation lines — one for the new vaccine type, one for the vaccination record.
-
----
-
-**9 — Second shelter and transfer**
-```
-Register a second shelter called "Cambridge Care" in Cambridge with capacity 10. Then transfer Luna from Boston Paws to Cambridge Care.
-```
-✅ Two confirmation lines — one for the new shelter, one for the pending transfer request.
-
----
-
-**10 — Audit log**
-```
-Show the audit log.
-```
-✅ A table listing every action taken this session, each row showing timestamp, staff name, action type, and target.
+- **Reference entities by description, not UUID.** *"whichever scored highest"*, *"that transfer request"*, *"the animal we just admitted"* — the agent re-uses IDs from its own tool output.
+- **End each step with `print` or `list`.** Confirms the action landed and makes the dashboard update visible to the audience.
+- **Bundle by story, not by entity type.** Step 2 above bundles match → adopt → vaccinate because that's a single narrative; splitting them would lose the flow.
+- **Approval / rejection must be explicit.** `CLAUDE.md` tells the agent to stop after `submit` or `request`. Adding "then approve" in the same prompt is the trigger to continue.

--- a/docs/presentation/deck.html
+++ b/docs/presentation/deck.html
@@ -1,0 +1,485 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Multi-Shelter Animal Adoption Management System — CS 5004 Final</title>
+
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reset.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reveal.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/theme/white.css" id="theme">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/plugin/highlight/monokai.css">
+
+  <style>
+    :root {
+      --r-main-font: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      --r-heading-font: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      --r-main-color: #1f2328;
+      --r-heading-color: #0b2545;
+      --r-link-color: #2563eb;
+      --r-selection-background-color: #fde68a;
+    }
+
+    .reveal .slides { text-align: left; }
+
+    /* 96px padding = 1-inch margin; vertical centering; overflow safety. */
+    .reveal .slides > section,
+    .reveal .slides > section > section {
+      box-sizing: border-box;
+      padding: 96px !important;
+      height: 100% !important;
+      top: 0 !important;
+      overflow: hidden;
+      display: flex !important;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    /* Auto-fit wrapper — JS applies transform: scale() on overflow. */
+    .slide-fit {
+      transform-origin: center center;
+      width: 100%;
+    }
+
+    .reveal h1 { font-size: 1.6em; margin-bottom: 0.3em; letter-spacing: -0.01em; line-height: 1.15; }
+    .reveal h2 { font-size: 1.1em; margin-bottom: 0.35em; letter-spacing: -0.01em; }
+    .reveal h3 { font-size: 0.8em; color: #475569; font-weight: 600; margin-top: 0; margin-bottom: 0.25em; }
+    .reveal p, .reveal li { font-size: 0.56em; line-height: 1.4; }
+    .reveal ul { margin-left: 1.0em; }
+    .reveal ul li { margin-bottom: 0.2em; }
+    .reveal ul ul { margin-top: 0.1em; }
+    .reveal ul ul li { font-size: 0.92em; color: #475569; }
+
+    .reveal pre {
+      width: 100%;
+      box-shadow: none;
+      margin: 0.25em 0;
+      font-size: 0.38em;
+      line-height: 1.4;
+    }
+    .reveal pre code {
+      padding: 0.8em 1em;
+      border-radius: 6px;
+    }
+
+    /* Title slide */
+    .reveal .title-slide h1 { color: #0b2545; font-size: 1.5em; margin-bottom: 0.3em; line-height: 1.15; }
+    .reveal .title-slide .subtitle { color: #475569; font-size: 0.65em; margin-bottom: 1.1em; }
+    .reveal .title-slide .team { color: #1f2328; font-size: 0.55em; }
+    .reveal .title-slide .team span { display: inline-block; margin: 0 0.75em; text-align: center; }
+    .reveal .title-slide .team span small { display: block; color: #64748b; font-weight: 400; font-size: 0.85em; margin-top: 0.15em; }
+    .reveal .title-slide { text-align: center; }
+
+    /* Kicker eyebrow */
+    .reveal .kicker {
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: #64748b;
+      font-size: 0.45em;
+      font-weight: 600;
+      margin-bottom: 0.5em;
+    }
+
+    /* One-liner under title */
+    .reveal .oneliner {
+      font-size: 0.62em;
+      color: #334155;
+      line-height: 1.4;
+      margin-top: -0.1em;
+      margin-bottom: 1em;
+      font-style: italic;
+    }
+
+    /* Multi-section bullets (Slide 2 "3 tabs vertical") */
+    .section-block {
+      border-left: 3px solid #0b2545;
+      padding: 0.3em 0.9em;
+      margin-bottom: 0.5em;
+      background: #f8fafc;
+    }
+    .section-block .section-label {
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #0b2545;
+      font-size: 0.48em;
+      font-weight: 700;
+      margin-bottom: 0.15em;
+    }
+    .section-block ul { margin: 0 0 0 1em; padding: 0; }
+    .section-block ul li { font-size: 0.56em; margin-bottom: 0.1em; }
+    .section-block p { margin: 0; font-size: 0.56em; line-height: 1.4; }
+
+    /* Layer stack (Slide 3) */
+    .layer-stack {
+      display: grid;
+      gap: 0.25em;
+      margin: 0.4em 0 0.7em 0;
+    }
+    .layer-row {
+      display: grid;
+      grid-template-columns: 180px 1fr;
+      gap: 1em;
+      padding: 0.35em 0.8em;
+      border-left: 3px solid #0b2545;
+      background: #f8fafc;
+      font-size: 0.58em;
+      line-height: 1.35;
+      align-items: baseline;
+    }
+    .layer-row .name { font-weight: 700; color: #0b2545; }
+    .layer-row .desc { color: #334155; }
+
+    .tools-strip {
+      font-size: 0.55em;
+      color: #334155;
+      padding: 0.5em 0;
+      border-top: 1px solid #e2e8f0;
+      margin-top: 0.4em;
+    }
+    .tools-strip strong { color: #0b2545; }
+
+    /* LIVE DEMO divider */
+    .demo-slide {
+      text-align: center;
+      align-items: center;
+    }
+    .demo-slide .demo-kicker {
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+      color: #64748b;
+      font-size: 0.55em;
+      font-weight: 600;
+      margin-bottom: 0.6em;
+    }
+    .demo-slide .demo-title {
+      font-size: 2.0em;
+      font-weight: 800;
+      color: #0b2545;
+      margin-bottom: 0.4em;
+      line-height: 1.1;
+    }
+    .demo-slide .demo-sub {
+      font-size: 0.7em;
+      color: #334155;
+    }
+    .demo-slide .demo-scaffold {
+      margin-top: 1.5em;
+      text-align: left;
+      display: inline-block;
+    }
+    .demo-slide .demo-scaffold ul {
+      font-size: 0.52em;
+      color: #475569;
+      margin: 0;
+      padding-left: 1em;
+    }
+
+    /* Takeaways (Slide 8) */
+    .takeaway-group {
+      margin-bottom: 0.55em;
+    }
+    .takeaway-label {
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #0b2545;
+      font-size: 0.48em;
+      font-weight: 700;
+      margin-bottom: 0.15em;
+    }
+    .takeaway-body {
+      font-size: 0.56em;
+      color: #1f2328;
+      line-height: 1.4;
+    }
+    .takeaway-body ul { margin: 0 0 0 1em; padding: 0; }
+    .takeaway-body ul li { font-size: 1em; margin-bottom: 0.1em; }
+
+    .footer {
+      position: absolute;
+      bottom: 28px;
+      left: 96px;
+      right: 96px;
+      text-align: center;
+      font-size: 0.32em;
+      color: #94a3b8;
+      letter-spacing: 0.05em;
+    }
+  </style>
+</head>
+<body>
+<div class="reveal">
+  <div class="slides">
+
+    <!-- Slide 1 — Title -->
+    <section class="title-slide">
+      <div class="kicker">CS 5004 · Northeastern University · Spring 2026</div>
+      <h1>Multi-Shelter Animal<br>Adoption Management System</h1>
+      <p class="subtitle">An OOD-first Java application, driven by a natural-language CLI</p>
+      <p class="team">
+        <span><strong>Guanyu Tao</strong><small>Service Layer + AI Integration</small></span>
+        <span><strong>Yiying Xie</strong><small>Domain Layer</small></span>
+        <span><strong>Yuxi Ou</strong><small>Strategy Layer + Matching</small></span>
+      </p>
+      <p class="subtitle" style="margin-top:1.2em; font-style:normal;">April 21, 2026</p>
+    </section>
+
+    <!-- Slide 2 — Introduction -->
+    <section>
+      <div class="kicker">Introduction</div>
+      <h2>What we set out to build and why</h2>
+
+      <div class="section-block">
+        <div class="section-label">Problem</div>
+        <ul>
+          <li>Shelters track animals, adopters, and vaccines in separate spreadsheets.</li>
+          <li>Cross-shelter matching is manual; vaccine deadlines get missed.</li>
+          <li>No AI automation in this space, and Java isn't built for frontend UIs.</li>
+        </ul>
+      </div>
+
+      <div class="section-block">
+        <div class="section-label">Objectives</div>
+        <ul>
+          <li>Rigorous OOD across clean layers.</li>
+          <li>One CLI — usable by humans <em>and</em> AI agents.</li>
+          <li>Extensible: new species, matching rule, or request type = one new class.</li>
+        </ul>
+      </div>
+
+      <div class="section-block">
+        <div class="section-label">What it does</div>
+        <ul>
+          <li>Intake animals and adopters.</li>
+          <li>Score adopter–animal compatibility.</li>
+          <li>Run adoption + transfer workflows.</li>
+          <li>Track vaccines + full audit log.</li>
+        </ul>
+      </div>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
+    <!-- Slide 3 — Architecture -->
+    <section>
+      <div class="kicker">Design &amp; methods — each layer depends only on the one beneath it</div>
+      <h2>Six-layer architecture</h2>
+
+      <div class="layer-stack">
+        <div class="layer-row"><span class="name">Presentation</span><span class="desc">Picocli: parse <code>--</code> args → call Application → print.</span></div>
+        <div class="layer-row"><span class="name">Application</span><span class="desc">One method per use case — load via Repository, call Services, save.</span></div>
+        <div class="layer-row"><span class="name">Service</span><span class="desc">5 services (Adoption, Transfer, Matching, Vaccination, Audit) — pure business logic.</span></div>
+        <div class="layer-row"><span class="name">Strategy</span><span class="desc">6 <code>IMatchingStrategy</code> impls composed by <code>MatchingScoreCalculator</code>.</span></div>
+        <div class="layer-row"><span class="name">Repository</span><span class="desc">Interfaces + CSV impls — the only code that touches disk.</span></div>
+        <div class="layer-row"><span class="name">Domain</span><span class="desc">Entity classes (<code>Animal</code>, <code>Shelter</code>, <code>Adopter</code>, …) — validated constructors, no I/O.</span></div>
+      </div>
+
+      <div class="tools-strip">
+        <strong>Tools:</strong> Java 17 · Gradle · Picocli · JUnit 5 · CSV (no DB).
+      </div>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
+    <!-- Slide 4 — Why CLI, not GUI -->
+    <section>
+      <div class="kicker">Design choice</div>
+      <h2>Why CLI, not GUI</h2>
+      <p class="oneliner">Java is built for backend logic. The CLI turns that into a universal API surface.</p>
+      <ul>
+        <li><strong>Right tool for the job.</strong> Java earns its keep on logic, not rendering pixels.</li>
+        <li><strong>One surface, many callers</strong> — humans in the terminal, AI agents (Claude Code), and 78 integration tests hit the same commands.</li>
+        <li><strong>Future-proof.</strong> A JS/web UI can layer on top by calling the CLI — Java core stays untouched.</li>
+      </ul>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
+    <!-- Slide 5 — Strategy pattern -->
+    <section>
+      <div class="kicker">Object-Oriented Design — highlight #1</div>
+      <h2>Strategy pattern</h2>
+      <p class="oneliner">One interface, six matching rules, zero <code>if</code>-ladders.</p>
+      <pre><code class="language-java" data-trim data-noescape>
+public interface IMatchingStrategy {
+    MatchingCriterion getCriterion();
+    boolean isApplicable(Adopter adopter, Animal animal);
+    double score(Adopter adopter, Animal animal);
+}
+
+public class SpeciesPreferenceStrategy      implements IMatchingStrategy { ... }
+public class BreedPreferenceStrategy        implements IMatchingStrategy { ... }
+public class AgePreferenceStrategy          implements IMatchingStrategy { ... }
+public class ActivityLevelStrategy          implements IMatchingStrategy { ... }
+public class LifestyleCompatibilityStrategy implements IMatchingStrategy { ... }
+public class VaccinationPreferenceStrategy  implements IMatchingStrategy { ... }
+      </code></pre>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
+    <!-- Slide 6 — Shared request lifecycle -->
+    <section>
+      <div class="kicker">Object-Oriented Design — highlight #2</div>
+      <h2>Shared request lifecycle</h2>
+      <p class="oneliner">Two request types, one state machine.</p>
+      <pre><code class="language-java" data-trim data-noescape>
+public enum RequestStatus { PENDING, APPROVED, REJECTED, CANCELLED }
+
+public class AdoptionRequest {
+    public void approve();
+    public void reject();
+    public void cancel();
+}
+
+public class TransferRequest {
+    public void approve();
+    public void reject();
+    public void cancel();
+}
+      </code></pre>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
+    <!-- Slide 7 — LIVE DEMO divider -->
+    <section class="demo-slide">
+      <div class="demo-kicker">Demonstration</div>
+      <div class="demo-title">LIVE DEMO</div>
+      <div class="demo-sub">Claude Code operating the <code>shelter</code> CLI</div>
+      <div class="demo-scaffold">
+        <ul>
+          <li>Register 2 shelters.</li>
+          <li>Admit a dog, a cat, a fish (shows <code>Other</code> extensibility).</li>
+          <li>Register an adopter → <code>shelter match animal</code>.</li>
+          <li>Submit + approve adoption.</li>
+          <li>Transfer across shelters.</li>
+          <li>Record vaccine + overdue check + audit log.</li>
+        </ul>
+      </div>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
+    <!-- Slide 8 — Takeaways -->
+    <section>
+      <div class="kicker">Conclusion</div>
+      <h2>Takeaways</h2>
+
+      <div class="takeaway-group">
+        <div class="takeaway-label">Learned</div>
+        <div class="takeaway-body">
+          <ul>
+            <li>Clear structure → problems are easy to locate and code is easy to reuse.</li>
+            <li>Layers don't duplicate work — the separation paid off.</li>
+            <li>3-person coordination was the real challenge — locking public interfaces early saved us.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="takeaway-group">
+        <div class="takeaway-label">Next</div>
+        <div class="takeaway-body">
+          <ul>
+            <li>CSV → real DB · add a REST layer · role-based access.</li>
+            <li>Add a JavaScript/TypeScript dashboard and a dedicated AI system.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
+    <!-- Slide 9 — AI use acknowledgment -->
+    <section>
+      <div class="kicker">Transparency note</div>
+      <h2>How AI fit into this project</h2>
+
+      <div class="takeaway-group">
+        <div class="takeaway-label">Tools</div>
+        <div class="takeaway-body">
+          <ul>
+            <li>Claude Code + Codex as pair-programming partners.</li>
+            <li><code>CLAUDE.md</code> and <code>AGENTS.md</code> in the repo — shared context so humans and agents stay in sync.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="takeaway-group">
+        <div class="takeaway-label">Process</div>
+        <div class="takeaway-body">
+          <ul>
+            <li>Research → planning → implementation with human in the loop.</li>
+            <li>Test-driven: unit tests, integration tests, human acceptance runs.</li>
+            <li>Docs-first: use cases, demo plan, integration-test plan.</li>
+            <li>This deck: built with reveal.js 5.1, highlight.js, a custom auto-fit script, and Claude Code; reviewed via Chrome MCP screenshots.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reveal.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/plugin/highlight/highlight.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/plugin/notes/notes.js"></script>
+<script>
+  // Wrap each slide's non-footer content in a .slide-fit div for auto-fit.
+  document.querySelectorAll('.reveal .slides > section').forEach(section => {
+    if (section.querySelector(':scope > .slide-fit')) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'slide-fit';
+    Array.from(section.childNodes).forEach(child => {
+      if (child.nodeType === 1) {
+        const tag = child.tagName;
+        if (tag === 'ASIDE') return;
+        if (child.classList && child.classList.contains('footer')) return;
+      }
+      wrapper.appendChild(child);
+    });
+    section.insertBefore(wrapper, section.firstChild);
+  });
+
+  function autoFitSlides() {
+    document.querySelectorAll('.reveal .slides > section').forEach(section => {
+      const wrapper = section.querySelector(':scope > .slide-fit');
+      if (!wrapper) return;
+      wrapper.style.transform = '';
+      const cs = getComputedStyle(section);
+      const padV = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+      const padH = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+      const availH = section.clientHeight - padV;
+      const availW = section.clientWidth - padH;
+      const contentH = wrapper.scrollHeight;
+      const contentW = wrapper.scrollWidth;
+      const scale = Math.min(1, availH / contentH, availW / contentW);
+      if (scale < 1) wrapper.style.transform = `scale(${scale})`;
+    });
+  }
+
+  Reveal.initialize({
+    hash: true,
+    slideNumber: 'c/t',
+    transition: 'fade',
+    controls: true,
+    progress: true,
+    center: false,
+    width: 1280,
+    height: 720,
+    margin: 0,
+    pdfSeparateFragments: false,
+    plugins: [ RevealHighlight, RevealNotes ]
+  }).then(() => {
+    autoFitSlides();
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(autoFitSlides);
+    }
+    Reveal.on('slidechanged', autoFitSlides);
+    Reveal.on('resize', autoFitSlides);
+    window.addEventListener('resize', () => setTimeout(autoFitSlides, 50));
+  });
+</script>
+</body>
+</html>

--- a/docs/presentation/slides.md
+++ b/docs/presentation/slides.md
@@ -1,0 +1,287 @@
+# Deck Content — Multi-Shelter Animal Adoption Management System
+
+One section per slide. Edit freely; tell me what changed and I'll sync into `deck.html`.
+Slide boundaries are marked by `---`.
+
+---
+
+## Presentation rules (from course instructor — 2026-04-17)
+
+### Logistics — "Project Presentations"
+
+- **Date:** April 21st, 2026
+- **Time:** 1:00 – 4:20 PM
+- Groups need to sign up for a time slot using the link which will be posted to Canvas.
+  - First signup, first served.
+- All groups must log into the Zoom link **BEFORE 1:00 PM**.
+  - Link is the link to our lectures on Canvas.
+  - Groups needing to be admitted after 1:00 PM will lose time from their allocated time slot.
+- You will be **stopped after 8 minutes** and therefore will lose points for items not presented.
+- All group members should participate equally in the presentation to get individual grades.
+- Possibility of individual one-to-one meetings to further dig deep into understanding of the project.
+
+### Structure — "Presentation"
+
+- **Duration: 10 minutes** (8-minute demo, 2-minute Q&A).
+- **Introduction (1–2 minutes)**
+  - Summarize the project: objectives, design, and application goals.
+- **Demonstration (5–6 minutes)**
+  - Demonstration of your project in operation.
+  - Methods and tools used.
+  - Walk-through of a small portion of your code.
+  - Findings and lessons learned (what was hard/easy?).
+  - Highlights of your use of 1–2 big ideas from Object Oriented Design.
+    - e.g., encapsulation, inheritance, composition, polymorphism, abstraction, MVC.
+- **Conclusion (1–2 minutes)**
+  - Explain your learnings of the course and how you applied them to this project.
+  - Highlight what you learned from the project.
+  - Summarize outcomes, potential improvements, and challenges you faced.
+- **Scholarly citations.**
+
+### Implications for this deck
+
+- Slides are a companion to the live CLI demo, not the main content — target **~8 slides**.
+- Each group member should own at least one section verbally.
+- Live demo is the anchor; slides exist to frame intro + conclusion and highlight OOD ideas.
+
+---
+
+## Target time budget (9 slides, 10 min total)
+
+| # | Slide | Rubric section | Owner | Time |
+|---|---|---|---|---|
+| 1 | Title | — | all | 10 s |
+| 2 | Introduction — problem, objectives, goals | Intro | Yiying | 45 s |
+| 3 | Architecture + methods & tools used | Intro / Methods | Gerry | 35 s |
+| 4 | Why CLI, not GUI | Intro / Design | Yiying | 25 s |
+| 5 | OOD big idea #1 — Strategy pattern (with code) | Demo / OOD | Yuxi | 65 s |
+| 6 | OOD big idea #2 — Shared request lifecycle (with code) | Demo / OOD | Gerry | 35 s |
+| 7 | LIVE DEMO (terminal) | Demo | Gerry drives, team narrates | 180 s |
+| 8 | Takeaways — learned, next | Conclusion | Gerry | 45 s |
+| 9 | AI use acknowledgment | Closing | all | 30 s |
+| — | Q&A | — | all | 120 s |
+
+Total slide time: 470 s (7:50) · Q&A: 120 s (2:00). Inside the 8-min + 2-min hard stop with 10 s cushion.
+
+---
+
+## Slide 1 — Title
+
+**Layout:** title
+
+**Kicker:** CS 5004 · Northeastern University · Spring 2026
+
+**Title:** Multi-Shelter Animal Adoption Management System
+
+**Subtitle:** An OOD-first Java application, driven by a natural-language CLI
+
+**Date:** April 21, 2026
+
+**Team:**
+- **Guanyu Tao** — Service Layer + AI Integration
+- **Yiying Xie** — Domain Layer
+- **Yuxi Ou** — Strategy Layer + Matching
+
+**Speaker notes:** 10 seconds. One sentence framing — who we are and what we built.
+
+---
+
+## Slide 2 — Introduction: problem, objectives, goals
+
+**Layout:** bullets
+
+**Kicker:** Introduction
+
+**Title:** What we set out to build and why
+
+**Problem:**
+- Shelters track animals, adopters, and vaccines in separate spreadsheets.
+- Cross-shelter matching is manual; vaccine deadlines get missed.
+- No AI automation in this space, and Java isn't built for frontend UIs.
+
+**Objectives:**
+- Rigorous OOD across clean layers.
+- One CLI — usable by humans *and* AI agents.
+- Extensible: new species, matching rule, or request type = one new class.
+
+**What it does:**
+- Intake animals and adopters.
+- Score adopter–animal compatibility.
+- Run adoption + transfer workflows.
+- Track vaccines + full audit log.
+
+> 3 tabs verticlelly: Problem, Objectives, What it does.
+
+**Speaker notes:** 60 s. Problem → three design pillars → capabilities. Don't read the slide; expand verbally.
+
+---
+
+## Slide 3 — Architecture, methods & tools
+
+**Layout:** layer-stack + tools sidebar
+
+**Kicker:** Design & methods
+
+**Title:** Six-layer architecture, one direction of dependency
+
+**Layers (top → bottom):**
+- **Presentation** — Picocli commands: parse `--` args → call Application → print. No logic.
+- **Application** — One method per use case (`admitAnimal`, `approveAdoption`, …): load via Repository, call Services, save.
+- **Service** — Business logic per concern: `AdoptionService`, `TransferService`, `MatchingService`, `VaccinationService`, `AuditService`.
+- **Strategy** — Six `IMatchingStrategy` impls; `MatchingScoreCalculator` composes them.
+- **Repository** — Interfaces + CSV impls (`AnimalRepository` → `CsvAnimalRepository`, …): the only code that touches disk.
+- **Domain** — Entity classes (`Animal`, `Shelter`, `Adopter`, …): validated constructors, no I/O.
+> the 5 layers part should be the first thing, and the main focus of this page. 
+
+**Tools:** Java 17 · Gradle · Picocli · JUnit 5 · CSV (no DB).
+
+**Speaker notes:** 45 s. One sentence per layer, then tools as a flyover.
+
+---
+
+## Slide 4 — Why CLI, not GUI
+
+**Layout:** title + one-liner + bullets
+
+**Kicker:** Design choice
+
+**Title:** Why CLI, not GUI
+
+**One-liner:** Java is built for backend logic. The CLI turns that into a universal API surface.
+
+**Bullets:**
+- **Right tool for the job.** Java earns its keep on logic, not rendering pixels.
+- **One surface, many callers** — humans in the terminal, AI agents (Claude Code), and 78 integration tests hit the same commands.
+- **Future-proof.** A JS/web UI can layer on top by calling the CLI — Java core stays untouched.
+
+**Speaker notes:** 30 s. Lead with "Java is backend-first," then the three-callers point with AI agents emphasized, then wave at the extensibility path. Don't dwell — this frames the code walkthroughs that follow.
+
+---
+
+## Slide 5 — OOD big idea #1: Strategy pattern
+
+**Layout:** title + one-liner + code
+
+**Title:** Strategy pattern
+
+**One-liner:** One interface, six matching rules, zero `if`-ladders.
+
+**Code:**
+```java
+public interface IMatchingStrategy {
+    MatchingCriterion getCriterion();
+    boolean isApplicable(Adopter adopter, Animal animal);
+    double score(Adopter adopter, Animal animal);
+}
+
+public class SpeciesPreferenceStrategy    implements IMatchingStrategy { ... }
+public class BreedPreferenceStrategy      implements IMatchingStrategy { ... }
+public class AgePreferenceStrategy        implements IMatchingStrategy { ... }
+public class ActivityLevelStrategy        implements IMatchingStrategy { ... }
+public class LifestyleCompatibilityStrategy implements IMatchingStrategy { ... }
+public class VaccinationPreferenceStrategy  implements IMatchingStrategy { ... }
+```
+
+**Speaker notes:** 75 s. Walk the 3 methods (criterion, applicable, score), then point at the 6 implementers. Close with "a seventh rule is one more class — nothing else changes."
+
+---
+
+## Slide 6 — OOD big idea #2: Shared request lifecycle
+
+**Layout:** title + one-liner + code
+
+**Title:** Shared request lifecycle
+
+**One-liner:** Two request types, one state machine.
+
+**Code:**
+```java
+public enum RequestStatus { PENDING, APPROVED, REJECTED, CANCELLED }
+
+public class AdoptionRequest {
+    public void approve();
+    public void reject();
+    public void cancel();
+}
+
+public class TransferRequest {
+    public void approve();
+    public void reject();
+    public void cancel();
+}
+```
+
+**Speaker notes:** 45 s. Point at the enum → both classes carry the same three verbs → "adding a third request type reuses all of it." Mention `RequestNotificationService` verbally.
+
+---
+
+## Slide 7 — LIVE DEMO
+
+**Layout:** full-bleed divider
+
+**Kicker:** Demonstration
+
+**Title:** Live: Claude Code operating the `shelter` CLI
+
+**Demo scaffold:**
+- Register 2 shelters.
+- Admit a dog, a cat, a fish (shows `Other` extensibility).
+- Register an adopter → `shelter match animal`.
+- Submit + approve adoption.
+- Transfer across shelters.
+- Record vaccine + overdue check + audit log.
+
+**Speaker notes:** ~3.5 min. Gerry drives; Yuxi narrates strategy firing; Yiying narrates domain invariants. Fall back to typed commands if AI stalls. Full script: `docs/demo-plan.md`.
+
+---
+
+## Slide 8 — Takeaways
+
+**Layout:** three short sections
+
+**Kicker:** Conclusion
+
+**Title:** Takeaways
+
+**Learned:**
+- Clear structure → problems are easy to locate and code is easy to reuse.
+- Layers don't duplicate work — the separation paid off.
+- 3-person coordination was the real challenge — locking public interfaces early saved us.
+
+**Next:**
+- CSV → real DB · add a REST layer · role-based access.
+- Add a JavaScript/TypeScript dashboard and a dedicated AI system.
+
+**Speaker notes:** 50 s. Learned → next. Close with "happy to go deeper in Q&A."
+
+---
+
+## Slide 9 — AI use acknowledgment
+
+**Layout:** three short sections
+
+**Kicker:** Transparency note
+
+**Title:** How AI fit into this project
+
+**Tools:**
+- Claude Code + Codex as pair-programming partners.
+- `CLAUDE.md` and `AGENTS.md` in the repo — shared context so humans and agents stay in sync.
+
+**Process:**
+- Research → planning → implementation with human in the loop.
+- Test-driven: unit tests, integration tests, human acceptance runs.
+- Docs-first: use cases, demo plan, integration-test plan.
+- This deck: built with reveal.js 5.1, highlight.js, a custom auto-fit script, and Claude Code; reviewed via Chrome MCP screenshots.
+
+**Speaker notes:** 25 s. Open by noting the professor's position that AI use is acceptable. Walk tools → process, close on the deck-tooling line so the audience understands the footprint is fully disclosed. Convey discipline, not novelty.
+
+---
+
+## Q&A (not a slide — 2 minutes)
+
+Likely questions to pre-think:
+- Why CSV and not a database? → scope; domain model is the interesting part.
+- How do you add a new species? → subclass `Animal`, handle in CSV repo, done — no enum edits.
+- What stops AI from changing match scores? → scoring is a separate service; AI only reads its output.
+- Is the test suite deterministic? → yes, thanks to `MockExplanationService` and `SHELTER_HOME` isolation.

--- a/docs/test-live.md
+++ b/docs/test-live.md
@@ -1,14 +1,76 @@
 # Live Test Plan (Claude Agent)
 
-Full end-to-end verification before demo. Claude Code acts as AI agent — interpreting natural language and executing `shelter` CLI commands.
+Full end-to-end verification before demo. Claude Code acts as AI agent — interpreting natural language and executing `shelter` CLI commands. A live markdown dashboard (`shelter print --watch`) renders system state to `~/shelter/dashboard.md` so the audience sees every mutation update within ~1 second.
 
-**Setup** (run from project root `management-system-for-multi-shelter-animal-adoption/`):
+---
+
+## Setup — full clean reinstall + dashboard
+
+Run once before a live demo. This rebuilds the binary, wipes any previous session, refreshes the agent's `CLAUDE.md` context file (which lists all commands the agent is allowed to run), and opens the three demo panes.
+
+### 0. Clean state
+
 ```bash
+# From project root. Shell the command opens here is irrelevant — it uses absolute paths.
+PROJECT_DIR="$HOME/developers/NU-coursework/management-system-for-multi-shelter-animal-adoption"
+cd "$PROJECT_DIR"
+
+# Build the distributable binary.
 ./gradlew installDist
-export PATH="$PWD/build/install/shelter/bin:$PATH"
-rm -rf ~/shelter/data
+
+# Make `shelter` available in every new terminal (persistent — run once, then reopen terminals).
+SHELTER_BIN="$PROJECT_DIR/build/install/shelter/bin"
+grep -q "$SHELTER_BIN" ~/.zshrc || \
+    echo "export PATH=\"$SHELTER_BIN:\$PATH\"" >> ~/.zshrc
+export PATH="$SHELTER_BIN:$PATH"
+
+# Wipe previous session data AND the stale CLAUDE.md (it is regenerated on next `shelter` run).
+rm -rf ~/shelter/data ~/shelter/CLAUDE.md ~/shelter/dashboard.md
+
+# Confirm the binary works AND regenerate CLAUDE.md + data dir.
 shelter --version
+shelter print    # prints 8 empty sections; also triggers bootstrap of ~/shelter/CLAUDE.md
 ```
+
+Expected: `shelter --version` prints `1.0`. `ls ~/shelter/` shows `CLAUDE.md` and `data/`. The `CLAUDE.md` file now documents `shelter print`, `shelter adopt list`, `shelter transfer list`, and `shelter vaccine list` so the agent knows they exist.
+
+### 1. Start the live dashboard watcher (Pane A — terminal, bottom-left)
+
+```bash
+shelter print --watch
+# → "Watching /Users/<you>/shelter/data, writing /Users/<you>/shelter/dashboard.md (Ctrl+C to stop)"
+```
+
+Leave this running for the entire demo. Every CSV change triggers a rewrite within 1s.
+
+### 2. Open the dashboard preview (Pane B — VS Code, top-left)
+
+```bash
+code ~/shelter/dashboard.md
+```
+
+Inside VS Code: `Cmd+K V` to open the markdown preview. Drag the preview tab to a side-pane and close the raw-markdown editor so only the rendered view is visible.
+
+### 3. Launch Claude Code in the shelter directory (Pane C — terminal, right half)
+
+```bash
+cd ~/shelter
+claude
+```
+
+Critical: `cd ~/shelter` first so Claude Code picks up `~/shelter/CLAUDE.md` as its instructions. That file tells the agent the full CLI surface, confirmation rules, and output conventions.
+
+Smoke test once Claude Code is running:
+```
+Show me everything we have right now.
+```
+Expected: the agent runs `shelter print` and produces the 8-section snapshot with `(none)` markers in every section. The dashboard preview already shows the same content. If the agent lists entities via separate `list` commands instead of `shelter print`, the `CLAUDE.md` refresh didn't take — re-run the last two lines of step 0.
+
+---
+
+## Visual checkpoint during every phase below
+
+After each command the agent runs, glance at **Pane B** (the preview). The affected section should update within a second. If it doesn't, something is wrong before you proceed to the next step.
 
 ---
 

--- a/scripts/init-demo.sh
+++ b/scripts/init-demo.sh
@@ -17,7 +17,7 @@ export PATH="$PROJECT_ROOT/build/install/shelter/bin:$PATH"
 shelter --version >/dev/null
 
 echo "==> Done. Shelter home initialized at: $SHELTER_HOME"
-echo "==> Entering $SHELTER_HOME (interactive shell with shelter on PATH)"
-cd "$SHELTER_HOME"
-export PATH="$PROJECT_ROOT/build/install/shelter/bin:$PATH"
-exec "$SHELL"
+echo
+echo "    binary:    $PROJECT_ROOT/build/install/shelter/bin/shelter"
+echo "    workdir:   $SHELTER_HOME"
+echo "    CLAUDE.md: $SHELTER_HOME/CLAUDE.md"

--- a/scripts/reset-demo.sh
+++ b/scripts/reset-demo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Reset the demo environment to a clean state.
+#
+# - Rebuilds the shelter binary via Gradle installDist.
+# - Symlinks `shelter` into ~/.local/bin so it resolves in every shell
+#   (including Claude Code's non-interactive bash — no sudo, no PATH exports).
+# - Wipes ~/shelter so the next `shelter` run regenerates CLAUDE.md and data/.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_SOURCE="$PROJECT_DIR/build/install/shelter/bin/shelter"
+BIN_LINK="$HOME/.local/bin/shelter"
+
+echo "==> Building shelter binary"
+cd "$PROJECT_DIR"
+./gradlew installDist
+
+echo "==> Linking $BIN_LINK -> $BIN_SOURCE"
+mkdir -p "$HOME/.local/bin"
+ln -sf "$BIN_SOURCE" "$BIN_LINK"
+
+echo "==> Wiping ~/shelter"
+rm -rf "$HOME/shelter"
+
+echo "==> Regenerating ~/shelter (CLAUDE.md + data/)"
+"$BIN_LINK" print >/dev/null
+
+echo
+echo "Done."
+echo "  binary:    $BIN_LINK"
+echo "  workdir:   $HOME/shelter"
+echo "  CLAUDE.md: $HOME/shelter/CLAUDE.md"
+echo
+echo "Open a fresh terminal and run 'shelter print' to confirm."

--- a/src/main/java/shelter/application/AdoptionApplicationService.java
+++ b/src/main/java/shelter/application/AdoptionApplicationService.java
@@ -2,6 +2,8 @@ package shelter.application;
 
 import shelter.domain.AdoptionRequest;
 
+import java.util.List;
+
 /**
  * Application service for the adoption request lifecycle.
  * Orchestrates validation, state transitions, notifications, and audit logging
@@ -42,4 +44,13 @@ public interface AdoptionApplicationService {
      * @param requestId the ID of the adoption request to cancel; must not be null or blank
      */
     void cancelRequest(String requestId);
+
+    /**
+     * Returns every adoption request currently in the system.
+     * Returns an empty list if no adoption requests have been submitted.
+     * Used by the {@code shelter print} command to render a system-wide snapshot.
+     *
+     * @return a list of all adoption requests
+     */
+    List<AdoptionRequest> listAllRequests();
 }

--- a/src/main/java/shelter/application/TransferApplicationService.java
+++ b/src/main/java/shelter/application/TransferApplicationService.java
@@ -2,6 +2,8 @@ package shelter.application;
 
 import shelter.domain.TransferRequest;
 
+import java.util.List;
+
 /**
  * Application service for the inter-shelter transfer request lifecycle.
  * Orchestrates availability checks, capacity validation, notifications, and audit logging
@@ -44,4 +46,13 @@ public interface TransferApplicationService {
      * @param requestId the ID of the transfer request to cancel; must not be null or blank
      */
     void cancelTransfer(String requestId);
+
+    /**
+     * Returns every transfer request currently in the system.
+     * Returns an empty list if no transfers have been requested.
+     * Used by the {@code shelter print} command to render a system-wide snapshot.
+     *
+     * @return a list of all transfer requests
+     */
+    List<TransferRequest> listAllTransfers();
 }

--- a/src/main/java/shelter/application/VaccinationApplicationService.java
+++ b/src/main/java/shelter/application/VaccinationApplicationService.java
@@ -1,5 +1,6 @@
 package shelter.application;
 
+import shelter.application.model.VaccinationRecordView;
 import shelter.domain.Species;
 import shelter.domain.VaccineType;
 import shelter.service.model.OverdueVaccination;
@@ -74,4 +75,14 @@ public interface VaccinationApplicationService {
      * @return a list of all {@link VaccineType} entries
      */
     List<VaccineType> listVaccineTypes();
+
+    /**
+     * Returns every vaccination record in the system, each wrapped in a view that
+     * resolves the animal and vaccine type display names. Returns an empty list if
+     * no vaccinations have been recorded. Orphaned records whose referenced animal
+     * or vaccine type can no longer be found are silently skipped.
+     *
+     * @return a list of {@link VaccinationRecordView} entries
+     */
+    List<VaccinationRecordView> listAllVaccinationRecords();
 }

--- a/src/main/java/shelter/application/impl/AdoptionApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/AdoptionApplicationServiceImpl.java
@@ -11,6 +11,8 @@ import shelter.service.AnimalService;
 import shelter.service.AuditService;
 import shelter.service.RequestNotificationService;
 
+import java.util.List;
+
 /**
  * Default implementation of {@link AdoptionApplicationService} that orchestrates
  * the full adoption request lifecycle: submit, approve, reject, and cancel.
@@ -114,6 +116,15 @@ public class AdoptionApplicationServiceImpl implements AdoptionApplicationServic
         adoptionService.cancel(request);
         notificationService.notifyAdoptionStatusChange(request);
         auditService.log("cancelled adoption request", request);
+    }
+
+    /**
+     * {@inheritDoc}
+     * Delegates to the underlying {@link shelter.service.AdoptionService}.
+     */
+    @Override
+    public List<AdoptionRequest> listAllRequests() {
+        return adoptionService.listAll();
     }
 
     /**

--- a/src/main/java/shelter/application/impl/TransferApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/TransferApplicationServiceImpl.java
@@ -12,6 +12,8 @@ import shelter.service.RequestNotificationService;
 import shelter.service.ShelterService;
 import shelter.service.TransferService;
 
+import java.util.List;
+
 /**
  * Default implementation of {@link TransferApplicationService} that orchestrates
  * inter-shelter transfer requests across the service layer.
@@ -111,6 +113,15 @@ public class TransferApplicationServiceImpl implements TransferApplicationServic
         TransferRequest request = findRequestById(requestId);
         transferService.dismiss(request);
         auditService.log("cancelled transfer", request);
+    }
+
+    /**
+     * {@inheritDoc}
+     * Delegates to the underlying {@link shelter.service.TransferService}.
+     */
+    @Override
+    public List<TransferRequest> listAllTransfers() {
+        return transferService.listAll();
     }
 
     /**

--- a/src/main/java/shelter/application/impl/VaccinationApplicationServiceImpl.java
+++ b/src/main/java/shelter/application/impl/VaccinationApplicationServiceImpl.java
@@ -1,10 +1,12 @@
 package shelter.application.impl;
 
 import shelter.application.VaccinationApplicationService;
+import shelter.application.model.VaccinationRecordView;
 import shelter.domain.Animal;
 import shelter.domain.VaccinationRecord;
 import shelter.domain.Species;
 import shelter.domain.VaccineType;
+import shelter.exception.EntityNotFoundException;
 import shelter.service.AnimalService;
 import shelter.service.AuditService;
 import shelter.service.VaccinationService;
@@ -12,6 +14,8 @@ import shelter.service.VaccineTypeCatalogService;
 import shelter.service.model.OverdueVaccination;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -115,5 +119,31 @@ public class VaccinationApplicationServiceImpl implements VaccinationApplication
     @Override
     public List<VaccineType> listVaccineTypes() {
         return vaccineTypeCatalogService.listAll();
+    }
+
+    /**
+     * {@inheritDoc}
+     * Resolves animal and vaccine type names by looking up each record's referenced IDs
+     * through the respective services. Records whose referenced animal or vaccine type
+     * cannot be found are skipped (defensive against orphaned rows).
+     */
+    @Override
+    public List<VaccinationRecordView> listAllVaccinationRecords() {
+        List<VaccinationRecord> records = vaccinationService.listAllRecords();
+        List<VaccinationRecordView> views = new ArrayList<>();
+        for (VaccinationRecord r : records) {
+            Animal animal;
+            VaccineType vt;
+            try {
+                // Look up associated entities; orphaned rows throw and are skipped
+                animal = animalService.findById(r.getAnimalId());
+                vt = vaccineTypeCatalogService.findById(r.getVaccineTypeId());
+            } catch (EntityNotFoundException skip) {
+                continue;
+            }
+            views.add(new VaccinationRecordView(
+                    r, animal.getName(), vt.getName(), animal.getSpecies()));
+        }
+        return Collections.unmodifiableList(views);
     }
 }

--- a/src/main/java/shelter/application/model/VaccinationRecordView.java
+++ b/src/main/java/shelter/application/model/VaccinationRecordView.java
@@ -1,0 +1,106 @@
+package shelter.application.model;
+
+import shelter.domain.Species;
+import shelter.domain.VaccinationRecord;
+
+import java.util.Objects;
+
+/**
+ * Application-layer DTO that bundles a {@link VaccinationRecord} with the display names
+ * of its associated animal and vaccine type. Used by the presentation layer to render
+ * human-readable vaccination snapshots without re-querying the domain services.
+ */
+public final class VaccinationRecordView {
+
+    private final VaccinationRecord record;
+    private final String animalName;
+    private final String vaccineTypeName;
+    private final Species species;
+
+    /**
+     * Constructs a VaccinationRecordView bundling a record with its resolved display fields.
+     * All fields are required and must not be null or blank.
+     *
+     * @param record          the underlying vaccination record; must not be null
+     * @param animalName      the animal's display name; must not be null or blank
+     * @param vaccineTypeName the vaccine type's display name; must not be null or blank
+     * @param species         the animal's species; must not be null
+     * @throws IllegalArgumentException if any argument is null or blank
+     */
+    public VaccinationRecordView(VaccinationRecord record, String animalName,
+                                 String vaccineTypeName, Species species) {
+        if (record == null) {
+            throw new IllegalArgumentException("VaccinationRecord must not be null.");
+        }
+        if (animalName == null || animalName.isBlank()) {
+            throw new IllegalArgumentException("Animal name must not be null or blank.");
+        }
+        if (vaccineTypeName == null || vaccineTypeName.isBlank()) {
+            throw new IllegalArgumentException("Vaccine type name must not be null or blank.");
+        }
+        if (species == null) {
+            throw new IllegalArgumentException("Species must not be null.");
+        }
+        this.record = record;
+        this.animalName = animalName;
+        this.vaccineTypeName = vaccineTypeName;
+        this.species = species;
+    }
+
+    /**
+     * Returns the wrapped vaccination record.
+     *
+     * @return the wrapped vaccination record
+     */
+    public VaccinationRecord getRecord() {
+        return record;
+    }
+
+    /**
+     * Returns the display name of the vaccinated animal.
+     *
+     * @return the display name of the vaccinated animal
+     */
+    public String getAnimalName() {
+        return animalName;
+    }
+
+    /**
+     * Returns the display name of the vaccine type.
+     *
+     * @return the display name of the vaccine type
+     */
+    public String getVaccineTypeName() {
+        return vaccineTypeName;
+    }
+
+    /**
+     * Returns the species of the vaccinated animal.
+     *
+     * @return the species of the vaccinated animal
+     */
+    public Species getSpecies() {
+        return species;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof VaccinationRecordView that)) return false;
+        return Objects.equals(record, that.record)
+                && Objects.equals(animalName, that.animalName)
+                && Objects.equals(vaccineTypeName, that.vaccineTypeName)
+                && species == that.species;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(record, animalName, vaccineTypeName, species);
+    }
+
+    @Override
+    public String toString() {
+        return "VaccinationRecordView[record=" + record + ", animal=" + animalName
+                + ", vaccine=" + vaccineTypeName + ", species=" + species + "]";
+    }
+}

--- a/src/main/java/shelter/cli/AdoptCmd.java
+++ b/src/main/java/shelter/cli/AdoptCmd.java
@@ -47,7 +47,7 @@ public class AdoptCmd implements Runnable {
      * @param out      the writer to print to; must not be null
      * @param requests the requests to render; must not be null (may be empty)
      */
-    static void renderList(PrintWriter out, List<AdoptionRequest> requests) {
+    public static void renderList(PrintWriter out, List<AdoptionRequest> requests) {
         out.printf("%-36s  %-16s  %-14s  %-10s  %s%n",
                 "ID,", "ADOPTER,", "ANIMAL,", "STATUS,", "SUBMITTED AT");
         if (requests.isEmpty()) {

--- a/src/main/java/shelter/cli/AdoptCmd.java
+++ b/src/main/java/shelter/cli/AdoptCmd.java
@@ -4,6 +4,9 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import shelter.domain.AdoptionRequest;
 
+import java.io.PrintWriter;
+import java.util.List;
+
 /**
  * Top-level CLI command group for the adoption request lifecycle.
  * Provides subcommands to submit, approve, reject, and cancel adoption requests.
@@ -13,6 +16,7 @@ import shelter.domain.AdoptionRequest;
         name = "adopt",
         description = "Manage adoption requests",
         subcommands = {
+                AdoptCmd.ListCmd.class,
                 AdoptCmd.SubmitCmd.class,
                 AdoptCmd.ApproveCmd.class,
                 AdoptCmd.RejectCmd.class,
@@ -29,6 +33,64 @@ public class AdoptCmd implements Runnable {
     @Override
     public void run() {
         System.out.println("Usage: shelter adopt <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // render helper (shared by `adopt list` and `shelter print`)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Renders adoption requests as a comma-headed, space-padded table to the given writer.
+     * Empty input prints the header followed by {@code (none)}.
+     * Used by both {@code shelter adopt list} and {@code shelter print}.
+     *
+     * @param out      the writer to print to; must not be null
+     * @param requests the requests to render; must not be null (may be empty)
+     */
+    static void renderList(PrintWriter out, List<AdoptionRequest> requests) {
+        out.printf("%-36s  %-16s  %-14s  %-10s  %s%n",
+                "ID,", "ADOPTER,", "ANIMAL,", "STATUS,", "SUBMITTED AT");
+        if (requests.isEmpty()) {
+            out.println("(none)");
+            out.flush();
+            return;
+        }
+        for (AdoptionRequest r : requests) {
+            out.printf("%-36s  %-16s  %-14s  %-10s  %s%n",
+                    r.getId(),
+                    r.getAdopter().getName(),
+                    r.getAnimal().getName(),
+                    r.getStatus().name(),
+                    r.getSubmittedAt());
+        }
+        out.flush();
+    }
+
+    // -------------------------------------------------------------------------
+    // list
+    // -------------------------------------------------------------------------
+
+    /**
+     * Lists every adoption request currently in the system.
+     * Used primarily for demo purposes and by the {@code shelter print} summary.
+     */
+    @Command(name = "list", description = "List all adoption requests",
+             mixinStandardHelpOptions = true)
+    static class ListCmd implements Runnable {
+
+        /**
+         * Executes the list operation by delegating to {@link AdoptCmd#renderList}.
+         * Writes to stdout via a flushing {@link PrintWriter}.
+         */
+        @Override
+        public void run() {
+            try {
+                renderList(new PrintWriter(System.out, true),
+                        AppContext.get().adoptionApp().listAllRequests());
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/shelter/cli/AdopterCmd.java
+++ b/src/main/java/shelter/cli/AdopterCmd.java
@@ -134,7 +134,7 @@ public class AdopterCmd implements Runnable {
         private ActivityLevel preferredActivityLevel;
 
         /** Whether vaccinated animals are required; omit for no preference. */
-        @Option(names = "--requires-vaccinated",
+        @Option(names = "--requires-vaccinated", arity = "1",
                 description = "Whether vaccinated animals are required: true or false")
         private Boolean requiresVaccinated;
 
@@ -207,7 +207,7 @@ public class AdopterCmd implements Runnable {
         private ActivityLevel preferredActivityLevel;
 
         /** New vaccination requirement; omit to keep current value. */
-        @Option(names = "--requires-vaccinated",
+        @Option(names = "--requires-vaccinated", arity = "1",
                 description = "New vaccination requirement: true or false (omit to keep current)")
         private Boolean requiresVaccinated;
 

--- a/src/main/java/shelter/cli/AdopterCmd.java
+++ b/src/main/java/shelter/cli/AdopterCmd.java
@@ -50,7 +50,7 @@ public class AdopterCmd implements Runnable {
      * @param out      the writer to print to; must not be null
      * @param adopters the adopters to render; must not be null (may be empty)
      */
-    static void renderList(PrintWriter out, List<Adopter> adopters) {
+    public static void renderList(PrintWriter out, List<Adopter> adopters) {
         out.printf("%-36s  %-12s  %-17s  %-20s  %-8s  %-12s  %-8s  %-10s  %-7s  %s%n",
                 "ID,", "NAME,", "LIVING SPACE,", "SCHEDULE,",
                 "SPECIES,", "BREED,", "ACTIVITY,", "VACCINATED,", "MIN AGE,", "MAX AGE");

--- a/src/main/java/shelter/cli/AdopterCmd.java
+++ b/src/main/java/shelter/cli/AdopterCmd.java
@@ -8,6 +8,7 @@ import shelter.domain.DailySchedule;
 import shelter.domain.LivingSpace;
 import shelter.domain.Species;
 
+import java.io.PrintWriter;
 import java.util.List;
 
 /**
@@ -42,42 +43,54 @@ public class AdopterCmd implements Runnable {
     // -------------------------------------------------------------------------
 
     /**
+     * Renders a list of adopters as a comma-headed, space-padded table to the given writer.
+     * Empty input produces the header row followed by {@code (none)} on the next line.
+     * Used by both {@code shelter adopter list} and {@code shelter print}.
+     *
+     * @param out      the writer to print to; must not be null
+     * @param adopters the adopters to render; must not be null (may be empty)
+     */
+    static void renderList(PrintWriter out, List<Adopter> adopters) {
+        out.printf("%-36s  %-12s  %-17s  %-20s  %-8s  %-12s  %-8s  %-10s  %-7s  %s%n",
+                "ID,", "NAME,", "LIVING SPACE,", "SCHEDULE,",
+                "SPECIES,", "BREED,", "ACTIVITY,", "VACCINATED,", "MIN AGE,", "MAX AGE");
+        if (adopters.isEmpty()) {
+            out.println("(none)");
+            out.flush();
+            return;
+        }
+        for (Adopter a : adopters) {
+            // Resolve preference fields; display "any" when no preference is set
+            shelter.domain.AdopterPreferences p = a.getPreferences();
+            String species    = p.getPreferredSpecies()       != null ? p.getPreferredSpecies().name()       : "any";
+            String breed      = p.getPreferredBreed()         != null ? p.getPreferredBreed()                : "any";
+            String activity   = p.getPreferredActivityLevel() != null ? p.getPreferredActivityLevel().name() : "any";
+            String vaccinated = p.getRequiresVaccinated()     != null ? p.getRequiresVaccinated().toString() : "any";
+            String minAge     = p.getMinAge()                 != null ? p.getMinAge().toString()             : "any";
+            String maxAge     = p.getMaxAge()                 != null ? p.getMaxAge().toString()             : "any";
+
+            out.printf("%-36s  %-12s  %-17s  %-20s  %-8s  %-12s  %-8s  %-10s  %-7s  %s%n",
+                    a.getId(), a.getName(), a.getLivingSpace(), a.getDailySchedule(),
+                    species, breed, activity, vaccinated, minAge, maxAge);
+        }
+        out.flush();
+    }
+
+    /**
      * Lists all registered adopters with their IDs, names, living spaces, schedules,
-     * and all preference fields. Fields with no preference set are displayed as "any".
-     * Prints a message if no adopters have been registered.
+     * and all preference fields. Prints {@code (none)} if no adopters have been registered.
      */
     @Command(name = "list", description = "List all adopters", mixinStandardHelpOptions = true)
     static class ListCmd implements Runnable {
 
         /**
-         * Executes the list operation and prints each adopter's full details to stdout,
-         * including all preference fields. Prints a message if no adopters are found.
+         * Executes the list operation by delegating to {@link AdopterCmd#renderList}.
+         * Writes to stdout via a flushing {@link PrintWriter}.
          */
         @Override
         public void run() {
             List<Adopter> adopters = AppContext.get().adopterApp().listAdopters();
-            if (adopters.isEmpty()) {
-                System.out.println("No adopters registered.");
-                return;
-            }
-            System.out.printf("%-36s  %-12s  %-17s  %-20s  %-8s  %-12s  %-8s  %-10s  %-7s  %-7s%n",
-                    "ID", "Name", "Living Space", "Schedule",
-                    "Species", "Breed", "Activity", "Vaccinated", "Min Age", "Max Age");
-            System.out.println("-".repeat(155));
-            for (Adopter a : adopters) {
-                // Resolve preference fields; display "any" when no preference is set
-                shelter.domain.AdopterPreferences p = a.getPreferences();
-                String species    = p.getPreferredSpecies()       != null ? p.getPreferredSpecies().name()       : "any";
-                String breed      = p.getPreferredBreed()         != null ? p.getPreferredBreed()                : "any";
-                String activity   = p.getPreferredActivityLevel() != null ? p.getPreferredActivityLevel().name() : "any";
-                String vaccinated = p.getRequiresVaccinated()     != null ? p.getRequiresVaccinated().toString() : "any";
-                String minAge     = p.getMinAge()                 != null ? p.getMinAge().toString()             : "any";
-                String maxAge     = p.getMaxAge()                 != null ? p.getMaxAge().toString()             : "any";
-
-                System.out.printf("%-36s  %-12s  %-17s  %-20s  %-8s  %-12s  %-8s  %-10s  %-7s  %-7s%n",
-                        a.getId(), a.getName(), a.getLivingSpace(), a.getDailySchedule(),
-                        species, breed, activity, vaccinated, minAge, maxAge);
-            }
+            renderList(new PrintWriter(System.out, true), adopters);
         }
     }
 

--- a/src/main/java/shelter/cli/AnimalCmd.java
+++ b/src/main/java/shelter/cli/AnimalCmd.java
@@ -9,6 +9,7 @@ import shelter.domain.Cat;
 import shelter.domain.Dog;
 import shelter.domain.Rabbit;
 
+import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -44,6 +45,50 @@ public class AnimalCmd implements Runnable {
     // -------------------------------------------------------------------------
 
     /**
+     * Renders a list of animal views as a comma-headed, space-padded table to the given writer.
+     * Empty input produces the header row followed by {@code (none)} on the next line.
+     * Species-specific fields show {@code N/A} when not applicable to the animal's species.
+     * Used by both {@code shelter animal list} and {@code shelter print}.
+     *
+     * @param out   the writer to print to; must not be null
+     * @param views the animal views to render; must not be null (may be empty)
+     */
+    static void renderList(PrintWriter out, List<AnimalView> views) {
+        out.printf("%-36s  %-8s  %-12s  %-18s  %-3s  %-8s  %-8s  %-7s  %-7s  %-6s  %-16s  %s%n",
+                "ID,", "SPECIES,", "NAME,", "BREED,", "AGE,", "ACTIVITY,",
+                "NEUTERED,", "INDOOR,", "SIZE,", "FUR,", "SHELTER,", "STATUS");
+        if (views.isEmpty()) {
+            out.println("(none)");
+            out.flush();
+            return;
+        }
+        for (AnimalView v : views) {
+            Animal a = v.getAnimal();
+            // Resolve species-specific fields; use "N/A" when not applicable to this species
+            String neutered = "N/A";
+            String indoor   = "N/A";
+            String size     = "N/A";
+            String fur      = "N/A";
+            if (a instanceof Dog dog) {
+                neutered = String.valueOf(dog.isNeutered());
+                size     = dog.getSize().name();
+            } else if (a instanceof Cat cat) {
+                neutered = String.valueOf(cat.isNeutered());
+                indoor   = String.valueOf(cat.isIndoor());
+            } else if (a instanceof Rabbit rabbit) {
+                fur = rabbit.getFurLength().name();
+            }
+
+            String status = a.isAvailable() ? "available" : "adopted";
+            out.printf("%-36s  %-8s  %-12s  %-18s  %-3d  %-8s  %-8s  %-7s  %-7s  %-6s  %-16s  %s%n",
+                    a.getId(), a.getSpecies(), a.getName(), a.getBreed(),
+                    a.getAge(), a.getActivityLevel(),
+                    neutered, indoor, size, fur, v.getShelterName(), status);
+        }
+        out.flush();
+    }
+
+    /**
      * Lists animals in the system, optionally filtered to a specific shelter.
      * Without {@code --shelter}, all animals system-wide are returned.
      */
@@ -56,47 +101,14 @@ public class AnimalCmd implements Runnable {
         private String shelterId;
 
         /**
-         * Executes the list operation and prints each animal's details to stdout.
-         * All columns are always shown; species-specific fields display "N/A" when not applicable.
-         * The Shelter column shows the shelter name resolved by the Application layer.
-         * Prints a message if no animals are found.
+         * Executes the list operation by delegating to {@link AnimalCmd#renderList}.
+         * Writes to stdout via a flushing {@link PrintWriter}.
          */
         @Override
         public void run() {
             try {
                 List<AnimalView> views = AppContext.get().animalApp().listAnimalsWithShelterName(shelterId);
-                if (views.isEmpty()) {
-                    System.out.println("No animals found.");
-                    return;
-                }
-                System.out.printf("%-36s  %-8s  %-12s  %-18s  %-3s  %-8s  %-8s  %-7s  %-7s  %-6s  %-16s  %s%n",
-                        "ID", "Species", "Name", "Breed", "Age", "Activity",
-                        "Neutered", "Indoor", "Size", "Fur", "Shelter", "Status");
-                System.out.println("-".repeat(148));
-                for (AnimalView v : views) {
-                    Animal a = v.getAnimal();
-
-                    // Resolve species-specific fields; use "N/A" when not applicable to this species
-                    String neutered = "N/A";
-                    String indoor   = "N/A";
-                    String size     = "N/A";
-                    String fur      = "N/A";
-                    if (a instanceof Dog dog) {
-                        neutered = String.valueOf(dog.isNeutered());
-                        size     = dog.getSize().name();
-                    } else if (a instanceof Cat cat) {
-                        neutered = String.valueOf(cat.isNeutered());
-                        indoor   = String.valueOf(cat.isIndoor());
-                    } else if (a instanceof Rabbit rabbit) {
-                        fur = rabbit.getFurLength().name();
-                    }
-
-                    String status = a.isAvailable() ? "available" : "adopted";
-                    System.out.printf("%-36s  %-8s  %-12s  %-18s  %-3d  %-8s  %-8s  %-7s  %-7s  %-6s  %-16s  %s%n",
-                            a.getId(), a.getSpecies(), a.getName(), a.getBreed(),
-                            a.getAge(), a.getActivityLevel(),
-                            neutered, indoor, size, fur, v.getShelterName(), status);
-                }
+                renderList(new PrintWriter(System.out, true), views);
             } catch (Exception e) {
                 System.err.println("Error: " + e.getMessage());
             }

--- a/src/main/java/shelter/cli/AnimalCmd.java
+++ b/src/main/java/shelter/cli/AnimalCmd.java
@@ -53,7 +53,7 @@ public class AnimalCmd implements Runnable {
      * @param out   the writer to print to; must not be null
      * @param views the animal views to render; must not be null (may be empty)
      */
-    static void renderList(PrintWriter out, List<AnimalView> views) {
+    public static void renderList(PrintWriter out, List<AnimalView> views) {
         out.printf("%-36s  %-8s  %-12s  %-18s  %-3s  %-8s  %-8s  %-7s  %-7s  %-6s  %-16s  %s%n",
                 "ID,", "SPECIES,", "NAME,", "BREED,", "AGE,", "ACTIVITY,",
                 "NEUTERED,", "INDOOR,", "SIZE,", "FUR,", "SHELTER,", "STATUS");

--- a/src/main/java/shelter/cli/AuditCmd.java
+++ b/src/main/java/shelter/cli/AuditCmd.java
@@ -43,7 +43,7 @@ public class AuditCmd implements Runnable {
      * @param entries the audit entries to render; must not be null (may be empty)
      * @param limit   the maximum number of most-recent entries to show; must be positive
      */
-    static void renderLog(PrintWriter out, List<AuditEntry<?>> entries, int limit) {
+    public static void renderLog(PrintWriter out, List<AuditEntry<?>> entries, int limit) {
         out.printf("%-20s  %-12s  %-30s  %s%n",
                 "TIMESTAMP,", "STAFF,", "ACTION,", "TARGET");
         if (entries.isEmpty()) {

--- a/src/main/java/shelter/cli/AuditCmd.java
+++ b/src/main/java/shelter/cli/AuditCmd.java
@@ -3,6 +3,7 @@ package shelter.cli;
 import picocli.CommandLine.Command;
 import shelter.service.model.AuditEntry;
 
+import java.io.PrintWriter;
 import java.util.List;
 
 /**
@@ -32,6 +33,45 @@ public class AuditCmd implements Runnable {
     // -------------------------------------------------------------------------
 
     /**
+     * Renders the audit log as a comma-headed, space-padded table to the given writer.
+     * Empty input produces the header row followed by {@code (none)} on the next line.
+     * If {@code entries.size() > limit}, only the last {@code limit} entries are printed
+     * and a truncation footer of the form {@code (showing last N of M entries)} follows.
+     * Used by both {@code shelter audit log} and {@code shelter print}.
+     *
+     * @param out     the writer to print to; must not be null
+     * @param entries the audit entries to render; must not be null (may be empty)
+     * @param limit   the maximum number of most-recent entries to show; must be positive
+     */
+    static void renderLog(PrintWriter out, List<AuditEntry<?>> entries, int limit) {
+        out.printf("%-20s  %-12s  %-30s  %s%n",
+                "TIMESTAMP,", "STAFF,", "ACTION,", "TARGET");
+        if (entries.isEmpty()) {
+            out.println("(none)");
+            out.flush();
+            return;
+        }
+        // When the list exceeds the limit, print only the tail (most recent)
+        int start = Math.max(0, entries.size() - limit);
+        for (int i = start; i < entries.size(); i++) {
+            AuditEntry<?> e = entries.get(i);
+            String staffName = e.getStaff() != null ? e.getStaff().getName() : "unknown";
+            String target    = e.getTarget() != null ? e.getTarget().toString() : "";
+            // Truncate long target strings for readability
+            if (target.length() > 35) {
+                target = target.substring(0, 32) + "...";
+            }
+            out.printf("%-20s  %-12s  %-30s  %s%n",
+                    e.getTimestamp(), staffName, e.getAction(), target);
+        }
+        // Footer showing truncation counts only when we actually truncated
+        if (start > 0) {
+            out.println("(showing last " + limit + " of " + entries.size() + " entries)");
+        }
+        out.flush();
+    }
+
+    /**
      * Displays the full persistent audit log of all staff actions.
      * Reads from the CSV-backed audit repository so the history survives across command executions.
      */
@@ -40,30 +80,14 @@ public class AuditCmd implements Runnable {
     static class LogCmd implements Runnable {
 
         /**
-         * Executes the log retrieval and prints each entry with timestamp, staff, and action.
-         * Prints a message if the audit log is empty.
+         * Executes the log retrieval by delegating to {@link AuditCmd#renderLog}.
+         * The full log is printed with no truncation; large logs use the {@code shelter print}
+         * summary to get a capped view.
          */
         @Override
-        @SuppressWarnings("rawtypes")
         public void run() {
             List<AuditEntry<?>> entries = AppContext.get().auditApp().getLog();
-            if (entries.isEmpty()) {
-                System.out.println("Audit log is empty.");
-                return;
-            }
-            System.out.printf("%-20s  %-12s  %-30s  %s%n",
-                    "Timestamp", "Staff", "Action", "Target");
-            System.out.println("-".repeat(90));
-            for (AuditEntry<?> e : entries) {
-                String staffName = e.getStaff() != null ? e.getStaff().getName() : "unknown";
-                String target    = e.getTarget() != null ? e.getTarget().toString() : "";
-                // Truncate long target strings for readability
-                if (target.length() > 35) {
-                    target = target.substring(0, 32) + "...";
-                }
-                System.out.printf("%-20s  %-12s  %-30s  %s%n",
-                        e.getTimestamp(), staffName, e.getAction(), target);
-            }
+            renderLog(new PrintWriter(System.out, true), entries, Integer.MAX_VALUE);
         }
     }
 }

--- a/src/main/java/shelter/cli/Main.java
+++ b/src/main/java/shelter/cli/Main.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
                 MatchCmd.class,
                 VaccineCmd.class,
                 AuditCmd.class,
+                PrintCmd.class,
                 CommandLine.HelpCommand.class
         },
         mixinStandardHelpOptions = true,
@@ -37,7 +38,7 @@ public class Main implements Runnable {
     @Override
     public void run() {
         System.out.println("Usage: shelter <subcommand> --help");
-        System.out.println("Subcommands: shelter, animal, adopter, adopt, transfer, match, vaccine, audit");
+        System.out.println("Subcommands: shelter, animal, adopter, adopt, transfer, match, vaccine, audit, print");
     }
 
     /**

--- a/src/main/java/shelter/cli/PrintCmd.java
+++ b/src/main/java/shelter/cli/PrintCmd.java
@@ -1,0 +1,131 @@
+package shelter.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import shelter.cli.print.DataDirHash;
+import shelter.cli.print.MarkdownRenderer;
+import shelter.cli.print.SnapshotRenderer;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Top-level CLI command that renders the full system state.
+ * Without flags, prints a one-shot 8-section snapshot to stdout.
+ * With {@code --watch}, polls the data directory and rewrites a markdown file
+ * whenever the CSV contents change. Used during the class demo to drive a
+ * live-updating VS Code preview pane.
+ */
+@Command(
+        name = "print",
+        description = "Print the full system state; optionally watch for changes and update a file",
+        mixinStandardHelpOptions = true
+)
+public class PrintCmd implements Runnable {
+
+    private static final String DEFAULT_OUT_NAME = "dashboard.md";
+    private static final long POLL_INTERVAL_MS = 1000L;
+    private static final DateTimeFormatter CLOCK = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    /** When set, run the watch loop instead of printing once and exiting. */
+    @Option(names = "--watch",
+            description = "Keep running, re-rendering the output file when CSVs change")
+    private boolean watch;
+
+    /** Output path for the markdown dashboard in watch mode. */
+    @Option(names = "--out",
+            description = "Output path for the markdown dashboard (watch mode only; default: <shelter-home>/dashboard.md)")
+    private Path out;
+
+    /**
+     * Either prints a one-shot snapshot to stdout or enters the watch loop.
+     * Errors are printed to stderr.
+     */
+    @Override
+    public void run() {
+        if (!watch) {
+            // One-shot mode: render the plain-text snapshot and return
+            new SnapshotRenderer(AppContext.get()).render(new PrintWriter(System.out, true));
+            return;
+        }
+        try {
+            runWatchLoop();
+        } catch (InterruptedException ie) {
+            // Preserve the interrupt so the JVM shuts down cleanly on Ctrl+C
+            Thread.currentThread().interrupt();
+        } catch (IOException ioe) {
+            System.err.println("Error: " + ioe.getMessage());
+        }
+    }
+
+    /**
+     * Polls the shelter data directory once per second and rewrites the output markdown
+     * when the SHA-1 digest of CSV contents changes. Writes atomically via a temp file.
+     *
+     * @throws IOException          if the data directory cannot be read or the output cannot be written
+     * @throws InterruptedException if the polling sleep is interrupted
+     */
+    private void runWatchLoop() throws IOException, InterruptedException {
+        Path shelterHome = resolveShelterHome();
+        Path dataDir = shelterHome.resolve("data");
+        Path outPath = (out != null) ? out : shelterHome.resolve(DEFAULT_OUT_NAME);
+
+        // Ensure the data directory exists so DataDirHash does not fail on a fresh install
+        Files.createDirectories(dataDir);
+        // Ensure the parent of the output file exists so atomic rename has somewhere to land
+        if (outPath.getParent() != null) {
+            Files.createDirectories(outPath.getParent());
+        }
+
+        System.out.println("Watching " + dataDir + ", writing " + outPath + " (Ctrl+C to stop)");
+
+        String lastHash = null;
+        while (!Thread.currentThread().isInterrupted()) {
+            String currentHash = DataDirHash.compute(dataDir);
+            // Only rewrite when the CSV byte-content has actually changed
+            if (!currentHash.equals(lastHash)) {
+                writeAtomically(outPath, new MarkdownRenderer(AppContext.get()).render());
+                System.out.println("[" + LocalTime.now().format(CLOCK) + "] updated");
+                lastHash = currentHash;
+            }
+            Thread.sleep(POLL_INTERVAL_MS);
+        }
+    }
+
+    /**
+     * Writes {@code content} to {@code target} via a temp file + atomic rename so
+     * the VS Code file watcher never sees a half-written file. Falls back to a
+     * non-atomic move if the filesystem does not support atomic moves.
+     *
+     * @param target  the destination path
+     * @param content the content to write
+     * @throws IOException if the temp file cannot be written or moved into place
+     */
+    private static void writeAtomically(Path target, String content) throws IOException {
+        Path tmp = target.resolveSibling(target.getFileName() + ".tmp");
+        Files.writeString(tmp, content);
+        try {
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException fallback) {
+            // Some filesystems (notably Windows shares) do not support atomic moves; degrade gracefully
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    /**
+     * Resolves the shelter home directory in the same way {@code Main} does:
+     * {@code $SHELTER_HOME} if set, otherwise {@code ~/shelter}.
+     *
+     * @return the resolved shelter home path
+     */
+    private static Path resolveShelterHome() {
+        String env = System.getenv("SHELTER_HOME");
+        return (env != null) ? Path.of(env) : Path.of(System.getProperty("user.home"), "shelter");
+    }
+}

--- a/src/main/java/shelter/cli/PrintCmd.java
+++ b/src/main/java/shelter/cli/PrintCmd.java
@@ -5,6 +5,7 @@ import picocli.CommandLine.Option;
 import shelter.cli.print.DataDirHash;
 import shelter.cli.print.MarkdownRenderer;
 import shelter.cli.print.SnapshotRenderer;
+import shelter.startup.SystemStartupImpl;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -90,12 +91,37 @@ public class PrintCmd implements Runnable {
             String currentHash = DataDirHash.compute(dataDir);
             // Only rewrite when the CSV byte-content has actually changed
             if (!currentHash.equals(lastHash)) {
-                writeAtomically(outPath, new MarkdownRenderer(AppContext.get()).render());
+                writeAtomically(outPath, renderFreshMarkdown(shelterHome));
                 System.out.println("[" + LocalTime.now().format(CLOCK) + "] updated");
                 lastHash = currentHash;
             }
             Thread.sleep(POLL_INTERVAL_MS);
         }
+    }
+
+    /**
+     * Builds a fresh {@link SystemStartupImpl} bound to {@code shelterHome} and renders
+     * the markdown dashboard from it. Rebuilding the graph each tick ensures the dashboard
+     * reflects CSV writes made by other {@code shelter} processes during the watch,
+     * avoiding stale in-memory state from the cached CLI application graph.
+     *
+     * @param shelterHome the base shelter home directory
+     * @return the rendered markdown dashboard
+     */
+    private static String renderFreshMarkdown(Path shelterHome) {
+        SystemStartupImpl fresh = new SystemStartupImpl(shelterHome);
+        fresh.initialize();
+        SnapshotRenderer snap = new SnapshotRenderer(
+                () -> fresh.shelterApp().listShelters(),
+                () -> fresh.animalApp().listAnimalsWithShelterName(null),
+                () -> fresh.adopterApp().listAdopters(),
+                () -> fresh.adoptionApp().listAllRequests(),
+                () -> fresh.transferApp().listAllTransfers(),
+                () -> fresh.vaccinationApp().listVaccineTypes(),
+                () -> fresh.vaccinationApp().listAllVaccinationRecords(),
+                () -> fresh.auditApp().getLog()
+        );
+        return new MarkdownRenderer(snap).render();
     }
 
     /**

--- a/src/main/java/shelter/cli/ShelterCmd.java
+++ b/src/main/java/shelter/cli/ShelterCmd.java
@@ -46,7 +46,7 @@ public class ShelterCmd implements Runnable {
      * @param out      the writer to print to; must not be null
      * @param shelters the shelters to render; must not be null (may be empty)
      */
-    static void renderList(PrintWriter out, List<Shelter> shelters) {
+    public static void renderList(PrintWriter out, List<Shelter> shelters) {
         out.printf("%-36s  %-20s  %-20s  %s%n",
                 "ID,", "NAME,", "LOCATION,", "CAPACITY");
         if (shelters.isEmpty()) {

--- a/src/main/java/shelter/cli/ShelterCmd.java
+++ b/src/main/java/shelter/cli/ShelterCmd.java
@@ -4,6 +4,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import shelter.domain.Shelter;
 
+import java.io.PrintWriter;
 import java.util.List;
 
 /**
@@ -38,31 +39,44 @@ public class ShelterCmd implements Runnable {
     // -------------------------------------------------------------------------
 
     /**
+     * Renders a list of shelters as a comma-headed, space-padded table to the given writer.
+     * Empty input produces the header row followed by {@code (none)} on the next line.
+     * Used by both {@code shelter shelter list} and {@code shelter print}.
+     *
+     * @param out      the writer to print to; must not be null
+     * @param shelters the shelters to render; must not be null (may be empty)
+     */
+    static void renderList(PrintWriter out, List<Shelter> shelters) {
+        out.printf("%-36s  %-20s  %-20s  %s%n",
+                "ID,", "NAME,", "LOCATION,", "CAPACITY");
+        if (shelters.isEmpty()) {
+            out.println("(none)");
+            out.flush();
+            return;
+        }
+        for (Shelter s : shelters) {
+            out.printf("%-36s  %-20s  %-20s  %d/%d%n",
+                    s.getId(), s.getName(), s.getLocation(),
+                    s.getCurrentCount(), s.getCapacity());
+        }
+        out.flush();
+    }
+
+    /**
      * Lists all registered shelters with their IDs, names, locations, and capacity usage.
-     * Prints a message if no shelters have been registered.
+     * Prints {@code (none)} if no shelters have been registered.
      */
     @Command(name = "list", description = "List all shelters", mixinStandardHelpOptions = true)
     static class ListCmd implements Runnable {
 
         /**
-         * Executes the list operation and prints each shelter's details to stdout.
-         * Prints a message if the system contains no shelters.
+         * Executes the list operation by delegating to {@link ShelterCmd#renderList}.
+         * Writes to stdout via a flushing {@link PrintWriter}.
          */
         @Override
         public void run() {
             List<Shelter> shelters = AppContext.get().shelterApp().listShelters();
-            if (shelters.isEmpty()) {
-                System.out.println("No shelters registered.");
-                return;
-            }
-            System.out.printf("%-36s  %-20s  %-20s  %s%n",
-                    "ID", "Name", "Location", "Capacity");
-            System.out.println("-".repeat(90));
-            for (Shelter s : shelters) {
-                System.out.printf("%-36s  %-20s  %-20s  %d/%d%n",
-                        s.getId(), s.getName(), s.getLocation(),
-                        s.getCurrentCount(), s.getCapacity());
-            }
+            renderList(new PrintWriter(System.out, true), shelters);
         }
     }
 

--- a/src/main/java/shelter/cli/TransferCmd.java
+++ b/src/main/java/shelter/cli/TransferCmd.java
@@ -47,7 +47,7 @@ public class TransferCmd implements Runnable {
      * @param out      the writer to print to; must not be null
      * @param requests the transfer requests to render; must not be null (may be empty)
      */
-    static void renderList(PrintWriter out, List<TransferRequest> requests) {
+    public static void renderList(PrintWriter out, List<TransferRequest> requests) {
         out.printf("%-36s  %-14s  %-14s  %-14s  %-10s  %s%n",
                 "ID,", "ANIMAL,", "FROM,", "TO,", "STATUS,", "REQUESTED AT");
         if (requests.isEmpty()) {

--- a/src/main/java/shelter/cli/TransferCmd.java
+++ b/src/main/java/shelter/cli/TransferCmd.java
@@ -4,6 +4,9 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import shelter.domain.TransferRequest;
 
+import java.io.PrintWriter;
+import java.util.List;
+
 /**
  * Top-level CLI command group for the inter-shelter transfer request lifecycle.
  * Provides subcommands to request, approve, reject, and cancel transfer requests.
@@ -13,6 +16,7 @@ import shelter.domain.TransferRequest;
         name = "transfer",
         description = "Manage inter-shelter transfer requests",
         subcommands = {
+                TransferCmd.ListCmd.class,
                 TransferCmd.RequestCmd.class,
                 TransferCmd.ApproveCmd.class,
                 TransferCmd.RejectCmd.class,
@@ -29,6 +33,65 @@ public class TransferCmd implements Runnable {
     @Override
     public void run() {
         System.out.println("Usage: shelter transfer <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // render helper (shared by `transfer list` and `shelter print`)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Renders transfer requests as a comma-headed, space-padded table to the given writer.
+     * Empty input prints the header followed by {@code (none)}.
+     * Used by both {@code shelter transfer list} and {@code shelter print}.
+     *
+     * @param out      the writer to print to; must not be null
+     * @param requests the transfer requests to render; must not be null (may be empty)
+     */
+    static void renderList(PrintWriter out, List<TransferRequest> requests) {
+        out.printf("%-36s  %-14s  %-14s  %-14s  %-10s  %s%n",
+                "ID,", "ANIMAL,", "FROM,", "TO,", "STATUS,", "REQUESTED AT");
+        if (requests.isEmpty()) {
+            out.println("(none)");
+            out.flush();
+            return;
+        }
+        for (TransferRequest r : requests) {
+            out.printf("%-36s  %-14s  %-14s  %-14s  %-10s  %s%n",
+                    r.getId(),
+                    r.getAnimal().getName(),
+                    r.getFrom().getName(),
+                    r.getTo().getName(),
+                    r.getStatus().name(),
+                    r.getRequestedAt());
+        }
+        out.flush();
+    }
+
+    // -------------------------------------------------------------------------
+    // list
+    // -------------------------------------------------------------------------
+
+    /**
+     * Lists every transfer request currently in the system.
+     * Used primarily for demo purposes and by the {@code shelter print} summary.
+     */
+    @Command(name = "list", description = "List all transfer requests",
+             mixinStandardHelpOptions = true)
+    static class ListCmd implements Runnable {
+
+        /**
+         * Executes the list operation by delegating to {@link TransferCmd#renderList}.
+         * Writes to stdout via a flushing {@link PrintWriter}.
+         */
+        @Override
+        public void run() {
+            try {
+                renderList(new PrintWriter(System.out, true),
+                        AppContext.get().transferApp().listAllTransfers());
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/shelter/cli/VaccineCmd.java
+++ b/src/main/java/shelter/cli/VaccineCmd.java
@@ -49,7 +49,7 @@ public class VaccineCmd implements Runnable {
      * @param out   the writer to print to; must not be null
      * @param types the vaccine types to render; must not be null (may be empty)
      */
-    static void renderTypeList(PrintWriter out, List<VaccineType> types) {
+    public static void renderTypeList(PrintWriter out, List<VaccineType> types) {
         out.printf("%-36s  %-20s  %-10s  %s%n",
                 "ID,", "NAME,", "SPECIES,", "VALIDITY (DAYS)");
         if (types.isEmpty()) {
@@ -72,8 +72,8 @@ public class VaccineCmd implements Runnable {
      * @param out   the writer to print to; must not be null
      * @param views the vaccination record views to render; must not be null (may be empty)
      */
-    static void renderRecordList(PrintWriter out,
-                                 List<shelter.application.model.VaccinationRecordView> views) {
+    public static void renderRecordList(PrintWriter out,
+                                        List<shelter.application.model.VaccinationRecordView> views) {
         out.printf("%-36s  %-14s  %-8s  %-20s  %s%n",
                 "ID,", "ANIMAL,", "SPECIES,", "VACCINE,", "DATE");
         if (views.isEmpty()) {

--- a/src/main/java/shelter/cli/VaccineCmd.java
+++ b/src/main/java/shelter/cli/VaccineCmd.java
@@ -19,6 +19,7 @@ import java.util.List;
         name = "vaccine",
         description = "Manage vaccinations and vaccine types",
         subcommands = {
+                VaccineCmd.ListCmd.class,
                 VaccineCmd.RecordCmd.class,
                 VaccineCmd.OverdueCmd.class,
                 VaccineCmd.TypeCmd.class
@@ -61,6 +62,62 @@ public class VaccineCmd implements Runnable {
                     t.getId(), t.getName(), t.getApplicableSpecies(), t.getValidityDays());
         }
         out.flush();
+    }
+
+    /**
+     * Renders vaccination records as a comma-headed, space-padded table to the given writer.
+     * Empty input prints the header followed by {@code (none)}.
+     * Used by both {@code shelter vaccine list} and {@code shelter print}.
+     *
+     * @param out   the writer to print to; must not be null
+     * @param views the vaccination record views to render; must not be null (may be empty)
+     */
+    static void renderRecordList(PrintWriter out,
+                                 List<shelter.application.model.VaccinationRecordView> views) {
+        out.printf("%-36s  %-14s  %-8s  %-20s  %s%n",
+                "ID,", "ANIMAL,", "SPECIES,", "VACCINE,", "DATE");
+        if (views.isEmpty()) {
+            out.println("(none)");
+            out.flush();
+            return;
+        }
+        for (shelter.application.model.VaccinationRecordView v : views) {
+            out.printf("%-36s  %-14s  %-8s  %-20s  %s%n",
+                    v.getRecord().getId(),
+                    v.getAnimalName(),
+                    v.getSpecies().name(),
+                    v.getVaccineTypeName(),
+                    v.getRecord().getDateAdministered());
+        }
+        out.flush();
+    }
+
+    // -------------------------------------------------------------------------
+    // list (vaccination records)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Lists every vaccination record in the system, using {@link shelter.application.model.VaccinationRecordView}
+     * to resolve animal and vaccine type display names. Used primarily for demo purposes
+     * and by the {@code shelter print} summary.
+     */
+    @Command(name = "list", description = "List all vaccination records",
+             mixinStandardHelpOptions = true)
+    static class ListCmd implements Runnable {
+
+        /**
+         * Executes the list operation by delegating to {@link VaccineCmd#renderRecordList}.
+         * Writes to stdout via a flushing {@link PrintWriter}.
+         */
+        @Override
+        public void run() {
+            try {
+                renderRecordList(new PrintWriter(System.out, true),
+                        AppContext.get().vaccinationApp().listAllVaccinationRecords());
+            } catch (Exception e) {
+                System.err.println("Error: " + e.getMessage());
+            }
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/shelter/cli/VaccineCmd.java
+++ b/src/main/java/shelter/cli/VaccineCmd.java
@@ -6,6 +6,7 @@ import shelter.domain.Species;
 import shelter.domain.VaccineType;
 import shelter.service.model.OverdueVaccination;
 
+import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -33,6 +34,33 @@ public class VaccineCmd implements Runnable {
     @Override
     public void run() {
         System.out.println("Usage: shelter vaccine <subcommand> --help");
+    }
+
+    // -------------------------------------------------------------------------
+    // render helpers (shared by list subcommands and `shelter print`)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Renders a list of vaccine types as a comma-headed, space-padded table to the given writer.
+     * Empty input produces the header row followed by {@code (none)} on the next line.
+     * Used by both {@code shelter vaccine type list} and {@code shelter print}.
+     *
+     * @param out   the writer to print to; must not be null
+     * @param types the vaccine types to render; must not be null (may be empty)
+     */
+    static void renderTypeList(PrintWriter out, List<VaccineType> types) {
+        out.printf("%-36s  %-20s  %-10s  %s%n",
+                "ID,", "NAME,", "SPECIES,", "VALIDITY (DAYS)");
+        if (types.isEmpty()) {
+            out.println("(none)");
+            out.flush();
+            return;
+        }
+        for (VaccineType t : types) {
+            out.printf("%-36s  %-20s  %-10s  %d%n",
+                    t.getId(), t.getName(), t.getApplicableSpecies(), t.getValidityDays());
+        }
+        out.flush();
     }
 
     // -------------------------------------------------------------------------
@@ -150,30 +178,20 @@ public class VaccineCmd implements Runnable {
 
         /**
          * Lists all vaccine types in the catalog with their IDs, names, species, and validity periods.
-         * Prints a message if the catalog is empty.
+         * Prints {@code (none)} if the catalog is empty.
          */
         @Command(name = "list", description = "List all vaccine types",
                  mixinStandardHelpOptions = true)
         static class ListCmd implements Runnable {
 
             /**
-             * Executes the list and prints each vaccine type's details.
-             * Prints a message if no vaccine types have been added.
+             * Executes the list operation by delegating to {@link VaccineCmd#renderTypeList}.
+             * Writes to stdout via a flushing {@link PrintWriter}.
              */
             @Override
             public void run() {
                 List<VaccineType> types = AppContext.get().vaccinationApp().listVaccineTypes();
-                if (types.isEmpty()) {
-                    System.out.println("No vaccine types in catalog.");
-                    return;
-                }
-                System.out.printf("%-36s  %-20s  %-10s  %s%n",
-                        "ID", "Name", "Species", "Validity (days)");
-                System.out.println("-".repeat(80));
-                for (VaccineType t : types) {
-                    System.out.printf("%-36s  %-20s  %-10s  %d%n",
-                            t.getId(), t.getName(), t.getApplicableSpecies(), t.getValidityDays());
-                }
+                renderTypeList(new PrintWriter(System.out, true), types);
             }
         }
 

--- a/src/main/java/shelter/cli/print/DataDirHash.java
+++ b/src/main/java/shelter/cli/print/DataDirHash.java
@@ -1,0 +1,70 @@
+package shelter.cli.print;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Computes a stable content hash over every {@code *.csv} file in a data directory.
+ * Hashing ignores file ordering and mtimes — only the file name and byte contents
+ * contribute. This lets the watch loop detect real data changes while ignoring
+ * spurious mtime bumps from no-op writes.
+ */
+public final class DataDirHash {
+
+    /** Prevents instantiation — this class exposes only a static API. */
+    private DataDirHash() {
+    }
+
+    /**
+     * Computes a SHA-1 hex digest over the sorted CSV files under {@code dataDir}.
+     * Each file contributes its relative file name bytes, a newline, and its full content
+     * to the digest in sorted-by-name order.
+     *
+     * @param dataDir the directory containing the CSV files; must exist and be a directory
+     * @return a 40-character hex digest
+     * @throws IOException if the directory cannot be read, is not a directory, or a file cannot be read
+     */
+    public static String compute(Path dataDir) throws IOException {
+        // Guard: fail fast with a clear error when the directory does not exist
+        if (!Files.isDirectory(dataDir)) {
+            throw new IOException("Not a directory: " + dataDir);
+        }
+
+        // Collect every *.csv file under the directory and sort for stable hashing order
+        List<Path> files = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dataDir, "*.csv")) {
+            for (Path p : stream) {
+                files.add(p);
+            }
+        }
+        Collections.sort(files);
+
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("SHA-1 not available", e);
+        }
+
+        // Each file contributes: filename bytes, newline separator, then full content bytes
+        for (Path p : files) {
+            md.update(p.getFileName().toString().getBytes());
+            md.update((byte) '\n');
+            md.update(Files.readAllBytes(p));
+        }
+
+        byte[] digest = md.digest();
+        StringBuilder hex = new StringBuilder(digest.length * 2);
+        for (byte b : digest) {
+            hex.append(String.format("%02x", b));
+        }
+        return hex.toString();
+    }
+}

--- a/src/main/java/shelter/cli/print/MarkdownRenderer.java
+++ b/src/main/java/shelter/cli/print/MarkdownRenderer.java
@@ -1,0 +1,110 @@
+package shelter.cli.print;
+
+import shelter.cli.AppContext;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Renders the full system snapshot as markdown suitable for VS Code's preview pane.
+ * Structure: a top-level {@code # Shelter System State} heading, an {@code *Updated: ...*}
+ * timestamp, then eight {@code ## Section} headings, each followed by a fenced code block
+ * containing the plain-text table produced by {@link SnapshotRenderer}.
+ */
+public final class MarkdownRenderer {
+
+    private static final DateTimeFormatter STAMP = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /** Section headings used in the markdown document, in order. */
+    private static final String[] SECTIONS = {
+            "Shelters", "Animals", "Adopters", "Adoption Requests",
+            "Transfer Requests", "Vaccine Types", "Vaccinations", "Audit Log"
+    };
+
+    /** Plain-text section titles emitted by {@link SnapshotRenderer}, aligned with {@link #SECTIONS}. */
+    private static final String[] TITLES = {
+            "SHELTERS", "ANIMALS", "ADOPTERS", "ADOPTION REQUESTS",
+            "TRANSFER REQUESTS", "VACCINE TYPES", "VACCINATIONS", "AUDIT LOG"
+    };
+
+    private final SnapshotRenderer snapshotRenderer;
+
+    /**
+     * Constructs a markdown renderer backed by the given snapshot renderer.
+     * This constructor enables dependency injection in unit tests.
+     *
+     * @param snapshotRenderer the plain-text snapshot renderer to wrap; must not be null
+     */
+    public MarkdownRenderer(SnapshotRenderer snapshotRenderer) {
+        if (snapshotRenderer == null) {
+            throw new IllegalArgumentException("SnapshotRenderer must not be null.");
+        }
+        this.snapshotRenderer = snapshotRenderer;
+    }
+
+    /**
+     * Convenience constructor that wires a {@link SnapshotRenderer} backed by the CLI context.
+     *
+     * @param ctx the context used to fetch live data; must not be null
+     */
+    public MarkdownRenderer(AppContext ctx) {
+        this(new SnapshotRenderer(ctx));
+    }
+
+    /**
+     * Produces the full markdown document as a single string.
+     * Each invocation reads current state fresh through the snapshot renderer.
+     *
+     * @return the rendered markdown document
+     */
+    public String render() {
+        StringBuilder doc = new StringBuilder();
+        doc.append("# Shelter System State\n\n");
+        doc.append("*Updated: ").append(LocalDateTime.now().format(STAMP)).append("*\n\n");
+
+        // Produce the full plain-text snapshot once, then split by section title for markdown wrapping
+        StringWriter sw = new StringWriter();
+        snapshotRenderer.render(new PrintWriter(sw));
+        String snapshot = sw.toString();
+
+        for (int i = 0; i < SECTIONS.length; i++) {
+            String body = extractSection(snapshot, TITLES[i]);
+            doc.append("## ").append(SECTIONS[i]).append("\n\n");
+            doc.append("```\n").append(body).append("```\n\n");
+        }
+        return doc.toString();
+    }
+
+    /**
+     * Extracts the body text of the named section from a plain-text snapshot.
+     * The section body is everything between {@code === TITLE ===} and the next
+     * {@code === } marker (or end-of-document), exclusive of both delimiters and
+     * surrounding blank lines. Returned body always ends with a newline.
+     */
+    private static String extractSection(String snapshot, String title) {
+        String marker = "=== " + title + " ===";
+        int start = snapshot.indexOf(marker);
+        if (start < 0) {
+            return "";
+        }
+        int bodyStart = snapshot.indexOf('\n', start) + 1;
+        int bodyEnd = snapshot.indexOf("=== ", bodyStart);
+        if (bodyEnd < 0) {
+            bodyEnd = snapshot.length();
+        }
+        String body = snapshot.substring(bodyStart, bodyEnd);
+        // Trim leading blank lines and collapse trailing blank lines to a single newline
+        while (body.startsWith("\n")) {
+            body = body.substring(1);
+        }
+        while (body.endsWith("\n\n")) {
+            body = body.substring(0, body.length() - 1);
+        }
+        if (!body.endsWith("\n")) {
+            body = body + "\n";
+        }
+        return body;
+    }
+}

--- a/src/main/java/shelter/cli/print/SnapshotRenderer.java
+++ b/src/main/java/shelter/cli/print/SnapshotRenderer.java
@@ -90,18 +90,27 @@ public final class SnapshotRenderer {
      */
     public SnapshotRenderer(AppContext ctx) {
         this(
-                () -> ctx.shelterApp().listShelters(),
-                () -> ctx.animalApp().listAnimalsWithShelterName(null),
-                () -> ctx.adopterApp().listAdopters(),
-                () -> ctx.adoptionApp().listAllRequests(),
-                () -> ctx.transferApp().listAllTransfers(),
-                () -> ctx.vaccinationApp().listVaccineTypes(),
-                () -> ctx.vaccinationApp().listAllVaccinationRecords(),
-                () -> ctx.auditApp().getLog()
+                () -> requireCtx(ctx).shelterApp().listShelters(),
+                () -> requireCtx(ctx).animalApp().listAnimalsWithShelterName(null),
+                () -> requireCtx(ctx).adopterApp().listAdopters(),
+                () -> requireCtx(ctx).adoptionApp().listAllRequests(),
+                () -> requireCtx(ctx).transferApp().listAllTransfers(),
+                () -> requireCtx(ctx).vaccinationApp().listVaccineTypes(),
+                () -> requireCtx(ctx).vaccinationApp().listAllVaccinationRecords(),
+                () -> requireCtx(ctx).auditApp().getLog()
         );
+        requireCtx(ctx);
+    }
+
+    /**
+     * Returns {@code ctx} if non-null; otherwise throws {@link IllegalArgumentException}.
+     * Used to fail fast both at construction time and at first lambda invocation.
+     */
+    private static AppContext requireCtx(AppContext ctx) {
         if (ctx == null) {
             throw new IllegalArgumentException("AppContext must not be null.");
         }
+        return ctx;
     }
 
     /**

--- a/src/main/java/shelter/cli/print/SnapshotRenderer.java
+++ b/src/main/java/shelter/cli/print/SnapshotRenderer.java
@@ -1,0 +1,139 @@
+package shelter.cli.print;
+
+import shelter.application.model.AnimalView;
+import shelter.application.model.VaccinationRecordView;
+import shelter.cli.AdoptCmd;
+import shelter.cli.AdopterCmd;
+import shelter.cli.AnimalCmd;
+import shelter.cli.AppContext;
+import shelter.cli.AuditCmd;
+import shelter.cli.ShelterCmd;
+import shelter.cli.TransferCmd;
+import shelter.cli.VaccineCmd;
+import shelter.domain.Adopter;
+import shelter.domain.AdoptionRequest;
+import shelter.domain.Shelter;
+import shelter.domain.TransferRequest;
+import shelter.domain.VaccineType;
+import shelter.service.model.AuditEntry;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Renders the full 8-section system snapshot as plain text.
+ * Used by both {@code shelter print} (writes to stdout) and by
+ * {@link MarkdownRenderer} (which wraps each section in a fenced code block).
+ * Section content is delegated to the package-private {@code render*} helpers
+ * on each CLI command class so formatting lives in exactly one place per entity.
+ */
+public final class SnapshotRenderer {
+
+    /** Maximum number of audit entries shown in the snapshot. */
+    static final int AUDIT_LIMIT = 20;
+
+    private final Supplier<List<Shelter>> shelters;
+    private final Supplier<List<AnimalView>> animalViews;
+    private final Supplier<List<Adopter>> adopters;
+    private final Supplier<List<AdoptionRequest>> adoptionRequests;
+    private final Supplier<List<TransferRequest>> transferRequests;
+    private final Supplier<List<VaccineType>> vaccineTypes;
+    private final Supplier<List<VaccinationRecordView>> vaccinationRecords;
+    private final Supplier<List<AuditEntry<?>>> auditLog;
+
+    /**
+     * Constructs a SnapshotRenderer from eight data-source suppliers.
+     * This primary constructor makes unit testing trivial — callers inject
+     * in-memory lambdas for each section without touching any singleton.
+     *
+     * @param shelters           supplier of the shelter list; must not be null
+     * @param animalViews        supplier of the animal-view list; must not be null
+     * @param adopters           supplier of the adopter list; must not be null
+     * @param adoptionRequests   supplier of the adoption request list; must not be null
+     * @param transferRequests   supplier of the transfer request list; must not be null
+     * @param vaccineTypes       supplier of the vaccine type list; must not be null
+     * @param vaccinationRecords supplier of the vaccination record view list; must not be null
+     * @param auditLog           supplier of the audit entry list; must not be null
+     * @throws IllegalArgumentException if any argument is null
+     */
+    public SnapshotRenderer(Supplier<List<Shelter>> shelters,
+                            Supplier<List<AnimalView>> animalViews,
+                            Supplier<List<Adopter>> adopters,
+                            Supplier<List<AdoptionRequest>> adoptionRequests,
+                            Supplier<List<TransferRequest>> transferRequests,
+                            Supplier<List<VaccineType>> vaccineTypes,
+                            Supplier<List<VaccinationRecordView>> vaccinationRecords,
+                            Supplier<List<AuditEntry<?>>> auditLog) {
+        if (shelters == null || animalViews == null || adopters == null
+                || adoptionRequests == null || transferRequests == null
+                || vaccineTypes == null || vaccinationRecords == null
+                || auditLog == null) {
+            throw new IllegalArgumentException("All section suppliers must be non-null.");
+        }
+        this.shelters = shelters;
+        this.animalViews = animalViews;
+        this.adopters = adopters;
+        this.adoptionRequests = adoptionRequests;
+        this.transferRequests = transferRequests;
+        this.vaccineTypes = vaccineTypes;
+        this.vaccinationRecords = vaccinationRecords;
+        this.auditLog = auditLog;
+    }
+
+    /**
+     * Constructs a SnapshotRenderer backed by the CLI's live application context.
+     * Each section fetches fresh data every time {@link #render} is called.
+     *
+     * @param ctx the context used to obtain application services; must not be null
+     */
+    public SnapshotRenderer(AppContext ctx) {
+        this(
+                () -> ctx.shelterApp().listShelters(),
+                () -> ctx.animalApp().listAnimalsWithShelterName(null),
+                () -> ctx.adopterApp().listAdopters(),
+                () -> ctx.adoptionApp().listAllRequests(),
+                () -> ctx.transferApp().listAllTransfers(),
+                () -> ctx.vaccinationApp().listVaccineTypes(),
+                () -> ctx.vaccinationApp().listAllVaccinationRecords(),
+                () -> ctx.auditApp().getLog()
+        );
+        if (ctx == null) {
+            throw new IllegalArgumentException("AppContext must not be null.");
+        }
+    }
+
+    /**
+     * Writes the full snapshot to the given writer in a fixed 8-section order:
+     * Shelters, Animals, Adopters, Adoption Requests, Transfer Requests,
+     * Vaccine Types, Vaccinations, Audit Log. Each section is introduced by a
+     * {@code === TITLE ===} line and separated from the next by a blank line.
+     *
+     * @param out the writer to print to; must not be null
+     */
+    public void render(PrintWriter out) {
+        section(out, "SHELTERS",          w -> ShelterCmd.renderList(w, shelters.get()));
+        section(out, "ANIMALS",           w -> AnimalCmd.renderList(w, animalViews.get()));
+        section(out, "ADOPTERS",          w -> AdopterCmd.renderList(w, adopters.get()));
+        section(out, "ADOPTION REQUESTS", w -> AdoptCmd.renderList(w, adoptionRequests.get()));
+        section(out, "TRANSFER REQUESTS", w -> TransferCmd.renderList(w, transferRequests.get()));
+        section(out, "VACCINE TYPES",     w -> VaccineCmd.renderTypeList(w, vaccineTypes.get()));
+        section(out, "VACCINATIONS",      w -> VaccineCmd.renderRecordList(w, vaccinationRecords.get()));
+        section(out, "AUDIT LOG",         w -> AuditCmd.renderLog(w, auditLog.get(), AUDIT_LIMIT));
+        out.flush();
+    }
+
+    /**
+     * Writes one section header, the section body, and a trailing blank line.
+     *
+     * @param out   the writer to print to
+     * @param title the section title (uppercase, no delimiters)
+     * @param body  the consumer that writes the section body
+     */
+    private static void section(PrintWriter out, String title, Consumer<PrintWriter> body) {
+        out.println("=== " + title + " ===");
+        body.accept(out);
+        out.println();
+    }
+}

--- a/src/main/java/shelter/service/AdoptionService.java
+++ b/src/main/java/shelter/service/AdoptionService.java
@@ -91,4 +91,13 @@ public interface AdoptionService {
      * @return a list of approved adoption requests after the date
      */
     List<AdoptionRequest> getApprovedAfter(LocalDate date);
+
+    /**
+     * Returns every adoption request currently persisted in the system.
+     * Returns an empty list if no requests have been submitted.
+     * Used by the presentation layer to render a full snapshot of the adoption queue.
+     *
+     * @return a list of all adoption requests
+     */
+    List<AdoptionRequest> listAll();
 }

--- a/src/main/java/shelter/service/TransferService.java
+++ b/src/main/java/shelter/service/TransferService.java
@@ -55,4 +55,13 @@ public interface TransferService {
      * @return a list of pending transfer requests involving the shelter
      */
     List<TransferRequest> getPendingRequests(Shelter shelter);
+
+    /**
+     * Returns every transfer request currently persisted in the system.
+     * Returns an empty list if no transfers have been requested.
+     * Used by the presentation layer to render a full snapshot of the transfer queue.
+     *
+     * @return a list of all transfer requests
+     */
+    List<TransferRequest> listAll();
 }

--- a/src/main/java/shelter/service/VaccinationService.java
+++ b/src/main/java/shelter/service/VaccinationService.java
@@ -50,4 +50,13 @@ public interface VaccinationService {
      * @return the matching vaccination record
      */
     VaccinationRecord findById(String id);
+
+    /**
+     * Returns every vaccination record currently persisted in the system.
+     * Returns an empty list if no vaccinations have been recorded.
+     * Used by the presentation layer to render a full vaccination snapshot.
+     *
+     * @return a list of all vaccination records
+     */
+    List<VaccinationRecord> listAllRecords();
 }

--- a/src/main/java/shelter/service/impl/AdoptionServiceImpl.java
+++ b/src/main/java/shelter/service/impl/AdoptionServiceImpl.java
@@ -203,4 +203,13 @@ public class AdoptionServiceImpl implements AdoptionService {
                 .filter(r -> r.getSubmittedAt().toLocalDate().isAfter(date))
                 .collect(Collectors.toList());
     }
+
+    /**
+     * {@inheritDoc}
+     * Delegates directly to the underlying repository's {@code findAll} query.
+     */
+    @Override
+    public List<AdoptionRequest> listAll() {
+        return requestRepository.findAll();
+    }
 }

--- a/src/main/java/shelter/service/impl/TransferServiceImpl.java
+++ b/src/main/java/shelter/service/impl/TransferServiceImpl.java
@@ -166,4 +166,13 @@ public class TransferServiceImpl implements TransferService {
         // The repository query covers both from-shelter and to-shelter in one call
         return requestRepository.findByShelterIdAndStatus(shelter.getId(), RequestStatus.PENDING);
     }
+
+    /**
+     * {@inheritDoc}
+     * Delegates directly to the underlying repository's {@code findAll} query.
+     */
+    @Override
+    public List<TransferRequest> listAll() {
+        return requestRepository.findAll();
+    }
 }

--- a/src/main/java/shelter/service/impl/VaccinationServiceImpl.java
+++ b/src/main/java/shelter/service/impl/VaccinationServiceImpl.java
@@ -188,6 +188,15 @@ public class VaccinationServiceImpl implements VaccinationService, VaccinationIn
     }
 
     /**
+     * {@inheritDoc}
+     * Delegates directly to the underlying repository's {@code findAll} query.
+     */
+    @Override
+    public List<VaccinationRecord> listAllRecords() {
+        return recordRepository.findAll();
+    }
+
+    /**
      * Scans the given vaccination history and returns the most recent administration date
      * for the specified vaccine type ID. Returns null if no matching record is found.
      *

--- a/src/main/java/shelter/startup/WorkdirBootstrapper.java
+++ b/src/main/java/shelter/startup/WorkdirBootstrapper.java
@@ -90,12 +90,16 @@ public class WorkdirBootstrapper {
             - `shelter adopter remove --id <adopter-id>`
 
             Adopt:
+            - `shelter adopt list`
+              (columns: ID / Adopter / Animal / Status / Submitted At)
             - `shelter adopt submit --adopter <adopter-id> --animal <animal-id>`
             - `shelter adopt approve --request <request-id>`
             - `shelter adopt reject --request <request-id>`
             - `shelter adopt cancel --request <request-id>`
 
             Transfer:
+            - `shelter transfer list`
+              (columns: ID / Animal / From / To / Status / Requested At)
             - `shelter transfer request --animal <animal-id> --from <source-shelter-id> --to <destination-shelter-id>`
             - `shelter transfer approve --request <request-id>`
             - `shelter transfer reject --request <request-id>`
@@ -106,6 +110,8 @@ public class WorkdirBootstrapper {
             - `shelter match adopter --animal <animal-id>`
 
             Vaccine:
+            - `shelter vaccine list`
+              (columns: ID / Animal / Species / Vaccine / Date)
             - `shelter vaccine record --animal <animal-id> --type <vaccine-type-name> --date <yyyy-mm-dd>`
             - `shelter vaccine overdue --animal <animal-id>`
             - `shelter vaccine type list`
@@ -115,6 +121,18 @@ public class WorkdirBootstrapper {
 
             Audit:
             - `shelter audit log`
+
+            Print / Live Dashboard:
+            - `shelter print`
+              Prints the full 8-section system snapshot to stdout
+              (sections: Shelters, Animals, Adopters, Adoption Requests, Transfer Requests,
+              Vaccine Types, Vaccinations, Audit Log).
+            - `shelter print --watch [--out <path>]`
+              Keeps running and rewrites a markdown file whenever CSV contents change.
+              Default output path is `~/shelter/dashboard.md`. Ideal for a demo: open the
+              file with VS Code's markdown preview in a side pane, run this command in a
+              terminal, then run any `shelter` command in another terminal and watch the
+              preview update within a second.
 
             ## Natural Language To CLI Guidance
 

--- a/src/main/java/shelter/startup/WorkdirBootstrapper.java
+++ b/src/main/java/shelter/startup/WorkdirBootstrapper.java
@@ -22,6 +22,26 @@ public class WorkdirBootstrapper {
     private static final String CLAUDE_TEMPLATE = """
             # CLAUDE.md - Shelter CLI Demo Context
 
+            ## Identity
+
+            You are the assistant for a **Multi-Shelter Animal Adoption Management System**
+            operated through the `shelter` CLI. You help human staff run day-to-day operations
+            across one or more shelters: registering shelters, admitting animals, managing
+            adopters, matching animals to adopters, submitting and approving adoption and
+            transfer requests, maintaining a vaccine catalog and vaccination records, viewing
+            the audit log, and printing a live system snapshot.
+
+            When the user greets you or asks who you are (for example: "hi", "hello",
+            "how are you", "what can you do", "tell me about yourself", "introduce yourself"),
+            reply briefly in 2-4 sentences:
+
+            1. State your identity as the shelter management assistant.
+            2. Summarize what you can help with (shelters, animals, adopters, matching,
+               adoptions, transfers, vaccinations, audit log, live `shelter print` snapshots).
+            3. Invite the user to make a concrete request.
+
+            Do NOT execute any `shelter` command during a greeting — wait for an actual task.
+
             ## Agent Behavior Rules (enforced during demo)
 
             **Language: English only.** All responses must be in English regardless of the
@@ -44,6 +64,14 @@ public class WorkdirBootstrapper {
             display any data returned by a `shelter` command, format the output as a table
             (markdown table is fine) and include every field returned — do not omit, summarize,
             or hide any column, even if the value is `N/A`, `any`, or empty.
+
+            **End every response with a conclusion.** After executing any shelter commands,
+            finish your reply with a short bullet-point summary. Rules:
+            - Use bullet points, one fact per bullet.
+            - Keep each bullet to one short sentence.
+            - Do NOT include UUIDs or raw IDs — use names instead.
+            - Focus on what happened and the resulting state, not on which commands were typed.
+            - Label the section **What I did:**
 
             ## Project Context
 

--- a/src/test/java/shelter/application/AdopterApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AdopterApplicationServiceImplTest.java
@@ -188,6 +188,7 @@ class AdopterApplicationServiceImplTest {
         @Override public List<shelter.domain.AdoptionRequest> getRequestsByAnimal(Animal a) { return List.of(); }
         @Override public List<shelter.domain.AdoptionRequest> getRequestsAfter(java.time.LocalDate d) { return List.of(); }
         @Override public List<shelter.domain.AdoptionRequest> getApprovedAfter(java.time.LocalDate d) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> listAll() { return List.of(); }
     }
 
     /**

--- a/src/test/java/shelter/application/AdoptionApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AdoptionApplicationServiceImplTest.java
@@ -122,6 +122,17 @@ class AdoptionApplicationServiceImplTest {
         assertThrows(EntityNotFoundException.class, () -> service.approveRequest("missing"));
     }
 
+    @Test
+    void listAllRequests_returnsDataFromAdoptionService() {
+        AdoptionRequest request = new AdoptionRequest(adopter, dog);
+        adoptionService.store.put(request.getId(), request);
+
+        List<AdoptionRequest> all = service.listAllRequests();
+
+        assertEquals(1, all.size());
+        assertSame(request, all.get(0));
+    }
+
     // -------------------------------------------------------------------------
     // Stubs
     // -------------------------------------------------------------------------

--- a/src/test/java/shelter/application/AdoptionApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AdoptionApplicationServiceImplTest.java
@@ -190,6 +190,11 @@ class AdoptionApplicationServiceImplTest {
         public List<AdoptionRequest> getApprovedAfter(LocalDate d) {
             return List.of();
         }
+
+        @Override
+        public List<AdoptionRequest> listAll() {
+            return new ArrayList<>(store.values());
+        }
     }
 
     /**

--- a/src/test/java/shelter/application/AnimalApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/AnimalApplicationServiceImplTest.java
@@ -289,6 +289,7 @@ class AnimalApplicationServiceImplTest {
         @Override public List<shelter.domain.AdoptionRequest> getRequestsByAnimal(Animal a) { return List.of(); }
         @Override public List<shelter.domain.AdoptionRequest> getRequestsAfter(LocalDate d) { return List.of(); }
         @Override public List<shelter.domain.AdoptionRequest> getApprovedAfter(LocalDate d) { return List.of(); }
+        @Override public List<shelter.domain.AdoptionRequest> listAll() { return List.of(); }
     }
 
     /**

--- a/src/test/java/shelter/application/TransferApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/TransferApplicationServiceImplTest.java
@@ -173,6 +173,11 @@ class TransferApplicationServiceImplTest {
         public List<TransferRequest> getPendingRequests(Shelter s) {
             return new ArrayList<>(store.values());
         }
+
+        @Override
+        public List<TransferRequest> listAll() {
+            return new ArrayList<>(store.values());
+        }
     }
 
     /**

--- a/src/test/java/shelter/application/TransferApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/TransferApplicationServiceImplTest.java
@@ -127,6 +127,17 @@ class TransferApplicationServiceImplTest {
         assertThrows(EntityNotFoundException.class, () -> service.approveTransfer("missing"));
     }
 
+    @Test
+    void listAllTransfers_returnsDataFromTransferService() {
+        TransferRequest t = new TransferRequest(dog, from, to);
+        transferService.store.put(t.getId(), t);
+
+        List<TransferRequest> all = service.listAllTransfers();
+
+        assertEquals(1, all.size());
+        assertSame(t, all.get(0));
+    }
+
     // -------------------------------------------------------------------------
     // Stubs
     // -------------------------------------------------------------------------

--- a/src/test/java/shelter/application/VaccinationApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/VaccinationApplicationServiceImplTest.java
@@ -141,6 +141,11 @@ class VaccinationApplicationServiceImplTest {
         public VaccinationRecord findById(String id) {
             return null;
         }
+
+        @Override
+        public List<VaccinationRecord> listAllRecords() {
+            return List.of();
+        }
     }
 
     /**

--- a/src/test/java/shelter/application/VaccinationApplicationServiceImplTest.java
+++ b/src/test/java/shelter/application/VaccinationApplicationServiceImplTest.java
@@ -109,6 +109,35 @@ class VaccinationApplicationServiceImplTest {
         assertEquals(1, service.listVaccineTypes().size());
     }
 
+    @Test
+    void listAllVaccinationRecords_bundlesAnimalAndVaccineTypeNames() {
+        VaccinationRecord record = new VaccinationRecord(
+                dog.getId(), rabies.getId(), LocalDate.of(2026, 1, 1));
+        vaccinationService.allRecords.add(record);
+
+        List<shelter.application.model.VaccinationRecordView> views =
+                service.listAllVaccinationRecords();
+
+        assertEquals(1, views.size());
+        shelter.application.model.VaccinationRecordView v = views.get(0);
+        assertSame(record, v.getRecord());
+        assertEquals("Rex", v.getAnimalName());
+        assertEquals("Rabies", v.getVaccineTypeName());
+        assertEquals(Species.DOG, v.getSpecies());
+    }
+
+    @Test
+    void listAllVaccinationRecords_skipsOrphanedRecords() {
+        VaccinationRecord orphan = new VaccinationRecord(
+                "nonexistent-animal", rabies.getId(), LocalDate.of(2026, 1, 1));
+        vaccinationService.allRecords.add(orphan);
+
+        List<shelter.application.model.VaccinationRecordView> views =
+                service.listAllVaccinationRecords();
+
+        assertTrue(views.isEmpty());
+    }
+
     // -------------------------------------------------------------------------
     // Stubs
     // -------------------------------------------------------------------------
@@ -120,6 +149,7 @@ class VaccinationApplicationServiceImplTest {
     private static class StubVaccinationService implements VaccinationService {
 
         int recordCount;
+        final List<VaccinationRecord> allRecords = new ArrayList<>();
 
         @Override
         public void recordVaccination(Animal a, VaccineType v, LocalDate d) {
@@ -144,7 +174,7 @@ class VaccinationApplicationServiceImplTest {
 
         @Override
         public List<VaccinationRecord> listAllRecords() {
-            return List.of();
+            return new ArrayList<>(allRecords);
         }
     }
 

--- a/src/test/java/shelter/cli/AdopterCmdRenderListTest.java
+++ b/src/test/java/shelter/cli/AdopterCmdRenderListTest.java
@@ -1,0 +1,43 @@
+package shelter.cli;
+
+import org.junit.jupiter.api.Test;
+import shelter.domain.Adopter;
+import shelter.domain.AdopterPreferences;
+import shelter.domain.DailySchedule;
+import shelter.domain.LivingSpace;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AdopterCmd#renderList(PrintWriter, List)}.
+ * Verifies comma-headed, space-padded table output and the empty {@code (none)} marker.
+ */
+class AdopterCmdRenderListTest {
+
+    @Test
+    void renderList_withAdopter_hasCommaHeaderAndRow() {
+        Adopter a = new Adopter("Alice", LivingSpace.APARTMENT, DailySchedule.HOME_MOST_OF_DAY,
+                null, new AdopterPreferences(null, null, null, null, 0, 20));
+
+        StringWriter sw = new StringWriter();
+        AdopterCmd.renderList(new PrintWriter(sw), List.of(a));
+
+        String out = sw.toString();
+        assertTrue(out.contains("NAME,"));
+        assertTrue(out.contains("Alice"));
+        assertFalse(out.contains("---"));
+    }
+
+    @Test
+    void renderList_empty_printsNoneMarker() {
+        StringWriter sw = new StringWriter();
+        AdopterCmd.renderList(new PrintWriter(sw), List.of());
+
+        assertTrue(sw.toString().contains("(none)"));
+    }
+}

--- a/src/test/java/shelter/cli/AnimalCmdRenderListTest.java
+++ b/src/test/java/shelter/cli/AnimalCmdRenderListTest.java
@@ -1,0 +1,45 @@
+package shelter.cli;
+
+import org.junit.jupiter.api.Test;
+import shelter.application.model.AnimalView;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Dog;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AnimalCmd#renderList(PrintWriter, List)}.
+ * Verifies comma-headed, space-padded table output and the empty {@code (none)} marker.
+ */
+class AnimalCmdRenderListTest {
+
+    @Test
+    void renderList_withAnimal_hasCommaHeaderAndRow() {
+        Dog dog = new Dog("Rex", "Lab", LocalDate.now().minusYears(2), ActivityLevel.LOW,
+                false, Dog.Size.MEDIUM, false);
+        AnimalView view = new AnimalView(dog, "Happy Tails");
+
+        StringWriter sw = new StringWriter();
+        AnimalCmd.renderList(new PrintWriter(sw), List.of(view));
+
+        String out = sw.toString();
+        assertTrue(out.contains("NAME,"));
+        assertTrue(out.contains("Rex"));
+        assertTrue(out.contains("Happy Tails"));
+        assertFalse(out.contains("---"));
+    }
+
+    @Test
+    void renderList_empty_printsNoneMarker() {
+        StringWriter sw = new StringWriter();
+        AnimalCmd.renderList(new PrintWriter(sw), List.of());
+
+        assertTrue(sw.toString().contains("(none)"));
+    }
+}

--- a/src/test/java/shelter/cli/AuditCmdRenderLogTest.java
+++ b/src/test/java/shelter/cli/AuditCmdRenderLogTest.java
@@ -1,0 +1,73 @@
+package shelter.cli;
+
+import org.junit.jupiter.api.Test;
+import shelter.domain.Staff;
+import shelter.service.model.AuditEntry;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AuditCmd#renderLog(PrintWriter, List, int)}.
+ * Verifies comma-headed output, the {@code (none)} empty marker, and the truncation footer.
+ */
+class AuditCmdRenderLogTest {
+
+    /**
+     * Builds a minimal audit entry for testing.
+     */
+    private static AuditEntry<Object> entry(String action, int i) {
+        Staff staff = new Staff("admin");
+        return new AuditEntry<>(staff, action + i, "target" + i,
+                LocalDateTime.of(2026, 1, 1, 0, 0, i));
+    }
+
+    @Test
+    void renderLog_withEntries_hasCommaHeader() {
+        List<AuditEntry<?>> entries = new ArrayList<>();
+        entries.add(entry("submitted ", 1));
+        entries.add(entry("approved ", 2));
+
+        StringWriter sw = new StringWriter();
+        AuditCmd.renderLog(new PrintWriter(sw), entries, Integer.MAX_VALUE);
+
+        String out = sw.toString();
+        assertTrue(out.contains("TIMESTAMP,"));
+        assertTrue(out.contains("ACTION,"));
+        assertTrue(out.contains("approved "));
+        assertFalse(out.contains("---"));
+        assertFalse(out.contains("(showing last"),
+                "no footer when all entries fit under the limit");
+    }
+
+    @Test
+    void renderLog_empty_printsNoneMarker() {
+        StringWriter sw = new StringWriter();
+        AuditCmd.renderLog(new PrintWriter(sw), List.of(), Integer.MAX_VALUE);
+
+        assertTrue(sw.toString().contains("(none)"));
+    }
+
+    @Test
+    void renderLog_withLimit_truncatesAndPrintsFooter() {
+        List<AuditEntry<?>> entries = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            entries.add(entry("action ", i));
+        }
+
+        StringWriter sw = new StringWriter();
+        AuditCmd.renderLog(new PrintWriter(sw), entries, 20);
+
+        String out = sw.toString();
+        assertTrue(out.contains("(showing last 20 of 25 entries)"),
+                "footer should report truncation counts");
+        // The 20 most recent entries are indices 5..24; index 0 must NOT appear
+        assertFalse(out.contains("action 0\n") || out.contains("action 0,"));
+    }
+}

--- a/src/test/java/shelter/cli/ShelterCmdRenderListTest.java
+++ b/src/test/java/shelter/cli/ShelterCmdRenderListTest.java
@@ -1,0 +1,42 @@
+package shelter.cli;
+
+import org.junit.jupiter.api.Test;
+import shelter.domain.Shelter;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ShelterCmd#renderList(PrintWriter, List)}.
+ * Verifies comma-headed, space-padded table output and the empty {@code (none)} marker.
+ */
+class ShelterCmdRenderListTest {
+
+    @Test
+    void renderList_withShelters_hasCommaHeaderAndPaddedRows() {
+        Shelter a = new Shelter("Alpha", "Boston", 10);
+
+        StringWriter sw = new StringWriter();
+        ShelterCmd.renderList(new PrintWriter(sw), List.of(a));
+
+        String out = sw.toString();
+        assertTrue(out.contains("NAME,"), "header has comma after NAME");
+        assertTrue(out.contains("LOCATION,"), "header has comma after LOCATION");
+        assertTrue(out.contains("Alpha"), "row has data");
+        assertTrue(out.contains("Boston"));
+        assertFalse(out.contains("---"), "no dashes in output");
+        assertFalse(out.contains("|"), "no pipes in output");
+    }
+
+    @Test
+    void renderList_empty_printsNoneMarker() {
+        StringWriter sw = new StringWriter();
+        ShelterCmd.renderList(new PrintWriter(sw), List.of());
+
+        assertTrue(sw.toString().contains("(none)"));
+    }
+}

--- a/src/test/java/shelter/cli/VaccineCmdRenderTypeListTest.java
+++ b/src/test/java/shelter/cli/VaccineCmdRenderTypeListTest.java
@@ -1,0 +1,40 @@
+package shelter.cli;
+
+import org.junit.jupiter.api.Test;
+import shelter.domain.Species;
+import shelter.domain.VaccineType;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link VaccineCmd#renderTypeList(PrintWriter, List)}.
+ * Verifies comma-headed output and the {@code (none)} empty marker.
+ */
+class VaccineCmdRenderTypeListTest {
+
+    @Test
+    void renderTypeList_withTypes_hasCommaHeaderAndRow() {
+        VaccineType rabies = new VaccineType("Rabies", Species.DOG, 365);
+
+        StringWriter sw = new StringWriter();
+        VaccineCmd.renderTypeList(new PrintWriter(sw), List.of(rabies));
+
+        String out = sw.toString();
+        assertTrue(out.contains("NAME,"));
+        assertTrue(out.contains("Rabies"));
+        assertFalse(out.contains("---"));
+    }
+
+    @Test
+    void renderTypeList_empty_printsNoneMarker() {
+        StringWriter sw = new StringWriter();
+        VaccineCmd.renderTypeList(new PrintWriter(sw), List.of());
+
+        assertTrue(sw.toString().contains("(none)"));
+    }
+}

--- a/src/test/java/shelter/cli/print/DataDirHashTest.java
+++ b/src/test/java/shelter/cli/print/DataDirHashTest.java
@@ -1,0 +1,55 @@
+package shelter.cli.print;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link DataDirHash#compute(Path)}. Verifies deterministic hashing of
+ * {@code *.csv} contents, insensitivity to file mtimes, and a clear error on a missing directory.
+ */
+class DataDirHashTest {
+
+    @Test
+    void sameContents_produceSameHash(@TempDir Path dir) throws Exception {
+        Files.writeString(dir.resolve("a.csv"), "row1\nrow2\n");
+        Files.writeString(dir.resolve("b.csv"), "rowX\n");
+        String h1 = DataDirHash.compute(dir);
+        String h2 = DataDirHash.compute(dir);
+        assertEquals(h1, h2);
+    }
+
+    @Test
+    void changedContents_produceDifferentHash(@TempDir Path dir) throws Exception {
+        Files.writeString(dir.resolve("a.csv"), "row1\n");
+        String h1 = DataDirHash.compute(dir);
+        Files.writeString(dir.resolve("a.csv"), "row1\nrow2\n");
+        String h2 = DataDirHash.compute(dir);
+        assertNotEquals(h1, h2);
+    }
+
+    @Test
+    void orderIndependent_mtimeDoesNotAffectHash(@TempDir Path dir) throws Exception {
+        Files.writeString(dir.resolve("a.csv"), "x\n");
+        Files.writeString(dir.resolve("b.csv"), "y\n");
+        String h1 = DataDirHash.compute(dir);
+        // Recompute after touching mtimes in reverse order
+        Files.setLastModifiedTime(dir.resolve("b.csv"), FileTime.fromMillis(1));
+        Files.setLastModifiedTime(dir.resolve("a.csv"), FileTime.fromMillis(2));
+        String h2 = DataDirHash.compute(dir);
+        assertEquals(h1, h2);
+    }
+
+    @Test
+    void missingDirectory_throws() {
+        assertThrows(IOException.class, () -> DataDirHash.compute(Path.of("/does/not/exist-xyz")));
+    }
+}

--- a/src/test/java/shelter/cli/print/MarkdownRendererTest.java
+++ b/src/test/java/shelter/cli/print/MarkdownRendererTest.java
@@ -1,0 +1,44 @@
+package shelter.cli.print;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link MarkdownRenderer}. Verifies the top-level heading, timestamp,
+ * all eight section subheadings, and that each section is wrapped in a fenced code block.
+ */
+class MarkdownRendererTest {
+
+    private MarkdownRenderer newEmptyRenderer() {
+        SnapshotRenderer snap = new SnapshotRenderer(
+                List::of, List::of, List::of, List::of,
+                List::of, List::of, List::of, List::of);
+        return new MarkdownRenderer(snap);
+    }
+
+    @Test
+    void render_hasTopLevelHeadingAndUpdatedTimestamp() {
+        String md = newEmptyRenderer().render();
+        assertTrue(md.startsWith("# Shelter System State"));
+        assertTrue(md.contains("*Updated:"));
+    }
+
+    @Test
+    void render_wrapsEachSectionInFencedCodeBlock() {
+        String md = newEmptyRenderer().render();
+        assertTrue(md.contains("## Shelters"));
+        assertTrue(md.contains("## Animals"));
+        assertTrue(md.contains("## Adopters"));
+        assertTrue(md.contains("## Adoption Requests"));
+        assertTrue(md.contains("## Transfer Requests"));
+        assertTrue(md.contains("## Vaccine Types"));
+        assertTrue(md.contains("## Vaccinations"));
+        assertTrue(md.contains("## Audit Log"));
+        // Each section emits one opening and one closing fence => at least 16 fence lines
+        long fences = md.lines().filter(line -> line.equals("```")).count();
+        assertTrue(fences >= 16, "Expected at least 16 fence lines, got " + fences);
+    }
+}

--- a/src/test/java/shelter/cli/print/SnapshotRendererTest.java
+++ b/src/test/java/shelter/cli/print/SnapshotRendererTest.java
@@ -1,0 +1,61 @@
+package shelter.cli.print;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link SnapshotRenderer}. Verifies that all eight section titles appear
+ * in the documented order regardless of underlying data contents, and that the
+ * supplier-based constructor allows data to be injected without touching the CLI singleton.
+ */
+class SnapshotRendererTest {
+
+    @Test
+    void render_emitsAllEightSectionTitlesInOrder() {
+        StringWriter sw = new StringWriter();
+        SnapshotRenderer renderer = new SnapshotRenderer(
+                List::of, List::of, List::of, List::of,
+                List::of, List::of, List::of, List::of);
+        renderer.render(new PrintWriter(sw));
+        String out = sw.toString();
+
+        int iShelters  = out.indexOf("=== SHELTERS ===");
+        int iAnimals   = out.indexOf("=== ANIMALS ===");
+        int iAdopters  = out.indexOf("=== ADOPTERS ===");
+        int iAdoptReq  = out.indexOf("=== ADOPTION REQUESTS ===");
+        int iXferReq   = out.indexOf("=== TRANSFER REQUESTS ===");
+        int iVacTypes  = out.indexOf("=== VACCINE TYPES ===");
+        int iVacs      = out.indexOf("=== VACCINATIONS ===");
+        int iAudit     = out.indexOf("=== AUDIT LOG ===");
+
+        for (int idx : new int[]{iShelters, iAnimals, iAdopters, iAdoptReq,
+                iXferReq, iVacTypes, iVacs, iAudit}) {
+            assertTrue(idx >= 0, "Missing section in output: " + out);
+        }
+        assertTrue(iShelters < iAnimals);
+        assertTrue(iAnimals < iAdopters);
+        assertTrue(iAdopters < iAdoptReq);
+        assertTrue(iAdoptReq < iXferReq);
+        assertTrue(iXferReq < iVacTypes);
+        assertTrue(iVacTypes < iVacs);
+        assertTrue(iVacs < iAudit);
+    }
+
+    @Test
+    void render_emptyDataSources_eachSectionPrintsNoneMarker() {
+        StringWriter sw = new StringWriter();
+        SnapshotRenderer renderer = new SnapshotRenderer(
+                List::of, List::of, List::of, List::of,
+                List::of, List::of, List::of, List::of);
+        renderer.render(new PrintWriter(sw));
+
+        // Every section reports (none) when its data source is empty
+        long noneCount = sw.toString().lines().filter(l -> l.equals("(none)")).count();
+        assertTrue(noneCount >= 8, "Expected (none) in every section, got " + noneCount);
+    }
+}

--- a/src/test/java/shelter/integration/AdopterIntegrationTest.java
+++ b/src/test/java/shelter/integration/AdopterIntegrationTest.java
@@ -76,7 +76,7 @@ class AdopterIntegrationTest extends CliIntegrationTest {
     void list_noAdopters_printsEmptyMessage() throws Exception {
         RunResult r = run("adopter", "list");
         assertSuccess(r);
-        assertOutputContains(r, "No adopters registered.");
+        assertOutputContains(r, "(none)");
     }
 
     /**

--- a/src/test/java/shelter/integration/AdoptionIntegrationTest.java
+++ b/src/test/java/shelter/integration/AdoptionIntegrationTest.java
@@ -215,4 +215,38 @@ class AdoptionIntegrationTest extends CliIntegrationTest {
         RunResult r = run("adopt", "cancel", "--request", requestId);
         assertOutputContains(r, "Error");
     }
+
+    // -------------------------------------------------------------------------
+    // adopt list
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that {@code shelter adopt list} on a fresh system exits successfully
+     * and prints the comma header plus the empty {@code (none)} marker.
+     */
+    @Test
+    void adoptList_emptyByDefault() throws Exception {
+        RunResult r = run("adopt", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "ID,");
+        assertOutputContains(r, "(none)");
+    }
+
+    /**
+     * Verifies that {@code shelter adopt list} shows a submitted request's adopter, animal,
+     * and PENDING status after the full submit flow has been exercised.
+     */
+    @Test
+    void adoptList_showsSubmittedRequest() throws Exception {
+        String shelterId = registerShelter();
+        String adopterId = registerAdopter("Alice");
+        String animalId = admitDog(shelterId, "Rex");
+        assertSuccess(run("adopt", "submit", "--adopter", adopterId, "--animal", animalId));
+
+        RunResult list = run("adopt", "list");
+        assertSuccess(list);
+        assertOutputContains(list, "Rex");
+        assertOutputContains(list, "Alice");
+        assertOutputContains(list, "PENDING");
+    }
 }

--- a/src/test/java/shelter/integration/AnimalIntegrationTest.java
+++ b/src/test/java/shelter/integration/AnimalIntegrationTest.java
@@ -182,7 +182,7 @@ class AnimalIntegrationTest extends CliIntegrationTest {
         String shelterId = registerShelter("Empty", 10);
         RunResult r = run("animal", "list", "--shelter", shelterId);
         assertSuccess(r);
-        assertOutputContains(r, "No animals found.");
+        assertOutputContains(r, "(none)");
     }
 
     // -------------------------------------------------------------------------
@@ -324,7 +324,7 @@ class AnimalIntegrationTest extends CliIntegrationTest {
 
         RunResult r = run("animal", "list");
         assertSuccess(r);
-        assertOutputContains(r, "Shelter");
+        assertOutputContains(r, "SHELTER,");
         assertOutputContains(r, "Happy Paws");
         assertOutputContains(r, "Green Field");
     }

--- a/src/test/java/shelter/integration/AuditIntegrationTest.java
+++ b/src/test/java/shelter/integration/AuditIntegrationTest.java
@@ -20,7 +20,7 @@ class AuditIntegrationTest extends CliIntegrationTest {
     void log_noActions_printsEmptyMessage() throws Exception {
         RunResult r = run("audit", "log");
         assertSuccess(r);
-        assertOutputContains(r, "Audit log is empty.");
+        assertOutputContains(r, "(none)");
     }
 
     /**
@@ -39,7 +39,7 @@ class AuditIntegrationTest extends CliIntegrationTest {
                 "--age", "3", "--activity", "HIGH", "--shelter", shelterId);
         RunResult r = run("audit", "log");
         assertSuccess(r);
-        assertOutputDoesNotContain(r, "Audit log is empty.");
+        assertOutputDoesNotContain(r, "(none)");
     }
 
     /**
@@ -64,6 +64,6 @@ class AuditIntegrationTest extends CliIntegrationTest {
         run("adopt", "submit", "--adopter", adopterId, "--animal", animalId);
         RunResult r = run("audit", "log");
         assertSuccess(r);
-        assertOutputDoesNotContain(r, "Audit log is empty.");
+        assertOutputDoesNotContain(r, "(none)");
     }
 }

--- a/src/test/java/shelter/integration/PrintIntegrationTest.java
+++ b/src/test/java/shelter/integration/PrintIntegrationTest.java
@@ -1,0 +1,86 @@
+package shelter.integration;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the {@code shelter print} command, covering the one-shot snapshot,
+ * populated-data rendering, and the {@code --watch} markdown dashboard file write.
+ * All three scenarios spawn real {@code shelter} subprocesses against an isolated
+ * {@code SHELTER_HOME} to exercise the full CLI stack.
+ */
+class PrintIntegrationTest extends CliIntegrationTest {
+
+    /**
+     * Verifies that {@code shelter print} against an empty system emits all eight
+     * section titles in the documented order and that each empty section displays
+     * the {@code (none)} marker.
+     */
+    @Test
+    void print_onEmptySystem_rendersAllEightSectionsWithNone() throws Exception {
+        RunResult r = run("print");
+        assertSuccess(r);
+        for (String title : new String[]{
+                "=== SHELTERS ===", "=== ANIMALS ===", "=== ADOPTERS ===",
+                "=== ADOPTION REQUESTS ===", "=== TRANSFER REQUESTS ===",
+                "=== VACCINE TYPES ===", "=== VACCINATIONS ===", "=== AUDIT LOG ==="}) {
+            assertOutputContains(r, title);
+        }
+        assertOutputContains(r, "(none)");
+    }
+
+    /**
+     * Verifies that after seeding a shelter and admitting an animal, {@code shelter print}
+     * includes both the shelter name and the animal name in the rendered snapshot.
+     */
+    @Test
+    void print_afterSeedingData_showsShelterAndAnimalRows() throws Exception {
+        String sId = extractId(run("shelter", "register",
+                "--name", "Happy Tails", "--location", "Boston", "--capacity", "10").stdout());
+        assertSuccess(run("animal", "admit", "--species", "dog", "--name", "Rex",
+                "--breed", "Lab", "--age", "3", "--activity", "LOW", "--shelter", sId));
+
+        RunResult r = run("print");
+        assertSuccess(r);
+        assertOutputContains(r, "Happy Tails");
+        assertOutputContains(r, "Rex");
+    }
+
+    /**
+     * Verifies that {@code shelter print --watch --out <path>} writes the dashboard file
+     * on first tick and that the output contains the markdown structure the renderer produces.
+     * The process is killed after the file appears so the test does not hang.
+     */
+    @Test
+    void printWatch_writesDashboardFileAndExitsOnTimeout() throws Exception {
+        Path out = shelterHome.resolve("dashboard.md");
+        Path binary = Path.of(System.getProperty("user.dir"),
+                "build/install/shelter/bin/shelter");
+        String[] command = {
+                binary.toString(),
+                "print", "--watch", "--out", out.toString()
+        };
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.environment().put("SHELTER_HOME", shelterHome.toString());
+        Process p = pb.start();
+        try {
+            // Poll up to 5 s for the file to appear
+            long deadline = System.currentTimeMillis() + 5000;
+            while (!Files.exists(out) && System.currentTimeMillis() < deadline) {
+                Thread.sleep(200);
+            }
+            assertTrue(Files.exists(out), "Dashboard file never written");
+            String md = Files.readString(out);
+            assertTrue(md.contains("# Shelter System State"));
+            assertTrue(md.contains("## Shelters"));
+        } finally {
+            p.destroy();
+            p.waitFor(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/src/test/java/shelter/integration/ShelterIntegrationTest.java
+++ b/src/test/java/shelter/integration/ShelterIntegrationTest.java
@@ -71,7 +71,7 @@ class ShelterIntegrationTest extends CliIntegrationTest {
     void list_noShelters_printsEmptyMessage() throws Exception {
         RunResult r = run("shelter", "list");
         assertSuccess(r);
-        assertOutputContains(r, "No shelters registered.");
+        assertOutputContains(r, "(none)");
     }
 
     /**

--- a/src/test/java/shelter/integration/TransferIntegrationTest.java
+++ b/src/test/java/shelter/integration/TransferIntegrationTest.java
@@ -179,4 +179,39 @@ class TransferIntegrationTest extends CliIntegrationTest {
         RunResult r = run("transfer", "cancel", "--request", requestId);
         assertOutputContains(r, "Error");
     }
+
+    // -------------------------------------------------------------------------
+    // transfer list
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that {@code shelter transfer list} on a fresh system exits successfully
+     * and prints the comma header plus the empty {@code (none)} marker.
+     */
+    @Test
+    void transferList_emptyByDefault() throws Exception {
+        RunResult r = run("transfer", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "ID,");
+        assertOutputContains(r, "(none)");
+    }
+
+    /**
+     * Verifies that {@code shelter transfer list} shows a requested transfer's animal,
+     * source and destination shelter names, and the PENDING status after a request has been made.
+     */
+    @Test
+    void transferList_showsRequestedTransfer() throws Exception {
+        String s1 = registerShelter("S1", 5);
+        String s2 = registerShelter("S2", 5);
+        String animalId = admitDog("Rex", s1);
+        assertSuccess(run("transfer", "request", "--animal", animalId, "--from", s1, "--to", s2));
+
+        RunResult list = run("transfer", "list");
+        assertSuccess(list);
+        assertOutputContains(list, "Rex");
+        assertOutputContains(list, "S1");
+        assertOutputContains(list, "S2");
+        assertOutputContains(list, "PENDING");
+    }
 }

--- a/src/test/java/shelter/integration/VaccineIntegrationTest.java
+++ b/src/test/java/shelter/integration/VaccineIntegrationTest.java
@@ -269,4 +269,39 @@ class VaccineIntegrationTest extends CliIntegrationTest {
                 "--id", "00000000-0000-0000-0000-000000000000");
         assertOutputContains(r, "Error");
     }
+
+    // -------------------------------------------------------------------------
+    // vaccine list (records)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that {@code shelter vaccine list} on a fresh system exits successfully
+     * and prints the {@code (none)} empty marker.
+     */
+    @Test
+    void vaccineList_emptyByDefault() throws Exception {
+        RunResult r = run("vaccine", "list");
+        assertSuccess(r);
+        assertOutputContains(r, "(none)");
+    }
+
+    /**
+     * Verifies that {@code shelter vaccine list} shows a recorded vaccination's animal name,
+     * vaccine type, and administration date after the full record flow has been exercised.
+     */
+    @Test
+    void vaccineList_showsRecordedVaccinations() throws Exception {
+        String sId = registerShelter();
+        String aId = admitDog("Rex", sId);
+        assertSuccess(run("vaccine", "type", "add",
+                "--name", "Rabies", "--species", "DOG", "--days", "365"));
+        assertSuccess(run("vaccine", "record",
+                "--animal", aId, "--type", "Rabies", "--date", "2026-04-01"));
+
+        RunResult list = run("vaccine", "list");
+        assertSuccess(list);
+        assertOutputContains(list, "Rex");
+        assertOutputContains(list, "Rabies");
+        assertOutputContains(list, "2026-04-01");
+    }
 }

--- a/src/test/java/shelter/service/impl/AdoptionServiceImplListAllTest.java
+++ b/src/test/java/shelter/service/impl/AdoptionServiceImplListAllTest.java
@@ -1,0 +1,213 @@
+package shelter.service.impl;
+
+import org.junit.jupiter.api.Test;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Adopter;
+import shelter.domain.AdopterPreferences;
+import shelter.domain.AdoptionRequest;
+import shelter.domain.Animal;
+import shelter.domain.DailySchedule;
+import shelter.domain.Dog;
+import shelter.domain.LivingSpace;
+import shelter.domain.RequestStatus;
+import shelter.repository.AdopterRepository;
+import shelter.repository.AdoptionRequestRepository;
+import shelter.repository.AnimalRepository;
+import shelter.service.AuditService;
+import shelter.service.model.AuditEntry;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AdoptionServiceImpl#listAll()}.
+ * Verifies that the method delegates to the underlying {@link AdoptionRequestRepository#findAll()}
+ * and returns every persisted request (or an empty list when none are stored).
+ */
+class AdoptionServiceImplListAllTest {
+
+    /**
+     * Builds a minimal valid {@link Adopter} for use in the stub repository.
+     */
+    private static Adopter newAdopter() {
+        return new Adopter("Alice", LivingSpace.APARTMENT, DailySchedule.HOME_MOST_OF_DAY,
+                null, new AdopterPreferences(null, null, null, null, 0, 20));
+    }
+
+    /**
+     * Builds a minimal valid {@link Dog} for use in the stub repository.
+     */
+    private static Dog newDog() {
+        return new Dog("Rex", "Lab", LocalDate.now().minusYears(2), ActivityLevel.LOW,
+                false, Dog.Size.MEDIUM, false);
+    }
+
+    @Test
+    void listAll_returnsEveryRequestFromRepository() {
+        StubAdoptionRequestRepo repo = new StubAdoptionRequestRepo();
+        Adopter a = newAdopter();
+        Dog d = newDog();
+        AdoptionRequest r1 = new AdoptionRequest(a, d);
+        AdoptionRequest r2 = new AdoptionRequest(a, d);
+        repo.records.add(r1);
+        repo.records.add(r2);
+
+        AdoptionServiceImpl service = new AdoptionServiceImpl(
+                repo, new StubAnimalRepo(), new StubAdopterRepo(), new NoopAudit<>());
+
+        List<AdoptionRequest> all = service.listAll();
+
+        assertEquals(2, all.size());
+        assertTrue(all.contains(r1));
+        assertTrue(all.contains(r2));
+    }
+
+    @Test
+    void listAll_emptyRepository_returnsEmptyList() {
+        AdoptionServiceImpl service = new AdoptionServiceImpl(
+                new StubAdoptionRequestRepo(), new StubAnimalRepo(), new StubAdopterRepo(), new NoopAudit<>());
+
+        assertTrue(service.listAll().isEmpty());
+    }
+
+    /**
+     * Minimal in-memory stub for {@link AdoptionRequestRepository}.
+     * Only {@link #findAll()} is exercised by these tests; other methods return empty results.
+     */
+    private static class StubAdoptionRequestRepo implements AdoptionRequestRepository {
+        private final List<AdoptionRequest> records = new ArrayList<>();
+
+        @Override
+        public void save(AdoptionRequest request) {
+            records.add(request);
+        }
+
+        @Override
+        public Optional<AdoptionRequest> findById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<AdoptionRequest> findAll() {
+            return new ArrayList<>(records);
+        }
+
+        @Override
+        public List<AdoptionRequest> findByAdopterId(String adopterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<AdoptionRequest> findByAnimalId(String animalId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<AdoptionRequest> findByShelterId(String shelterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<AdoptionRequest> findByStatus(RequestStatus status) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<AdoptionRequest> findByAdopterIdAndStatus(String adopterId, RequestStatus status) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<AdoptionRequest> findByShelterIdAndStatus(String shelterId, RequestStatus status) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void delete(String id) {
+            // no-op
+        }
+    }
+
+    /**
+     * Minimal in-memory stub for {@link AnimalRepository}; all methods are no-ops.
+     */
+    private static class StubAnimalRepo implements AnimalRepository {
+        @Override
+        public void save(Animal animal) {
+            // no-op
+        }
+
+        @Override
+        public Optional<Animal> findById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Animal> findAll() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Animal> findByShelterId(String shelterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Animal> findByAdopterId(String adopterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void delete(String id) {
+            // no-op
+        }
+    }
+
+    /**
+     * Minimal in-memory stub for {@link AdopterRepository}; all methods are no-ops.
+     */
+    private static class StubAdopterRepo implements AdopterRepository {
+        @Override
+        public void save(Adopter adopter) {
+            // no-op
+        }
+
+        @Override
+        public Optional<Adopter> findById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Adopter> findAll() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void delete(String id) {
+            // no-op
+        }
+    }
+
+    /**
+     * Minimal no-op audit service for tests that do not care about audit side effects.
+     *
+     * @param <T> the audit target type
+     */
+    private static class NoopAudit<T> implements AuditService<T> {
+        @Override
+        public void log(String action, T target) {
+            // no-op
+        }
+
+        @Override
+        public List<AuditEntry<T>> getLog() {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/test/java/shelter/service/impl/TransferServiceImplListAllTest.java
+++ b/src/test/java/shelter/service/impl/TransferServiceImplListAllTest.java
@@ -1,0 +1,205 @@
+package shelter.service.impl;
+
+import org.junit.jupiter.api.Test;
+import shelter.domain.ActivityLevel;
+import shelter.domain.Animal;
+import shelter.domain.Dog;
+import shelter.domain.RequestStatus;
+import shelter.domain.Shelter;
+import shelter.domain.TransferRequest;
+import shelter.repository.AnimalRepository;
+import shelter.repository.ShelterRepository;
+import shelter.repository.TransferRequestRepository;
+import shelter.service.AuditService;
+import shelter.service.model.AuditEntry;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link TransferServiceImpl#listAll()}.
+ * Verifies that the method delegates to {@link TransferRequestRepository#findAll()} and
+ * returns every persisted transfer request (or an empty list when none are stored).
+ */
+class TransferServiceImplListAllTest {
+
+    /**
+     * Builds a minimal valid {@link Dog} for use in tests.
+     */
+    private static Dog newDog() {
+        return new Dog("Rex", "Lab", LocalDate.now().minusYears(2),
+                ActivityLevel.LOW, false, Dog.Size.MEDIUM, false);
+    }
+
+    @Test
+    void listAll_returnsEveryRequestFromRepository() {
+        Dog dog = newDog();
+        Shelter a = new Shelter("Alpha", "Boston", 10);
+        Shelter b = new Shelter("Bravo", "Cambridge", 10);
+        a.addAnimal(dog);
+        TransferRequest t1 = new TransferRequest(dog, a, b);
+        TransferRequest t2 = new TransferRequest(dog, a, b);
+
+        StubTransferRepo repo = new StubTransferRepo();
+        repo.records.add(t1);
+        repo.records.add(t2);
+
+        TransferServiceImpl svc = new TransferServiceImpl(
+                repo, new StubAnimalRepo(), new StubShelterRepo(), new NoopAudit<>());
+
+        List<TransferRequest> all = svc.listAll();
+
+        assertEquals(2, all.size());
+        assertTrue(all.contains(t1));
+        assertTrue(all.contains(t2));
+    }
+
+    @Test
+    void listAll_emptyRepository_returnsEmptyList() {
+        TransferServiceImpl svc = new TransferServiceImpl(
+                new StubTransferRepo(), new StubAnimalRepo(), new StubShelterRepo(), new NoopAudit<>());
+
+        assertTrue(svc.listAll().isEmpty());
+    }
+
+    /**
+     * Minimal in-memory stub for {@link TransferRequestRepository}.
+     * Only {@link #findAll()} is exercised by these tests; other methods return empty results.
+     */
+    private static class StubTransferRepo implements TransferRequestRepository {
+        private final List<TransferRequest> records = new ArrayList<>();
+
+        @Override
+        public void save(TransferRequest request) {
+            records.add(request);
+        }
+
+        @Override
+        public Optional<TransferRequest> findById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<TransferRequest> findAll() {
+            return new ArrayList<>(records);
+        }
+
+        @Override
+        public List<TransferRequest> findByAnimalId(String animalId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<TransferRequest> findByFromShelterId(String shelterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<TransferRequest> findByToShelterId(String shelterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<TransferRequest> findByStatus(RequestStatus status) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<TransferRequest> findByShelterIdAndStatus(String shelterId, RequestStatus status) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<TransferRequest> findByAnimalIdAndStatus(String animalId, RequestStatus status) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void delete(String id) {
+            // no-op
+        }
+    }
+
+    /**
+     * Minimal in-memory stub for {@link AnimalRepository}; all methods are no-ops.
+     */
+    private static class StubAnimalRepo implements AnimalRepository {
+        @Override
+        public void save(Animal animal) {
+            // no-op
+        }
+
+        @Override
+        public Optional<Animal> findById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Animal> findAll() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Animal> findByShelterId(String shelterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Animal> findByAdopterId(String adopterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void delete(String id) {
+            // no-op
+        }
+    }
+
+    /**
+     * Minimal in-memory stub for {@link ShelterRepository}; all methods are no-ops.
+     */
+    private static class StubShelterRepo implements ShelterRepository {
+        @Override
+        public void save(Shelter shelter) {
+            // no-op
+        }
+
+        @Override
+        public Optional<Shelter> findById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Shelter> findAll() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void delete(String id) {
+            // no-op
+        }
+    }
+
+    /**
+     * Minimal no-op audit service for tests that do not care about audit side effects.
+     *
+     * @param <T> the audit target type
+     */
+    private static class NoopAudit<T> implements AuditService<T> {
+        @Override
+        public void log(String action, T target) {
+            // no-op
+        }
+
+        @Override
+        public List<AuditEntry<T>> getLog() {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/test/java/shelter/service/impl/VaccinationServiceImplListAllTest.java
+++ b/src/test/java/shelter/service/impl/VaccinationServiceImplListAllTest.java
@@ -1,0 +1,143 @@
+package shelter.service.impl;
+
+import org.junit.jupiter.api.Test;
+import shelter.domain.Species;
+import shelter.domain.VaccinationRecord;
+import shelter.domain.VaccineType;
+import shelter.repository.VaccinationRecordRepository;
+import shelter.repository.VaccineTypeRepository;
+import shelter.service.AuditService;
+import shelter.service.model.AuditEntry;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link VaccinationServiceImpl#listAllRecords()}.
+ * Verifies that the method delegates to the underlying {@link VaccinationRecordRepository#findAll()}
+ * and returns every persisted vaccination record.
+ */
+class VaccinationServiceImplListAllTest {
+
+    @Test
+    void listAllRecords_returnsEveryRecord() {
+        StubRecordRepo repo = new StubRecordRepo();
+        VaccinationRecord r1 = new VaccinationRecord("animal-1", "vaccine-1", LocalDate.now().minusDays(10));
+        VaccinationRecord r2 = new VaccinationRecord("animal-2", "vaccine-1", LocalDate.now().minusDays(5));
+        repo.records.add(r1);
+        repo.records.add(r2);
+
+        VaccinationServiceImpl svc = new VaccinationServiceImpl(
+                repo, new StubTypeRepo(), new NoopAudit<>());
+
+        List<VaccinationRecord> all = svc.listAllRecords();
+
+        assertEquals(2, all.size());
+        assertTrue(all.contains(r1));
+        assertTrue(all.contains(r2));
+    }
+
+    @Test
+    void listAllRecords_emptyRepository_returnsEmptyList() {
+        VaccinationServiceImpl svc = new VaccinationServiceImpl(
+                new StubRecordRepo(), new StubTypeRepo(), new NoopAudit<>());
+
+        assertTrue(svc.listAllRecords().isEmpty());
+    }
+
+    /**
+     * Minimal in-memory stub for {@link VaccinationRecordRepository}.
+     * Only {@link #findAll()} is exercised by these tests; other methods return empty results.
+     */
+    private static class StubRecordRepo implements VaccinationRecordRepository {
+        private final List<VaccinationRecord> records = new ArrayList<>();
+
+        @Override
+        public void save(VaccinationRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public Optional<VaccinationRecord> findById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<VaccinationRecord> findByAnimalId(String animalId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<VaccinationRecord> findAll() {
+            return new ArrayList<>(records);
+        }
+
+        @Override
+        public List<VaccinationRecord> findByShelterId(String shelterId) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void delete(String id) {
+            // no-op
+        }
+    }
+
+    /**
+     * Minimal in-memory stub for {@link VaccineTypeRepository}; all methods are no-ops.
+     */
+    private static class StubTypeRepo implements VaccineTypeRepository {
+        @Override
+        public void save(VaccineType vaccineType) {
+            // no-op
+        }
+
+        @Override
+        public Optional<VaccineType> findById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<VaccineType> findByName(String name) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<VaccineType> findByApplicableSpecies(Species species) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<VaccineType> findAll() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void delete(String id) {
+            // no-op
+        }
+    }
+
+    /**
+     * Minimal no-op audit service for tests that do not care about audit side effects.
+     *
+     * @param <T> the audit target type
+     */
+    private static class NoopAudit<T> implements AuditService<T> {
+        @Override
+        public void log(String action, T target) {
+            // no-op
+        }
+
+        @Override
+        public List<AuditEntry<T>> getLog() {
+            return Collections.emptyList();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **`shelter print` + `--watch`**: one-shot 8-section snapshot and file-watcher that rewrites `~/shelter/dashboard.md` on CSV change — powers a VS Code markdown preview live dashboard during the demo
- **New list subcommands**: `shelter adopt list`, `shelter transfer list`, `shelter vaccine list`
- **Agent CLAUDE.md**: identity block, full command reference, behavior rules (English-only, confirm-before-delete, submit-only gate, full-table rendering, *What I did* bullet conclusion after every response)
- **Demo scripts**: `reset-demo.sh` (build + symlink + wipe + regenerate in one command); `init-demo.sh` no longer hijacks the shell
- **Docs**: README rewritten around AI-agent-driven workflow; demo script replaced with 4 compound prompts; test-live guide updated with 3-pane layout
- **Bug fix**: `--requires-vaccinated true|false` now accepted by Picocli (`arity = "1"` on Boolean fields)

## Test plan

- [ ] Run `bash scripts/reset-demo.sh` — binary links, `~/shelter/CLAUDE.md` generated with all new rules
- [ ] Run `shelter print` — prints 8 sections, empty sections show `(none)`
- [ ] Run `shelter print --watch &` then add a shelter — dashboard.md updates within 1 s
- [ ] Run `shelter adopt list`, `shelter transfer list`, `shelter vaccine list` — headers print, `(none)` when empty
- [ ] Run `shelter adopter register ... --requires-vaccinated true` — no "Unmatched argument" error
- [ ] Open `~/shelter/CLAUDE.md` — confirm Identity, Agent Behavior Rules, and *What I did* conclusion rule are present
- [ ] Follow `docs/demo-script.md` warm-up + Prompt 1 end-to-end — agent replies with **What I did:** bullet list