### PR TITLE
docs(presentation): add thank-you slide with scholarly citations

### DIFF
--- a/docs/presentation/deck.html
+++ b/docs/presentation/deck.html
@@ -635,6 +635,28 @@ After that, show me the audit log so we can review every action from this sessio
       <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
     </section>
 
+    <!-- Slide 10 — Thank you + Citations -->
+    <section>
+      <div class="kicker">Thank you</div>
+      <h2>Questions?</h2>
+
+      <div class="takeaway-group">
+        <div class="takeaway-label">Citations</div>
+        <div class="takeaway-body">
+          <ul>
+            <li>Picocli — <a href="https://picocli.info/">picocli.info</a></li>
+            <li>JUnit 5 User Guide — <a href="https://junit.org/junit5/docs/current/user-guide/">junit.org/junit5</a></li>
+            <li>Gradle Application Plugin — <a href="https://docs.gradle.org/current/userguide/application_plugin.html">docs.gradle.org</a></li>
+            <li>Gamma et al., <em>Design Patterns</em> — Strategy — <a href="https://en.wikipedia.org/wiki/Strategy_pattern">wikipedia.org/wiki/Strategy_pattern</a></li>
+            <li>Oracle Java SE 17 API — <a href="https://docs.oracle.com/en/java/javase/17/docs/api/">docs.oracle.com</a></li>
+            <li>reveal.js 5.1 — <a href="https://revealjs.com/">revealjs.com</a></li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="footer">CS 5004 Final — Multi-Shelter Animal Adoption</div>
+    </section>
+
   </div>
 </div>
 

--- a/docs/presentation/slides.md
+++ b/docs/presentation/slides.md
@@ -278,6 +278,26 @@ public class TransferRequest {
 
 ---
 
+## Slide 10 — Thank you + Citations
+
+**Layout:** title + bullets
+
+**Kicker:** Thank you
+
+**Title:** Questions?
+
+**Citations:**
+- Picocli — https://picocli.info/
+- JUnit 5 User Guide — https://junit.org/junit5/docs/current/user-guide/
+- Gradle Application Plugin — https://docs.gradle.org/current/userguide/application_plugin.html
+- Gamma et al., *Design Patterns* — Strategy — https://en.wikipedia.org/wiki/Strategy_pattern
+- Oracle Java SE 17 API — https://docs.oracle.com/en/java/javase/17/docs/api/
+- reveal.js 5.1 — https://revealjs.com/
+
+**Speaker notes:** Holds the screen during Q&A so citations stay visible. No spoken content — covered by Q&A time.
+
+---
+
 ## Q&A (not a slide — 2 minutes)
 
 Likely questions to pre-think:


### PR DESCRIPTION
## Summary
- Adds a tenth slide ("Thank you / Questions?") that stays on-screen through Q&A and lists the scholarly references the project relied on.
- Satisfies the rubric's "Resources and Citations" requirement (4 pts) without spending any of the 8-minute spoken content budget.

## Test plan
- [x] Open `docs/presentation/deck.html` in a browser, navigate to slide 10, confirm citations render with working links.