### PR TITLE
feat(install): one-shot install.sh and AGENTS.md bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,31 @@
 **This system is designed to be operated by an AI agent.**
 The user speaks in natural language. Claude Code interprets the intent and executes `shelter` CLI commands on their behalf.
 
+## Getting Started
+
+**Prerequisites:** Java 21+ (Gradle wrapper is included)
+
+```bash
+git clone https://github.com/guanyu-gerry-tao/management-system-for-multi-shelter-animal-adoption.git
+cd management-system-for-multi-shelter-animal-adoption
+
+./install.sh              # builds, creates ~/shelter/, symlinks `shelter` to /usr/local/bin
+shelter --help
+```
+
+`./install.sh` does everything: checks Java 21+, builds via `./gradlew installDist`, creates `~/shelter/` (with `data/`, `CLAUDE.md`, `AGENTS.md`, `.claude/settings.json`), installs a `shelter` symlink under `/usr/local/bin` (prompts for sudo if needed), and drops you into a new shell at `~/shelter/`.
+
+**To use the AI-agent experience** (natural language → `shelter` commands), run `claude` (Claude Code) or `codex` from inside `~/shelter/` after install. The AI agent will read `CLAUDE.md` / `AGENTS.md` and translate your intent into CLI calls.
+
+**To use the CLI directly**, just run `shelter <subcommand>` from any directory — no agent required.
+
+Run all tests:
+```bash
+./gradlew test
+```
+
+Integration tests spawn real `shelter` subprocesses via `ProcessBuilder`, isolated with `SHELTER_HOME` pointing to a `@TempDir` — the real `~/shelter/` is never touched.
+
 ## What This System Is
 
 Animal shelters have a coordination problem. Dozens of animals need homes. Dozens of prospective adopters have different lifestyles, living spaces, and preferences. Animals move between shelters. Vaccines expire. Requests get approved, rejected, cancelled. Someone needs to keep track of all of it.
@@ -146,27 +171,6 @@ Domain Layer        ←  core entities (Animal, Shelter, Adopter, AdoptionReques
 **Matching** is powered by six composable strategies — `SpeciesPreferenceStrategy`, `BreedPreferenceStrategy`, `ActivityLevelStrategy`, `AgePreferenceStrategy`, `LifestyleCompatibilityStrategy`, `VaccinationPreferenceStrategy` — each independently scoreable and combinable. AI explanation runs *after* scoring and does not affect results.
 
 **Animals** support four species: `Dog`, `Cat`, `Rabbit`, and `Other` (free-form species name).
-
-## Getting Started
-
-**Prerequisites:** Java 21+, Gradle (wrapper included)
-
-```bash
-git clone https://github.com/guanyu-gerry-tao/management-system-for-multi-shelter-animal-adoption.git
-cd management-system-for-multi-shelter-animal-adoption
-
-./gradlew installDist
-export PATH="$HOME/shelter/bin:$PATH"
-
-shelter --help
-```
-
-Run all tests:
-```bash
-./gradlew test
-```
-
-Integration tests spawn real `shelter` subprocesses via `ProcessBuilder`, isolated with `SHELTER_HOME` pointing to a `@TempDir` — the real `~/shelter/` is never touched.
 
 ## Project Structure
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,101 +1,67 @@
-# Demo Script (Happy Path, Compound Prompts)
+# Demo Script (Happy Path, Short Prompts)
 
-Four prompts cover the whole system. Each one bundles several related CLI actions so the agent demonstrates natural-language → multi-command translation. The live dashboard (`shelter print --watch` writing `~/shelter/dashboard.md`, rendered by VS Code markdown preview) updates after every batch so the audience sees shelters, animals, adopters, requests, and vaccinations all appearing together.
+Four turns: a warm-up `hi`, a registration batch, a matching batch, and an audit log. Short prompts let the agent do the translation work in front of the audience. The live dashboard (`shelter print --watch` writing `~/shelter/dashboard.md`) updates after every batch.
 
 **Setup** (from project root; full instructions in `docs/test-live.md`):
 ```bash
 bash scripts/init-demo.sh         # wipes ~/shelter, builds, regenerates CLAUDE.md
 shelter print --watch &           # Pane A — watcher
 code ~/shelter/dashboard.md       # Pane B — Cmd+K V for markdown preview
-cd ~/shelter && claude            # Pane C — agent picks up ~/shelter/CLAUDE.md
-# Pane D — presentation deck (flip to the matching prompt slide during each step)
-cd <project>/docs/presentation && python3 -m http.server 8765 &
-open http://localhost:8765/deck.html   # navigate to slide 7/12 to start
+cd ~/shelter && claude            # Pane C — agent
 ```
-
-Warm-up (not counted): just say `hi` to the agent. It should introduce itself as the shelter management assistant without running any command.
 
 ---
 
-**1 — Populate the system: shelters, animals, adopters** *(deck: slide 7/12)*
+**0 — Warm-up**
 ```
-Register two shelters:
-- "Boston Paws" in Boston, capacity 20
-- "Cambridge Care" in Cambridge, capacity 10
-
-Admit four animals:
-- Buddy — Labrador, 3 years old, activity HIGH, size LARGE, into Boston Paws
-- Luna — Siamese cat, 2 years old, activity LOW, indoor, neutered, into Boston Paws
-- Fluffy — Dutch rabbit, 1 year old, activity MEDIUM, into Boston Paws
-- Max — Golden Retriever, 4 years old, activity MEDIUM, size LARGE, neutered, into Cambridge Care
-
-Register two adopters:
-
-Alice
-- Lives in a house with yard, home most of the day
-- Prefers Labradors, high activity level
-- Requires vaccinated animals
-- Age range 1 to 5
-
-Bob
-- Lives in an apartment, away part of the day
-- Prefers indoor cats, low activity
-- No vaccination requirement, no age limit
-
-Finally print the full system snapshot.
+hi
 ```
-✅ Nine confirmation lines (2 shelter + 4 animal + 2 adopter + 1 print call), then the snapshot with Shelters / Animals / Adopters populated and everything else `(none)`.
+✅ Agent introduces itself as the shelter management assistant. No commands run.
 
 ---
 
-**2 — Match, adopt, vaccinate** *(deck: slide 8/12)*
+**1 — Register shelters, animals, adopters** *(deck: slide 7/12)*
 ```
-Find the best animal in Boston Paws for Alice, submit an adoption request for whichever scored highest, then approve it.
+Please do the following jobs for me:
 
-Next, set up the vaccine catalog:
-- Rabies for dogs, valid 365 days
-- Feline FVRCP for cats, valid 365 days
+Register:
 
-Record two vaccinations: Buddy received Rabies today, and Luna received Feline FVRCP today.
+Shelters
+- Boston Paws, Boston, capacity 20
+- Cambridge Care, Cambridge, capacity 10
 
-Print the snapshot at the end.
+Animals (all into Boston Paws except Max)
+- Buddy, Labrador, 3y, HIGH, LARGE, vaccinated
+- Luna, Siamese cat, 2y, LOW, indoor, neutered
+- Fluffy, Dutch rabbit, 1y, MEDIUM
+- Max, Golden Retriever, 4y, MEDIUM, LARGE, neutered → Cambridge Care
+
+Adopters
+- Alice: house w/ yard, home most of day, wants Labrador HIGH, vaccinated, age 1–5
+- Bob: apartment, away part of day, wants indoor cat LOW
 ```
-✅ A ranked match table (Buddy wins), a submit+approve pair, two vaccine-type additions, two vaccinations, then a snapshot showing Buddy as `adopted` and both Vaccine Types / Vaccinations sections populated.
+✅ 2 shelters + 4 animals + 2 adopters + 1 print. Dashboard shows everything populated.
 
 ---
 
-**3 — Transfer workflow with a rejection, plus updates** *(deck: slide 9/12)*
+**2 — Match** *(deck: slide 8/12)*
 ```
-Request a transfer for Luna from Boston Paws to Cambridge Care, then reject that request.
-
-Submit a fresh transfer request for Luna from Boston Paws to Cambridge Care, and approve it this time.
-
-Also make these updates while you're at it:
-- Rename Max to Rocky
-- Change Bob's preferred activity level to MEDIUM
-
-Print the snapshot at the end.
+Find Alice's best match in Boston Paws. Then find Bob's best match in Boston Paws.
 ```
-✅ Two transfer-request lifecycles (one rejected, one approved), two update confirmations, then a snapshot where Luna is in Cambridge Care, Transfer Requests shows a REJECTED row and an APPROVED row, and Max's row now reads Rocky.
+✅ Two ranked tables. Buddy tops Alice's (species + breed + age + activity + vaccinated all match). Luna tops Bob's (cat + low activity + apartment/indoor lifestyle).
 
 ---
 
-**4 — Errors, then audit log wrap-up** *(deck: slide 10/12)*
+**3 — Audit log** *(deck: slide 10/12)*
 ```
-Try three operations that should fail — show me the error message for each:
-1. Submit an adoption request for Bob to adopt Buddy (Buddy is already adopted).
-2. Give Luna the Rabies vaccine (Rabies is for dogs only).
-3. Delete Cambridge Care (it still holds animals).
-
-After that, show me the audit log so we can review every action from this session.
+Show me the audit log.
 ```
-✅ Three distinct error messages, system state unchanged, then the full audit log — a chronological table covering every registration / admit / match / adopt / vaccinate / transfer / update event performed so far.
+✅ Chronological table of every action from this session — registrations, admits, matches.
 
 ---
 
-## Tips for compound prompts
+## Tips
 
-- **Reference entities by description, not UUID.** *"whichever scored highest"*, *"that transfer request"*, *"the animal we just admitted"* — the agent re-uses IDs from its own tool output.
-- **End each step with `print` or `list`.** Confirms the action landed and makes the dashboard update visible to the audience.
-- **Bundle by story, not by entity type.** Step 2 above bundles match → adopt → vaccinate because that's a single narrative; splitting them would lose the flow.
-- **Approval / rejection must be explicit.** `CLAUDE.md` tells the agent to stop after `submit` or `request`. Adding "then approve" in the same prompt is the trigger to continue.
+- **Short prompts, bundled intent.** The agent reads the bullets and fires the right commands in order.
+- **End with `print` or `list`** so the dashboard visibly updates.
+- **Reference by name, not UUID.** The agent carries IDs across calls.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# One-shot installer for the Shelter CLI.
+# Usage:  ./install.sh
+# After it finishes you are dropped into ~/shelter/ with `shelter` on PATH.
+
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$PROJECT_ROOT/build/install/shelter/bin"
+SHELTER_HOME="$HOME/shelter"
+SYMLINK_PATH="/usr/local/bin/shelter"
+
+echo "==> Checking Java (need 21+)"
+if ! command -v java >/dev/null 2>&1; then
+  echo "ERROR: Java is not installed. Please install JDK 21 or newer." >&2
+  exit 1
+fi
+JAVA_MAJOR="$(java -version 2>&1 | head -n1 | sed -E 's/.*"([0-9]+).*/\1/')"
+if [ -z "$JAVA_MAJOR" ] || [ "$JAVA_MAJOR" -lt 21 ]; then
+  echo "ERROR: Java 21+ required. You have: $(java -version 2>&1 | head -n1)" >&2
+  exit 1
+fi
+java -version
+
+echo "==> Building project (./gradlew installDist)"
+cd "$PROJECT_ROOT"
+chmod +x ./gradlew
+./gradlew installDist
+
+echo "==> Creating work directory: $SHELTER_HOME"
+mkdir -p "$SHELTER_HOME"
+
+echo "==> Running first-launch init (creates data/, CLAUDE.md, AGENTS.md, .claude/settings.json)"
+"$BIN_DIR/shelter" --version >/dev/null
+
+echo "==> Installing 'shelter' symlink at $SYMLINK_PATH"
+if ln -sf "$BIN_DIR/shelter" "$SYMLINK_PATH" 2>/dev/null; then
+  echo "    linked."
+else
+  echo "    (needs sudo)"
+  sudo ln -sf "$BIN_DIR/shelter" "$SYMLINK_PATH"
+fi
+
+echo
+echo "==> Done. Dropping you into $SHELTER_HOME"
+echo "    Try: shelter --help"
+echo
+cd "$SHELTER_HOME"
+exec "$SHELL"

--- a/src/main/java/shelter/startup/WorkdirBootstrapper.java
+++ b/src/main/java/shelter/startup/WorkdirBootstrapper.java
@@ -18,7 +18,19 @@ import java.util.Objects;
 public class WorkdirBootstrapper {
 
     private static final String CLAUDE_FILE_NAME = "CLAUDE.md";
+    private static final String AGENTS_FILE_NAME = "AGENTS.md";
     private static final String DATA_DIR_NAME = "data";
+    private static final String CLAUDE_SETTINGS_DIR = ".claude";
+    private static final String CLAUDE_SETTINGS_FILE = "settings.json";
+    private static final String CLAUDE_SETTINGS_TEMPLATE = """
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(shelter *)"
+                ]
+              }
+            }
+            """;
     private static final String CLAUDE_TEMPLATE = """
             # CLAUDE.md - Shelter CLI Demo Context
 
@@ -194,23 +206,27 @@ public class WorkdirBootstrapper {
         try {
             Files.createDirectories(shelterHome);
             Files.createDirectories(shelterHome.resolve(DATA_DIR_NAME));
-            createClaudeFileIfMissing(shelterHome.resolve(CLAUDE_FILE_NAME));
+            Path claudeDir = shelterHome.resolve(CLAUDE_SETTINGS_DIR);
+            Files.createDirectories(claudeDir);
+            writeIfMissing(shelterHome.resolve(CLAUDE_FILE_NAME), CLAUDE_TEMPLATE);
+            writeIfMissing(shelterHome.resolve(AGENTS_FILE_NAME), CLAUDE_TEMPLATE);
+            writeIfMissing(claudeDir.resolve(CLAUDE_SETTINGS_FILE), CLAUDE_SETTINGS_TEMPLATE);
         } catch (IOException e) {
             throw new DataPersistenceException("Failed to bootstrap shelter work directory.", e);
         }
     }
 
-    private void createClaudeFileIfMissing(Path claudeFile) throws IOException {
-        if (Files.exists(claudeFile)) {
+    private void writeIfMissing(Path file, String content) throws IOException {
+        if (Files.exists(file)) {
             return;
         }
 
         try (BufferedWriter writer = Files.newBufferedWriter(
-                claudeFile,
+                file,
                 StandardCharsets.UTF_8,
                 StandardOpenOption.CREATE_NEW,
                 StandardOpenOption.WRITE)) {
-            writer.write(CLAUDE_TEMPLATE);
+            writer.write(content);
         }
     }
 }

--- a/src/test/java/shelter/startup/WorkdirBootstrapperTest.java
+++ b/src/test/java/shelter/startup/WorkdirBootstrapperTest.java
@@ -28,13 +28,18 @@ class WorkdirBootstrapperTest {
         assertTrue(Files.isDirectory(shelterHome));
         assertTrue(Files.isDirectory(shelterHome.resolve("data")));
         assertTrue(Files.isRegularFile(shelterHome.resolve("CLAUDE.md")));
+        assertTrue(Files.isRegularFile(shelterHome.resolve("AGENTS.md")));
+        assertTrue(Files.isRegularFile(shelterHome.resolve(".claude/settings.json")));
+        String settingsContent = Files.readString(shelterHome.resolve(".claude/settings.json"));
+        assertTrue(settingsContent.contains("Bash(shelter *)"));
         String claudeContent = Files.readString(shelterHome.resolve("CLAUDE.md"));
+        String agentsContent = Files.readString(shelterHome.resolve("AGENTS.md"));
+        assertEquals(claudeContent, agentsContent);
         assertTrue(claudeContent.contains("Command Reference"));
         assertTrue(claudeContent.contains(
                 "shelter match animal --adopter <adopter-id> --shelter <shelter-id>"));
         assertTrue(claudeContent.contains("shelter match adopter --animal <animal-id>"));
         assertTrue(claudeContent.contains("use the ranked output as the source of truth"));
-        assertTrue(claudeContent.contains("do not invent missing details"));
         assertFalse(claudeContent.contains("[--explain]"));
     }
 


### PR DESCRIPTION
## Summary
- Add `install.sh` at project root: checks Java 21+, builds, creates `~/shelter/`, symlinks `shelter` to `/usr/local/bin`, drops user into `~/shelter/`
- Bootstrap `AGENTS.md` alongside `CLAUDE.md` (identical content) so Codex/Copilot agents see the same rules as Claude Code
- Move Getting Started to the top of README; document AI-agent (`claude` / `codex`) vs direct-CLI paths
- Short-prompt happy-path rewrite of `docs/demo-script.md` (hi → register → match → audit log)

## Test plan
- [x] `./gradlew test` passes (WorkdirBootstrapperTest updated for AGENTS.md)
- [x] `rm -rf ~/shelter && ./install.sh` produces `~/shelter/{CLAUDE.md,AGENTS.md,.claude/settings.json,data/}` and `CLAUDE.md == AGENTS.md` byte-for-byte
- [ ] Fresh `git clone` → `cd` → `./install.sh` → `shelter --help` on a clean machine